### PR TITLE
chore: clear quick-win deck — async warning + models/config coverage

### DIFF
--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -219,6 +219,13 @@ class TestMainFunctions:
         with patch("asyncio.run") as mock_asyncio_run:
             main()
             mock_asyncio_run.assert_called_once()
+            # asyncio.run is mocked, so the main_async() coroutine handed to
+            # it is never awaited. Close it explicitly to avoid a
+            # ``RuntimeWarning: coroutine 'main_async' was never awaited``.
+            args, _ = mock_asyncio_run.call_args
+            import asyncio as _asyncio
+            if _asyncio.iscoroutine(args[0]):
+                args[0].close()
 
     def test_main_entry_point(self):
         """Test the if __name__ == '__main__' block."""

--- a/tests/unit/mcp/test_server_extended.py
+++ b/tests/unit/mcp/test_server_extended.py
@@ -64,6 +64,11 @@ class TestMainFunctionCallsAsyncioRun:
             mock_asyncio_run.assert_called_once()
             args, _ = mock_asyncio_run.call_args
             assert asyncio.iscoroutine(args[0]) or hasattr(args[0], "_coro")
+            # asyncio.run is mocked, so the main_async() coroutine handed to
+            # it is never awaited. Close it explicitly to avoid a
+            # ``RuntimeWarning: coroutine 'main_async' was never awaited``.
+            if asyncio.iscoroutine(args[0]):
+                args[0].close()
 
 
 class TestDispatchToolAllTools:

--- a/tests/unit/test_models_config_extended.py
+++ b/tests/unit/test_models_config_extended.py
@@ -54,6 +54,29 @@ class TestModelConfigPathValidation:
         cfg = ModelConfig(name="m", model_path=str(f))
         assert cfg.model_path == str(f)
 
+    def test_missing_non_shard_path_raises(self, tmp_path: Path) -> None:
+        """Cover ``llauncher/models/config.py:79`` — the non-shard
+        missing-path raise.
+
+        ``_skip_path_validation`` is declared as a Pydantic private attr,
+        so at first import ``getattr(cls, '_skip_path_validation', False)``
+        returns a ``ModelPrivateAttr`` (truthy) and the validator is a
+        no-op. ``from_dict_unvalidated`` mutates the class attribute to a
+        literal ``bool`` (``True`` then ``False`` in its ``finally``),
+        which makes the validator reachable for subsequent constructions.
+        Force that priming here so the test is independent of suite
+        ordering, then assert the non-shard branch raises.
+        """
+        # Prime the class-level flag to a real ``bool`` so the validator
+        # actually runs (see docstring).
+        ModelConfig.from_dict_unvalidated({
+            "name": "_prime",
+            "model_path": "/intentionally/missing.gguf",
+        })
+        missing = tmp_path / "does-not-exist.gguf"  # no ``-of-`` shard marker
+        with pytest.raises(ValueError, match="does not exist"):
+            ModelConfig(name="m", model_path=str(missing))
+
 
 # ---------------------------------------------------------------------------
 # from_dict / unvalidated migrations


### PR DESCRIPTION
## Summary

Clears the three "quick wins" the dossier (`docs/handoffs/2026-05-test-coverage-and-security.md` §4) flagged as cheap, independent items. Two real code changes (both in tests), one verify-only.

- **A. Async test warning** (commit `3b34c0f`): `pytest` was emitting `RuntimeWarning: coroutine 'main_async' was never awaited` because two MCP tests patch `asyncio.run` as a `Mock` and the coroutine handed to it never gets awaited. Fix: after asserting the mock was called, explicitly `args[0].close()` if the arg is a coroutine. Applied at both call sites (`tests/unit/mcp/test_server.py::TestMainFunctions` and `tests/unit/mcp/test_server_extended.py::TestMainFunctionCallsAsyncioRun`). +12 lines.
- **B. Pre-existing failures** — verify-only. The dossier's "three pre-existing failures" item was already stale at write time (it said "894/10, no current failures"). Post-PR #75 the suite is **903 passed / 10 skipped / 1 warning** (the warning is third-party protobuf, not ours). No code change for this item.
- **C. Models/config uncovered line** (commit `628e383`): `llauncher/models/config.py:79` (non-shard missing-path raise) was the last uncovered statement in that module. Added `test_missing_non_shard_path_raises`. Investigation surfaced a design hazard worth tracking — see Followups below.

## Test plan

- `python3 -m pytest tests/unit/mcp/test_server.py tests/unit/mcp/test_server_extended.py tests/unit/test_models_config_extended.py -q` → 37/37 pass.
- `python3 -m pytest -q` → **903 passed / 10 skipped / 1 warning** (protobuf deprecation, not ours). Net +1 test vs. post-#75 baseline. Zero `main_async` warnings.

## Followups

- **#88** — `_skip_path_validation: bool = False` is treated as a Pydantic v2 `PrivateAttr` descriptor (truthy), so the path-existence validator silently no-ops until `from_dict_unvalidated` mutates the class attribute to a real `bool`. Also: class-level mutation is not thread-safe. Item C's test primes the class attr explicitly so the regression assertion is order-independent; #88 tracks the actual fix (ClassVar annotation + ContextVar-based skip flag).

## Note for next-session dossier

The dossier's §4 quick wins and the §7 closeout I wrote reference these items as "#6 / #9 / #11". Those are **placeholder IDs from a prior orchestration task tracker, not GitHub issue numbers** — the GitHub issues with those numbers are unrelated and long-closed. This PR captures the work by content. The dossier text remains as-is; a future dossier-sync pass can update the §4 reference style.
