### PR TITLE
test(regression): Phase A — recent feature regressions

### DIFF
--- a/tests/regression/test_cancel_regression.py
+++ b/tests/regression/test_cancel_regression.py
@@ -1,0 +1,252 @@
+"""Regression tests for ADR-014 cancel verb (issue #54).
+
+The existing ``tests/unit/test_operations.py`` already covers the five
+canonical cancel paths (pre-preflight, post-commit advisory, post-stop,
+during readiness, post-success). This file pins down the remaining
+*error* branches that the feature introduced:
+
+* **Cancel-then-rollback-also-fails** (``swap.py`` lines 649-661): a
+  cancel arrives between stop-old and launch-new (post-stop checkpoint)
+  AND the cancel-restore launch fails. The port is dead; the action is
+  ``failed`` with ``port_state='unavailable'``. Without coverage, a
+  refactor of ``_handle_cancel_during_swap`` could silently downgrade
+  ``port_state`` to ``restored`` and lie to operators.
+
+* **``take_marker`` partial-write cleanup** (``marker.py`` lines 116-123):
+  if writing the marker JSON raises mid-write, the partial file must be
+  unlinked. Without it, the empty/corrupt marker poisons subsequent
+  reconciliation reads.
+
+* **``request_cancel`` tempfile cleanup** (``marker.py`` lines 188-193):
+  if ``os.replace`` fails after writing the temp file, the temp file
+  must be unlinked. Without it, ``run_dir`` accumulates ``.swap.tmp``
+  detritus.
+
+Together with the existing tests these lock down the full ADR-014
+cancel surface — start, swap (all five phases plus failed restore), and
+marker module internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import os as _os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llauncher import operations as ops
+from llauncher.core import audit_log as al
+from llauncher.core import lockfile as lf
+from llauncher.core import marker as mk
+from llauncher.core.audit_log import AuditAction, AuditResult
+from llauncher.models.config import ModelConfig
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirroring tests/unit/test_operations.py — kept local so
+# this file can be run in isolation: ``pytest tests/regression``)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "run"
+    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", target)
+    return target
+
+
+@pytest.fixture
+def audit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "audit.jsonl"
+    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", target)
+    return target
+
+
+def _make_config(name: str) -> ModelConfig:
+    return ModelConfig.from_dict_unvalidated(
+        {
+            "name": name,
+            "model_path": f"/fake/path/{name}.gguf",
+            "n_gpu_layers": 255,
+            "ctx_size": 4096,
+        }
+    )
+
+
+def _config_lookup(*configs: ModelConfig):
+    by_name = {c.name: c for c in configs}
+
+    def side_effect(name: str):
+        return by_name.get(name)
+
+    return side_effect
+
+
+_NO_PREFLIGHT = {"model_health_check": None, "vram_check": None}
+
+
+# ---------------------------------------------------------------------------
+# Cancel during swap post-stop AND cancel-restore fails → port_dead
+# ---------------------------------------------------------------------------
+
+
+def test_swap_cancel_then_rollback_fails_reports_port_dead(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Cancel at post-stop + failed restore → action='failed', port unavailable.
+
+    Pins ``_handle_cancel_during_swap``'s failed-restore branch
+    (``swap.py`` 649-661). A refactor that flips this to ``restored``
+    would silently lie about the port state to operators.
+    """
+    lf.write_lockfile(8081, "old", _os.getpid(), run_dir=run_dir)
+    new_popen = MagicMock(); new_popen.pid = 88888
+
+    # Cancel detected at post-stop checkpoint. Restore launch then fails
+    # readiness (e.g. the previous_config's model file is gone).
+    with patch(
+        "llauncher.operations.ConfigStore.get_model",
+        side_effect=_config_lookup(_make_config("old"), _make_config("new-model")),
+    ), patch("llauncher.operations.proc.stop_server_by_port", return_value=True), \
+         patch("llauncher.operations.proc.start_server", return_value=new_popen), \
+         patch("llauncher.operations.proc.wait_for_server_ready",
+               return_value=(False, ["restore failed: model not found"])), \
+         patch("llauncher.operations.proc.stop_server_by_pid"), \
+         patch("llauncher.operations.swap.mk.is_cancelled", return_value=True):
+        result = ops.swap("new-model", 8081, caller="test", **_NO_PREFLIGHT)
+
+    assert result.success is False
+    assert result.action == "failed"
+    assert result.port_state == "unavailable"
+    assert result.model is None  # port is dead — no model is serving
+
+    # Audit captured the UNAVAILABLE outcome with the diagnostic message.
+    entries = al.read_entries(path=audit_path)
+    unavailable = [
+        e for e in entries
+        if e.action == AuditAction.SWAPPED and e.result == AuditResult.UNAVAILABLE
+    ]
+    assert len(unavailable) >= 1, (
+        f"expected SWAPPED/UNAVAILABLE audit entry; got "
+        f"{[(e.action, e.result) for e in entries]}"
+    )
+    assert "port_dead" in unavailable[-1].message
+
+    # Marker released by the swap()-level finally block.
+    assert (run_dir / "8081.swap").exists() is False
+
+
+# ---------------------------------------------------------------------------
+# marker.take_marker — partial-write cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_take_marker_cleans_up_partial_write_on_exception(tmp_path: Path) -> None:
+    """If JSON dump raises mid-write, the partial marker file must be unlinked.
+
+    Pins ``marker.py`` 116-123. Without this guarantee, the marker
+    module's reconciliation would later encounter an empty/corrupt file
+    on a port that has no in-flight op.
+    """
+    run_dir = tmp_path / "run"
+
+    # Make json.dump raise after the file has been created but before
+    # any data is written. The except block must unlink the partial file.
+    with patch("llauncher.core.marker.json.dump", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            mk.take_marker(
+                8081,
+                caller="cli",
+                from_model="a",
+                to_model="b",
+                run_dir=run_dir,
+            )
+
+    # The partial marker file must have been cleaned up.
+    assert not (run_dir / "8081.swap").exists(), (
+        "partial marker file leaked; reconciliation would see corrupt state"
+    )
+
+
+def test_take_marker_partial_write_cleanup_tolerates_missing_file(
+    tmp_path: Path,
+) -> None:
+    """Cleanup path swallows FileNotFoundError if the file is already gone.
+
+    Defensive case: another agent (or the OS) could have removed the
+    partial file between the write failure and our unlink attempt. The
+    cleanup must not mask the original exception with a secondary one.
+    """
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    def boom_dump(*_a, **_kw):
+        # Pre-delete the file the fdopen handle is attached to so the
+        # subsequent ``path.unlink()`` raises FileNotFoundError. The
+        # except clause should swallow it and re-raise the original.
+        for f in run_dir.glob("*.swap"):
+            f.unlink()
+        raise OSError("simulated write failure")
+
+    with patch("llauncher.core.marker.json.dump", side_effect=boom_dump):
+        with pytest.raises(OSError, match="simulated write failure"):
+            mk.take_marker(
+                8081,
+                caller="cli",
+                from_model="a",
+                to_model="b",
+                run_dir=run_dir,
+            )
+
+    assert not (run_dir / "8081.swap").exists()
+
+
+# ---------------------------------------------------------------------------
+# marker.request_cancel — tempfile cleanup on os.replace failure
+# ---------------------------------------------------------------------------
+
+
+def test_request_cancel_cleans_up_tempfile_on_replace_failure(
+    tmp_path: Path,
+) -> None:
+    """OSError during ``os.replace`` must trigger tempfile cleanup.
+
+    Pins ``marker.py`` 188-193. Without this, ``run_dir`` accumulates
+    ``8081.swap.tmp`` files that confuse later operators / scripts.
+    """
+    run_dir = tmp_path / "run"
+    # Seed an existing marker so ``request_cancel`` proceeds past the
+    # "no marker" early return.
+    mk.take_marker(
+        8081,
+        caller="cli",
+        from_model="a",
+        to_model="b",
+        run_dir=run_dir,
+    )
+
+    with patch(
+        "llauncher.core.marker.os.replace",
+        side_effect=OSError("simulated EXDEV cross-device link"),
+    ):
+        with pytest.raises(OSError, match="simulated EXDEV"):
+            mk.request_cancel(8081, run_dir=run_dir)
+
+    # Live marker is unchanged (replace never succeeded).
+    live = mk.read_marker(8081, run_dir=run_dir)
+    assert live is not None
+    assert live.cancelled is False, (
+        "marker should be untouched when os.replace failed"
+    )
+
+    # Tempfile must have been cleaned up — no .swap.tmp left behind.
+    leftover = list(run_dir.glob("*.swap.tmp"))
+    assert leftover == [], (
+        f"request_cancel leaked tempfiles on os.replace failure: {leftover}"
+    )

--- a/tests/regression/test_logs_lifecycle_regression.py
+++ b/tests/regression/test_logs_lifecycle_regression.py
@@ -1,0 +1,221 @@
+"""Regression tests for ADR-013 logs lifecycle (issue #52).
+
+These pin down the specific behaviors the feature introduced — and which
+would silently break if someone refactored the rotation/banner ordering
+or stopped reading the configured log directory at process boot:
+
+* ``LAUNCHER_LOG_DIR`` environment variable is honored when the settings
+  module is (re)imported. Historical bug shape: a hard-coded ``LOG_DIR``
+  ignored the env, so volume-mounted container deployments wrote inside
+  the container instead of onto the host mount.
+* The startup banner is *flushed before* ``subprocess.Popen`` inherits
+  the file descriptor. Historical bug shape: the banner was written but
+  not flushed, so child output landed in the file before the banner,
+  defeating the "grep ``=== started at`` for run boundaries" UX promise.
+* Rotation runs *before* the banner write. Historical bug shape: if the
+  rotation step were moved after the open-for-append, an oversized log
+  would receive the banner first and rotate on the *next* run, defeating
+  the size cap by exactly one run's worth of output.
+
+The bounded-tail and append-preserves-prior-content guarantees are
+already nailed down by ``tests/unit/test_process.py::TestStartServerLogsLifecycle``
+and ``TestTailFile``; we do not duplicate those here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llauncher.core.process import start_server
+from llauncher.models.config import ModelConfig
+
+
+@pytest.fixture
+def minimal_config() -> ModelConfig:
+    return ModelConfig.from_dict_unvalidated(
+        {
+            "name": "test-model",
+            "model_path": "/fake/path/model.gguf",
+            "n_gpu_layers": 255,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# LAUNCHER_LOG_DIR env honored
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_log_dir_env_honored_on_settings_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``LAUNCHER_LOG_DIR`` env var is read by ``settings`` at import time.
+
+    Regression: a hard-coded default would silently override an
+    operator-supplied env on a container with a volume mount.
+    """
+    custom = tmp_path / "container-mounted-logs"
+    monkeypatch.setenv("LAUNCHER_LOG_DIR", str(custom))
+
+    import llauncher.core.settings as settings_mod
+
+    reloaded = importlib.reload(settings_mod)
+    try:
+        assert reloaded.LAUNCHER_LOG_DIR == custom
+    finally:
+        # Restore the un-monkey-patched module state for subsequent tests.
+        monkeypatch.delenv("LAUNCHER_LOG_DIR", raising=False)
+        importlib.reload(settings_mod)
+
+
+def test_launcher_log_max_bytes_env_honored_on_settings_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``LAUNCHER_LOG_MAX_BYTES`` env var is parsed as int at import time."""
+    monkeypatch.setenv("LAUNCHER_LOG_MAX_BYTES", "12345")
+
+    import llauncher.core.settings as settings_mod
+
+    reloaded = importlib.reload(settings_mod)
+    try:
+        assert reloaded.LAUNCHER_LOG_MAX_BYTES == 12345
+    finally:
+        monkeypatch.delenv("LAUNCHER_LOG_MAX_BYTES", raising=False)
+        importlib.reload(settings_mod)
+
+
+def test_launcher_log_keep_env_honored_on_settings_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``LAUNCHER_LOG_KEEP`` env var is parsed as int at import time."""
+    monkeypatch.setenv("LAUNCHER_LOG_KEEP", "7")
+
+    import llauncher.core.settings as settings_mod
+
+    reloaded = importlib.reload(settings_mod)
+    try:
+        assert reloaded.LAUNCHER_LOG_KEEP == 7
+    finally:
+        monkeypatch.delenv("LAUNCHER_LOG_KEEP", raising=False)
+        importlib.reload(settings_mod)
+
+
+# ---------------------------------------------------------------------------
+# Banner flushed before subprocess inherits FD
+# ---------------------------------------------------------------------------
+
+
+def test_banner_flushed_before_subprocess_spawn(
+    tmp_path: Path, minimal_config: ModelConfig
+) -> None:
+    """``log.flush()`` MUST be called before ``Popen`` inherits the fd.
+
+    Regression: without the flush, child output races the banner buffer
+    and lands first, defeating ADR-013's run-boundary grep contract.
+    """
+    mock_bin = MagicMock()
+    mock_bin.exists.return_value = True
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # Capture the order of file writes vs subprocess.Popen invocation by
+    # recording each via a shared timeline list.
+    timeline: list[str] = []
+
+    real_open = open
+
+    def tracking_open(path, mode="r", *args, **kwargs):
+        # Only instrument the live log file; let other opens (settings,
+        # imports, etc.) pass through untouched.
+        if str(path).endswith(".log") and "a" in mode:
+            f = real_open(path, mode, *args, **kwargs)
+            real_flush = f.flush
+
+            def spy_flush() -> None:
+                timeline.append("flush")
+                real_flush()
+
+            f.flush = spy_flush  # type: ignore[assignment]
+            return f
+        return real_open(path, mode, *args, **kwargs)
+
+    def fake_popen(*_args, **_kwargs) -> MagicMock:
+        timeline.append("popen")
+        return MagicMock()
+
+    with patch("llauncher.core.process.DEFAULT_SERVER_BINARY", mock_bin), \
+         patch("llauncher.core.process.LOG_DIR", log_dir), \
+         patch("builtins.open", side_effect=tracking_open), \
+         patch("subprocess.Popen", side_effect=fake_popen):
+        start_server(minimal_config, port=8081)
+
+    # Both events captured.
+    assert "flush" in timeline, "log file was never flushed before Popen"
+    assert "popen" in timeline, "Popen was never invoked"
+    # Flush precedes Popen — the load-bearing ordering.
+    assert timeline.index("flush") < timeline.index("popen"), (
+        f"banner not flushed before subprocess spawn; timeline={timeline}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rotation occurs BEFORE banner write (size cap is honored on the *next*
+# run, not delayed by one)
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_runs_before_banner_write(
+    tmp_path: Path, minimal_config: ModelConfig
+) -> None:
+    """Rotation MUST be evaluated before the banner is appended.
+
+    Regression: if rotation moved after the open-for-append, a file
+    already over the cap would absorb a full run's output before the
+    *next* startup actually rotates it — defeating the cap by one run.
+    """
+    mock_bin = MagicMock()
+    mock_bin.exists.return_value = True
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log_file = log_dir / "test-model-8081.log"
+    # Pre-existing oversized content.
+    log_file.write_text("X" * 500)
+
+    call_order: list[str] = []
+
+    real_rotate = importlib.import_module(
+        "llauncher.core.log_rotation"
+    ).rotate_if_needed
+
+    def tracking_rotate(path, *, max_bytes, keep):
+        call_order.append("rotate")
+        return real_rotate(path, max_bytes=max_bytes, keep=keep)
+
+    real_open = open
+
+    def tracking_open(path, mode="r", *args, **kwargs):
+        if str(path).endswith(".log") and "a" in mode:
+            call_order.append("open-append")
+        return real_open(path, mode, *args, **kwargs)
+
+    with patch("llauncher.core.process.DEFAULT_SERVER_BINARY", mock_bin), \
+         patch("llauncher.core.process.LOG_DIR", log_dir), \
+         patch("llauncher.core.process.settings.LAUNCHER_LOG_MAX_BYTES", 100), \
+         patch("llauncher.core.process.settings.LAUNCHER_LOG_KEEP", 3), \
+         patch("llauncher.core.process.log_rotation.rotate_if_needed",
+               side_effect=tracking_rotate), \
+         patch("builtins.open", side_effect=tracking_open), \
+         patch("subprocess.Popen", return_value=MagicMock()):
+        start_server(minimal_config, port=8081)
+
+    assert "rotate" in call_order and "open-append" in call_order
+    assert call_order.index("rotate") < call_order.index("open-append"), (
+        f"rotation must precede banner write; order={call_order}"
+    )
+    # Rotation actually happened (file is .log.1 now).
+    assert (log_dir / "test-model-8081.log.1").exists()

--- a/tests/regression/test_orphan_regression.py
+++ b/tests/regression/test_orphan_regression.py
@@ -1,0 +1,486 @@
+"""Regression tests for ADR-015 orphan policy (issue #55).
+
+The existing ``tests/unit/test_orphan.py`` already covers the per-process
+classification rules (managed, no-lockfile, stale, pid-mismatch,
+unreadable, sort order) and the in-memory state dedupe behavior via
+mocks. This file pins down the *cross-surface contract* and the
+*write-side guarantees* that a refactor could silently break without
+any unit test failing:
+
+* **Annotation-only contract** (``llauncher/operations/orphan.py`` lines
+  47-106): ``list_orphans`` reads ``lf.read_lockfile`` and
+  ``lf.is_pid_alive`` only — it must NOT call any kill verb
+  (``stop_server_by_pid`` / ``stop_server_by_port``) and must NOT write
+  a lockfile claiming the orphan. ADR-015 §6 explicitly defers adoption
+  ("Any lockfile *write* on behalf of an orphan pid" is out of scope).
+  A refactor that tries to "fix" an orphan by reaping or claiming would
+  silently violate the ADR.
+
+* **Canonical envelope shape across surfaces** (HTTP/MCP/CLI): the same
+  orphan must serialize identically on ``GET /orphans``, MCP
+  ``list_orphans``, and ``llauncher orphan list --json`` — all three are
+  documented in ADR-015 §5 as returning the same canonical fields
+  (``pid``, ``port``, ``cmdline_unreadable``). A surface that drifts
+  (drops a field, renames one, returns a different envelope) breaks
+  the operator's "same data everywhere" promise.
+
+* **Empty list is success, not 404 / error**: ADR-015 §5 specifies
+  ``total: 0`` with an empty list. A surface that 404s on "no orphans"
+  forces every caller to write a presence check; the regression here
+  pins each surface to the success-with-empty-shape contract.
+
+* **Audit-file idempotency** (``state.py`` lines 161-170 +
+  ``orphan.py:record_observed_orphan`` lines 109-125): the existing
+  unit test verifies the in-memory dedupe via mocking out
+  ``record_observed_orphan``. This regression exercises the *actual*
+  audit append path against a real tmp file to confirm that
+  ``refresh_orphans`` writes exactly one ``OBSERVED_ORPHAN`` entry per
+  pid-sighting-pair-per-agent-lifetime. A refactor that moves the
+  dedupe check below the ``record_observed_orphan`` call (or removes
+  it) would write a duplicate line on every refresh.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llauncher import operations as ops
+from llauncher.core import audit_log as al
+from llauncher.core import lockfile as lf
+from llauncher.core.audit_log import AuditAction, AuditResult
+from llauncher.operations.orphan import OrphanInfo
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirroring the style of test_cancel_regression.py so this
+# file can be run in isolation: ``pytest tests/regression``)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "run"
+    target.mkdir()
+    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", target)
+    return target
+
+
+@pytest.fixture
+def audit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "audit.jsonl"
+    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", target)
+    return target
+
+
+def _fake_proc(pid: int) -> MagicMock:
+    m = MagicMock()
+    m.pid = pid
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Annotation-only contract: list_orphans is observation, not reconciliation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case,setup",
+    [
+        ("no_lockfile", "no_lockfile"),
+        ("stale_lockfile", "stale_lockfile"),
+        ("pid_mismatch", "pid_mismatch"),
+        ("unreadable_cmdline", "unreadable_cmdline"),
+    ],
+)
+def test_list_orphans_never_kills_or_claims(
+    case: str, setup: str, run_dir: Path
+) -> None:
+    """Pin ADR-015 §6: ``list_orphans`` annotates only — no kill, no claim.
+
+    Covers ``llauncher/operations/orphan.py:47-106``. Every classification
+    branch must read the lockfile and process table; none may call into
+    ``proc.stop_server_by_pid`` / ``proc.stop_server_by_port`` (would
+    reap an orphan we don't own) nor ``lf.write_lockfile`` (would
+    silently adopt — adoption is deferred to a future ADR).
+    """
+    if setup == "no_lockfile":
+        annotated = [(_fake_proc(9001), 8081, False)]
+        is_alive = True
+    elif setup == "stale_lockfile":
+        lf.write_lockfile(8082, "old", 7777, run_dir=run_dir)
+        annotated = [(_fake_proc(9002), 8082, False)]
+        is_alive = False
+    elif setup == "pid_mismatch":
+        lf.write_lockfile(8083, "old", 6666, run_dir=run_dir)
+        annotated = [(_fake_proc(9003), 8083, False)]
+        is_alive = True
+    elif setup == "unreadable_cmdline":
+        annotated = [(_fake_proc(9004), None, True)]
+        is_alive = True
+    else:  # pragma: no cover - guarded by parametrize
+        pytest.fail(f"unknown setup {setup!r}")
+
+    with patch(
+        "llauncher.operations.orphan.proc.find_all_llama_servers_annotated",
+        return_value=annotated,
+    ), patch(
+        "llauncher.operations.orphan.lf.is_pid_alive", return_value=is_alive
+    ), patch(
+        "llauncher.core.process.stop_server_by_pid"
+    ) as kill_pid, patch(
+        "llauncher.core.process.stop_server_by_port"
+    ) as kill_port, patch(
+        "llauncher.core.lockfile.write_lockfile"
+    ) as write_lock:
+        result = ops.list_orphans()
+
+    assert len(result) == 1, f"case {case}: expected exactly one orphan"
+    kill_pid.assert_not_called()
+    kill_port.assert_not_called()
+    write_lock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface canonical envelope shape (ADR-015 §5)
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_FIELDS = {"pid", "port", "cmdline_unreadable"}
+
+
+@pytest.fixture
+def http_client():
+    from fastapi.testclient import TestClient
+    from llauncher.agent.server import create_app
+    from llauncher.agent import routing
+
+    routing._state = None
+    yield TestClient(create_app())
+    routing._state = None
+
+
+def test_http_orphans_envelope_canonical(http_client, monkeypatch) -> None:
+    """``GET /orphans`` returns ``{node, orphans:[...], total}`` per ADR-015 §5.
+
+    Pins ``llauncher/agent/routing.py:196-219``. A surface drift here
+    (renamed ``total`` to ``count``, dropped ``node``, wrapped in
+    another envelope) would break MCP-vs-HTTP parity.
+    """
+    from llauncher.agent import routing
+
+    fake_state = MagicMock()
+    fake_state.orphans = [
+        OrphanInfo(pid=11001, port=8081),
+        OrphanInfo(pid=11002, port=None, cmdline_unreadable=True),
+    ]
+    monkeypatch.setattr(routing, "get_state", lambda: fake_state)
+
+    resp = http_client.get("/orphans")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"node", "orphans", "total"}
+    assert body["total"] == 2
+    for o in body["orphans"]:
+        assert set(o.keys()) == _CANONICAL_FIELDS
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_orphans_envelope_canonical() -> None:
+    """MCP ``list_orphans`` returns the same orphan dicts as HTTP.
+
+    Pins ``llauncher/mcp_server/tools/servers.py:274-284``. The MCP
+    envelope intentionally omits ``node`` (per-call MCP context),
+    but each orphan dict MUST carry the canonical three fields.
+    """
+    from llauncher.mcp_server.tools.servers import list_orphans as mcp_list
+
+    state = MagicMock()
+    state.orphans = [
+        OrphanInfo(pid=11003, port=8082),
+        OrphanInfo(pid=11004, port=None, cmdline_unreadable=True),
+    ]
+
+    result = await mcp_list(state, {})
+    assert set(result.keys()) == {"orphans", "total"}
+    assert result["total"] == 2
+    for o in result["orphans"]:
+        assert set(o.keys()) == _CANONICAL_FIELDS
+
+
+def test_cli_orphan_list_json_envelope_canonical() -> None:
+    """``llauncher orphan list --json`` emits the same per-orphan dicts.
+
+    Pins ``llauncher/cli.py:260-289``. CLI ``--json`` is the
+    machine-readable surface; the table is for humans. The JSON form
+    MUST be a flat list of canonical orphan dicts (no envelope) so it
+    composes with ``jq`` the same way HTTP does after a ``.orphans``
+    selector.
+    """
+    from typer.testing import CliRunner
+    from llauncher.cli import app
+
+    runner = CliRunner()
+    orphans = [
+        OrphanInfo(pid=11005, port=8083),
+        OrphanInfo(pid=11006, port=None, cmdline_unreadable=True),
+    ]
+    with patch("llauncher.operations.list_orphans", return_value=orphans):
+        result = runner.invoke(app, ["orphan", "list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list) and len(payload) == 2
+    for o in payload:
+        assert set(o.keys()) == _CANONICAL_FIELDS
+
+
+def test_cross_surface_orphan_dicts_agree(http_client, monkeypatch) -> None:
+    """The same ``OrphanInfo`` serializes identically across HTTP / MCP / CLI.
+
+    Operators paste the JSON from one surface into a script that
+    consumes another. The contract that "an orphan is an orphan
+    everywhere" is what makes that work; this test pins it.
+    """
+    import asyncio
+
+    from llauncher.agent import routing
+    from llauncher.mcp_server.tools.servers import list_orphans as mcp_list
+    from typer.testing import CliRunner
+    from llauncher.cli import app
+
+    orphans = [
+        OrphanInfo(pid=12001, port=8084),
+        OrphanInfo(pid=12002, port=None, cmdline_unreadable=True),
+    ]
+
+    # HTTP
+    fake_state = MagicMock()
+    fake_state.orphans = list(orphans)
+    monkeypatch.setattr(routing, "get_state", lambda: fake_state)
+    http_orphans = http_client.get("/orphans").json()["orphans"]
+
+    # MCP
+    mcp_state = MagicMock()
+    mcp_state.orphans = list(orphans)
+    mcp_result = asyncio.get_event_loop().run_until_complete(
+        mcp_list(mcp_state, {})
+    )
+    mcp_orphans = mcp_result["orphans"]
+
+    # CLI
+    runner = CliRunner()
+    with patch("llauncher.operations.list_orphans", return_value=list(orphans)):
+        cli_result = runner.invoke(app, ["orphan", "list", "--json"])
+    cli_orphans = json.loads(cli_result.stdout)
+
+    # The three surfaces must agree on each orphan dict.
+    assert http_orphans == mcp_orphans == cli_orphans
+
+
+# ---------------------------------------------------------------------------
+# Empty orphan list is a successful response across surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_http_orphans_empty_is_200(http_client, monkeypatch) -> None:
+    """Empty orphan list returns 200 with shape — not 404 / error.
+
+    Pins ADR-015 §5: callers should not need a presence check.
+    """
+    from llauncher.agent import routing
+
+    fake_state = MagicMock()
+    fake_state.orphans = []
+    monkeypatch.setattr(routing, "get_state", lambda: fake_state)
+
+    resp = http_client.get("/orphans")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["orphans"] == []
+    assert body["total"] == 0
+    assert "node" in body
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_orphans_empty_returns_envelope() -> None:
+    """MCP ``list_orphans`` with zero orphans returns the shape, not None / error."""
+    from llauncher.mcp_server.tools.servers import list_orphans as mcp_list
+
+    state = MagicMock()
+    state.orphans = []
+
+    result = await mcp_list(state, {})
+    assert result == {"orphans": [], "total": 0}
+
+
+def test_cli_orphan_list_empty_exit_zero() -> None:
+    """``llauncher orphan list`` with zero orphans exits 0 (not an error)."""
+    from typer.testing import CliRunner
+    from llauncher.cli import app
+
+    runner = CliRunner()
+    with patch("llauncher.operations.list_orphans", return_value=[]):
+        result = runner.invoke(app, ["orphan", "list"])
+
+    assert result.exit_code == 0
+    # The human-facing message is a contract too: silence would leave
+    # the operator wondering whether the command ran.
+    assert "no orphan" in result.stdout.lower()
+
+
+def test_cli_orphan_list_empty_json_is_array() -> None:
+    """``llauncher orphan list --json`` with zero orphans emits ``[]``.
+
+    Pins ``cli.py:274-276``. The ``--json`` branch must always emit
+    valid JSON; a refactor that emitted nothing on the empty case
+    (because the table-print branch handles "empty" with a message)
+    would break ``jq`` consumers.
+    """
+    from typer.testing import CliRunner
+    from llauncher.cli import app
+
+    runner = CliRunner()
+    with patch("llauncher.operations.list_orphans", return_value=[]):
+        result = runner.invoke(app, ["orphan", "list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == []
+
+
+# ---------------------------------------------------------------------------
+# Audit idempotency on disk: same orphan does not duplicate audit entries
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_orphans_emits_observed_orphan_once_per_lifetime(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Pin ADR-015 §3: first-sighting writes one audit line; repeats are silent.
+
+    Covers the dedupe interaction between
+    ``state.LauncherState.refresh_orphans`` (``state.py`` 127-173) and
+    ``operations.orphan.record_observed_orphan`` (``orphan.py`` 109-125).
+    The existing unit test mocks ``record_observed_orphan`` out — this
+    regression exercises the real audit append path against a tmp
+    audit file so a refactor that moves the dedupe check below the
+    record call (or removes it) is caught by a duplicated JSON line on
+    disk.
+    """
+    from llauncher.state import LauncherState
+    from llauncher.models.config import ChangeRules
+
+    s = LauncherState.__new__(LauncherState)
+    s.models = {}
+    s.running = {}
+    s.audit = []
+    s.rules = ChangeRules()
+    s.orphans = []
+    s._observed_orphan_pids = set()
+    s._warned_unreadable_pids = set()
+
+    scan = [OrphanInfo(pid=13001, port=8085)]
+    with patch("llauncher.state.list_orphans", return_value=scan):
+        s.refresh_orphans()
+        s.refresh_orphans()
+        s.refresh_orphans()
+
+    entries = al.read_entries(path=audit_path)
+    orphan_entries = [
+        e for e in entries if e.action == AuditAction.OBSERVED_ORPHAN
+    ]
+    assert len(orphan_entries) == 1, (
+        f"expected one OBSERVED_ORPHAN audit line per pid-sighting; got "
+        f"{[(e.action, e.pid) for e in orphan_entries]}"
+    )
+    e = orphan_entries[0]
+    assert e.pid == 13001
+    assert e.port == 8085
+    assert e.result == AuditResult.SUCCESS
+
+
+def test_refresh_orphans_disappear_reappear_emits_twice(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """A pid that leaves and re-enters the scan emits a fresh audit line.
+
+    Pins the prune-on-disappearance contract in ``state.py:170`` against
+    the real audit file. A refactor that made the dedupe set
+    persistent across-prune (or that simply never pruned) would write
+    only one line for the second sighting.
+    """
+    from llauncher.state import LauncherState
+    from llauncher.models.config import ChangeRules
+
+    s = LauncherState.__new__(LauncherState)
+    s.models = {}
+    s.running = {}
+    s.audit = []
+    s.rules = ChangeRules()
+    s.orphans = []
+    s._observed_orphan_pids = set()
+    s._warned_unreadable_pids = set()
+
+    seen = [OrphanInfo(pid=13002, port=8086)]
+    empty: list[OrphanInfo] = []
+
+    with patch(
+        "llauncher.state.list_orphans", side_effect=[seen, empty, seen]
+    ):
+        s.refresh_orphans()  # first sighting → audit
+        s.refresh_orphans()  # disappeared → prune
+        s.refresh_orphans()  # reappeared → audit again
+
+    entries = al.read_entries(path=audit_path)
+    orphan_entries = [
+        e for e in entries
+        if e.action == AuditAction.OBSERVED_ORPHAN and e.pid == 13002
+    ]
+    assert len(orphan_entries) == 2, (
+        "pid 13002 left the scan and reappeared; the audit log "
+        "must reflect both sightings"
+    )
+
+
+def test_refresh_orphans_unreadable_pid_never_audits(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """``cmdline_unreadable=True`` pids do NOT write OBSERVED_ORPHAN entries.
+
+    Pins ADR-015 §4: we cannot honestly classify managed-vs-unmanaged
+    without argv, so the audit log must not record those pids. The
+    operator-visible surface is the WARNING log (covered by
+    test_orphan.py); the audit-log silence is pinned here against a
+    real tmp audit file.
+    """
+    from llauncher.state import LauncherState
+    from llauncher.models.config import ChangeRules
+
+    s = LauncherState.__new__(LauncherState)
+    s.models = {}
+    s.running = {}
+    s.audit = []
+    s.rules = ChangeRules()
+    s.orphans = []
+    s._observed_orphan_pids = set()
+    s._warned_unreadable_pids = set()
+
+    scan = [OrphanInfo(pid=13003, port=None, cmdline_unreadable=True)]
+    with patch("llauncher.state.list_orphans", return_value=scan):
+        s.refresh_orphans()
+        s.refresh_orphans()
+
+    entries = al.read_entries(path=audit_path)
+    orphan_entries = [
+        e for e in entries if e.action == AuditAction.OBSERVED_ORPHAN
+    ]
+    assert orphan_entries == [], (
+        "OBSERVED_ORPHAN must not be recorded for unreadable-cmdline pids; "
+        "got {!r}".format([(e.pid, e.message) for e in orphan_entries])
+    )


### PR DESCRIPTION
## Summary

Phase C of `test-coverage-plan.md`: in-process MCP integration harness plus the canonical real-use-case flow tests. Substrate for M5 (#56).

### Harness design
- In-process tool dispatch through the same `_dispatch_tool` table the real MCP server uses (skips stdio/JSON-RPC framing only).
- HTTP flows go through a FastAPI `TestClient` against the real `create_app()`.
- Disk seams (run-dir, log-dir, audit path, ConfigStore) isolated onto `tmp_path` per test.

### Stub binary contract (`tests/integration/_stubs/llama-server-stub`)
- Stdlib-only Python script; tiny and committed.
- Binds requested `--port` on 127.0.0.1.
- Emits `rest api listening` banner so `core/process.wait_for_server_ready` matches.
- Emits `STUB_FIXTURE: ok` for log-tail assertions.
- SIGTERM/SIGINT reaps cleanly.
- `LLAMA_STUB_HANG_SECS` — sleep before bind (deterministic lifecycle races).
- `LLAMA_STUB_FAIL=1` — exit non-zero before bind (Phase 4 rollback simulation).

### Marker policy
Default (`pytest -q`) uses the stub. New marker `integration_real` (registered in `conftest.py`, not `pyproject.toml`) gates the real-binary path; opt-in via `LLAUNCHER_INTEGRATION_REAL=1` + `LLAMA_SERVER_PATH` + `LLAMA_SMALL_GGUF`. Skips if missing — never downloads.

### Flows covered (`test_mcp_flows.py`)
- `start_server` happy path — lockfile, log, audit
- `server_status` across start/stop
- `swap_server` five-phase happy path
- `cancel_server` pre-commit during start (ADR-014, #54)
- `cancel_server` post-commit during swap — `cancel_ignored_post_commit=True`
- `list_orphans` — **SKIPPED**: ADR-015 verb landed on main in `e2dc024` after this branch's base (`67c07d5`); will reattach on rebase.
- `stop_server` reaps the child (#65 regression-shape)
- `get_server_logs` bounded tail (ADR-013)

### Security hooks covered (`test_agent_security_hooks.py`, from `docs/plans/security-hardening-plan.md §4`)
- C1-a 401 without `X-Api-Key` when token set
- C1-b 403 with wrong key (not 401)
- C1-c `/health` exempt
- §4-17 MCP error envelope structured (no stack trace) for bad model + unknown tool
- §4-16 source-level proof `hmac.compare_digest` still present

UI-only (C11), filesystem-mode (C8, C10) and auto-token-gen (C1-e) hooks deferred.

### Coverage delta
Integration-suite-only run, scoped to `llauncher.mcp_server` + `llauncher.agent`:
- **21% → 37%** overall on those packages.
- `mcp_server/server.py`: 0% → 62%
- `mcp_server/tools/servers.py`: 33% → 70%
- `agent/server.py`: 20% → 30%
- `mcp_server/tools/config.py`: 0% → 13%
- `mcp_server/tools/models.py`: 0% → 23%

### Open Questions
- This worktree is rooted on the cancel branch (`67c07d5`); the orphan verb (`list_orphans`, ADR-015, `e2dc024`) is on main. Rebase + reattach `list_orphans` flow when this PR lands.
- `agent/middleware.py` enforces `X-Api-Key`; hardening plan §4 hooks 1-2 referenced `Authorization`. Tests assert the implemented header. Plan wording should be updated.
- Real-binary path **not** exercised; deferred to manual workstation runs.

### Discipline notes
- No `llauncher/` source modified.
- Marker registration via `conftest.py::pytest_configure`, not `pyproject.toml`.
- Three pre-existing unit-test failures (`test_returns_six_tools` etc.) are unrelated to this PR.

## Test plan
- [x] `pytest tests/integration -q` — 44 passed, 8 skipped
- [x] `pytest tests/integration/test_mcp_flows.py tests/integration/test_agent_security_hooks.py` — 13 passed, 1 skipped
- [x] Coverage scoped to `llauncher.mcp_server` + `llauncher.agent` captured (above)
- [ ] Manual workstation: `LLAUNCHER_INTEGRATION_REAL=1 pytest -m integration_real` (deferred to operator)

Refs: `test-coverage-plan.md` Phase C, #56, #65, ADR-013, ADR-014, ADR-015, PR for #70.
