### PR TITLE
cleanup(cli): remove dead _skip_path_validation pop (#95)

### DIFF
--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -129,8 +129,6 @@ def model_info(
 
     headers = ["KEY", "VALUE"]
     cfg_dict = config.model_dump()
-    # Omit the internal flag used during deserialization
-    cfg_dict.pop("_skip_path_validation", None)
     rows = [[k, str(v)] for k, v in cfg_dict.items()]
     _print_table(headers, rows, title=f"Model: {name}")
 


### PR DESCRIPTION
## Summary

- Remove the dead `cfg_dict.pop("_skip_path_validation", None)` and its misleading comment from `llauncher/cli.py::model_info`.
- After #93 (`5759a28`), `ModelConfig._skip_path_validation` is `ClassVar[bool]`, so Pydantic excludes it from `model_dump()` output — the defensive pop can never fire.

Closes #95

## Test plan

- Full suite green; the popped key cannot appear in `model_dump()` for a `ClassVar` field.
- `python3 -m pytest -q`: 935 passed, 10 skipped, total coverage 94.66% (floor 93%).
