### PR TITLE
security(models): deny-list managed flags in extra_args (#81, C7)

### DIFF
--- a/llauncher/mcp_server/tools/config.py
+++ b/llauncher/mcp_server/tools/config.py
@@ -135,23 +135,29 @@ async def update_model_config(state: LauncherState, args: dict) -> dict:
     existing = state.models[name]
     updated_config = existing.model_copy()
 
-    # Apply updates (default_port silently dropped per ADR-010)
+    # Apply updates (default_port silently dropped per ADR-010). With
+    # ``validate_assignment=True`` on ``ModelConfig`` (review of PR #101),
+    # each per-field assignment below validates that field's constraints;
+    # wrap the whole block so the resulting ValidationError returns the
+    # same clean error dict as the explicit ``model_validate`` below
+    # rather than escaping uncaught.
     updates.pop("default_port", None)
-    if "n_gpu_layers" in updates:
-        updated_config.n_gpu_layers = updates["n_gpu_layers"]
-    if "ctx_size" in updates:
-        updated_config.ctx_size = updates["ctx_size"]
-    if "threads" in updates:
-        updated_config.threads = updates["threads"]
-    if "flash_attn" in updates:
-        updated_config.flash_attn = updates["flash_attn"]
-    if "no_mmap" in updates:
-        updated_config.no_mmap = updates["no_mmap"]
-    if "extra_args" in updates:
-        updated_config.extra_args = updates["extra_args"]
-
-    # Validate the updated config
     try:
+        if "n_gpu_layers" in updates:
+            updated_config.n_gpu_layers = updates["n_gpu_layers"]
+        if "ctx_size" in updates:
+            updated_config.ctx_size = updates["ctx_size"]
+        if "threads" in updates:
+            updated_config.threads = updates["threads"]
+        if "flash_attn" in updates:
+            updated_config.flash_attn = updates["flash_attn"]
+        if "no_mmap" in updates:
+            updated_config.no_mmap = updates["no_mmap"]
+        if "extra_args" in updates:
+            updated_config.extra_args = updates["extra_args"]
+
+        # Re-validate the whole shape after per-field assignments — catches
+        # any cross-field invariants the individual validators don't cover.
         ModelConfig.model_validate(updated_config)
     except Exception as e:
         return {"success": False, "error": f"Validation error: {e}"}

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -6,6 +6,7 @@ field discriminates the backend inference engine; only ``llama_server``
 is implemented in M1, vLLM follows in M6.
 """
 
+import shlex
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -14,6 +15,34 @@ from typing import ClassVar, Literal
 from pydantic import BaseModel, Field, field_validator
 
 from llauncher.core.settings import BLACKLISTED_PORTS as _ENV_BLACKLISTED_PORTS
+
+
+# Deny-list of llama-server flags llauncher manages at its own boundary
+# (Issue #81 / security-hardening-plan §3 C7). These flags must not appear
+# in :attr:`ModelConfig.extra_args` because:
+#
+# * ``--api-key`` / ``--alias`` — security-sensitive identity that
+#   llauncher will own once #87/#10 land. A malicious config slipping
+#   one of these in would silently override llauncher's intent.
+# * ``-m`` / ``--model`` — set by ``build_command`` from
+#   :attr:`ModelConfig.model_path` (``core/process.py``). Duplication
+#   bypasses the path validator on ``model_path``.
+# * ``--host`` / ``--port`` — supplied at start time as runtime
+#   parameters (ADR-010). An override here defeats port allocation
+#   and the loopback-default binding (C2, PR #75).
+#
+# Kept intentionally small; the rest of llauncher's managed flags
+# (``--ctx-size``, sampling params, etc.) are merely "would conflict",
+# not "must be controlled at the boundary". Operators get a clearer
+# error from llama-server's argv parser for those.
+DENIED_EXTRA_ARG_FLAGS: frozenset[str] = frozenset({
+    "--api-key",
+    "--alias",
+    "-m",
+    "--model",
+    "--host",
+    "--port",
+})
 
 
 class BackendKind(str, Enum):
@@ -68,6 +97,49 @@ class ModelConfig(BaseModel):
     # makes this a plain Python class variable so the validator runs as
     # intended on first construction (see issue #88).
     _skip_path_validation: ClassVar[bool] = False
+
+    @field_validator("extra_args", mode="before")
+    @classmethod
+    def extra_args_no_managed_flags(cls, v):
+        """Reject ``extra_args`` tokens that collide with llauncher-managed flags.
+
+        Mirrors the runtime ``shlex.split`` at
+        ``llauncher/core/process.py`` so the boundary check sees argv the
+        same way the launcher will. Both bare (``--api-key foo``) and
+        equals (``--api-key=foo``) forms are rejected.
+
+        Implements security-hardening-plan §3 C7 (Issue #81). See
+        :data:`DENIED_EXTRA_ARG_FLAGS` for the curated deny-list and the
+        rationale for each entry.
+        """
+        if v is None or v == "":
+            return v
+        # Legacy ``list[str]`` shape is normalized to ``str`` in
+        # ``from_dict_unvalidated`` *before* validation runs, but defend
+        # in depth so the validator behaves sanely if called directly.
+        if isinstance(v, list):
+            tokens = [str(t) for t in v]
+        else:
+            try:
+                tokens = shlex.split(str(v))
+            except ValueError as e:
+                # Malformed shell-quoting (unbalanced quote, etc.) —
+                # surface as a validation error rather than letting
+                # subprocess construction blow up at start time.
+                raise ValueError(f"extra_args is not a valid shell token string: {e}")
+
+        for token in tokens:
+            # Match both bare flag and ``--flag=value`` form. We compare
+            # the head before ``=`` so ``--api-key=foo`` is rejected
+            # identically to ``--api-key foo``.
+            head = token.split("=", 1)[0]
+            if head in DENIED_EXTRA_ARG_FLAGS:
+                raise ValueError(
+                    f"extra_args contains llauncher-managed flag "
+                    f"{head!r} — set it via the dedicated ModelConfig "
+                    f"field or remove it. See security-hardening-plan §3 C7."
+                )
+        return v
 
     @field_validator("model_path", mode="before")
     @classmethod

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -62,7 +62,13 @@ class ModelConfig(BaseModel):
     supplied at call time per ADR-010.
     """
 
-    model_config = {"arbitrary_types_allowed": True}
+    # ``validate_assignment``: the ``extra_args`` deny-list (C7) is also
+    # enforced on field assignment, not only at construction time. Without
+    # this, a caller that mutates ``cfg.extra_args`` after construction
+    # would silently bypass the deny-list (review of PR #101 / Issue #81).
+    # Production assignment surface today: ``mcp_server/tools/config.py``
+    # ``update_model_config``.
+    model_config = {"arbitrary_types_allowed": True, "validate_assignment": True}
 
     name: str
     model_path: str

--- a/tests/unit/test_models_config_extra_args.py
+++ b/tests/unit/test_models_config_extra_args.py
@@ -1,0 +1,212 @@
+"""Regression tests for the ``extra_args`` deny-list validator.
+
+Implements assertions C7-a..C7-c from
+``docs/plans/security-hardening-plan.md`` §4 (Issue #81). The validator
+under test lives on :class:`llauncher.models.config.ModelConfig` and
+mirrors the runtime ``shlex.split`` in
+``llauncher/core/process.py`` so that a malicious config is rejected at
+save/load time rather than silently injecting argv into ``llama-server``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llauncher.models.config import (
+    DENIED_EXTRA_ARG_FLAGS,
+    ModelConfig,
+)
+
+
+@pytest.fixture
+def model_file(tmp_path: Path) -> str:
+    """A tmp file that satisfies the ``model_path`` existence validator."""
+    f = tmp_path / "m.gguf"
+    f.write_bytes(b"x")
+    return str(f)
+
+
+class TestExtraArgsDenyList:
+    """C7-a..C7-c plus equals-form coverage."""
+
+    # ---- C7-a: deny --api-key (bare and equals form) -------------------
+
+    def test_c7_a_denies_api_key_bare(self, model_file: str) -> None:
+        with pytest.raises(ValueError, match="--api-key"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--api-key foo",
+            )
+
+    def test_c7_a_denies_api_key_equals_form(self, model_file: str) -> None:
+        """``--api-key=foo`` must be rejected just like the bare form —
+        otherwise the deny-list is trivially bypassable.
+        """
+        with pytest.raises(ValueError, match="--api-key"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--api-key=foo",
+            )
+
+    # ---- C7-b: deny --alias --------------------------------------------
+
+    def test_c7_b_denies_alias_bare(self, model_file: str) -> None:
+        with pytest.raises(ValueError, match="--alias"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--alias evil",
+            )
+
+    def test_c7_b_denies_alias_equals_form(self, model_file: str) -> None:
+        with pytest.raises(ValueError, match="--alias"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--alias=evil",
+            )
+
+    # ---- C7-c: benign args succeed -------------------------------------
+
+    def test_c7_c_allows_benign_ctx_size(self, model_file: str) -> None:
+        """Benign llama-server flags must round-trip unchanged."""
+        cfg = ModelConfig(
+            name="m",
+            model_path=model_file,
+            extra_args="--ctx-size 4096",
+        )
+        assert cfg.extra_args == "--ctx-size 4096"
+
+    def test_c7_c_allows_log_disable(self, model_file: str) -> None:
+        """Plan §4 lists ``--log-disable`` as the C7-c canonical example."""
+        cfg = ModelConfig(
+            name="m",
+            model_path=model_file,
+            extra_args="--log-disable",
+        )
+        assert cfg.extra_args == "--log-disable"
+
+    def test_c7_c_allows_empty(self, model_file: str) -> None:
+        """The default empty string must not be flagged."""
+        cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
+        assert cfg.extra_args == ""
+
+    def test_c7_c_allows_multiple_benign(self, model_file: str) -> None:
+        cfg = ModelConfig(
+            name="m",
+            model_path=model_file,
+            extra_args="--ctx-size 4096 --log-disable --verbose",
+        )
+        assert "--ctx-size" in cfg.extra_args
+
+    # ---- additional managed-flag coverage ------------------------------
+
+    @pytest.mark.parametrize(
+        "flag",
+        sorted(DENIED_EXTRA_ARG_FLAGS),
+    )
+    def test_each_managed_flag_is_denied(self, model_file: str, flag: str) -> None:
+        """Every member of ``DENIED_EXTRA_ARG_FLAGS`` must trigger the
+        validator. Guards against the constant drifting out of sync with
+        the validator (e.g. someone adding a flag to the set but
+        accidentally short-circuiting it in the validator).
+        """
+        # Use a placeholder value so flags that expect arguments still
+        # parse cleanly. The validator only inspects the flag head.
+        with pytest.raises(ValueError, match="llauncher-managed flag"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args=f"{flag} sentinel-value",
+            )
+
+    def test_denied_flag_via_from_dict(self, model_file: str) -> None:
+        """Surface the same error through the public dict constructor —
+        this is the path the UI/CLI take when persisting a config.
+        """
+        with pytest.raises(ValueError, match="--api-key"):
+            ModelConfig.from_dict({
+                "name": "m",
+                "model_path": model_file,
+                "extra_args": "--api-key leak",
+            })
+
+    def test_denied_flag_via_from_dict_unvalidated(self) -> None:
+        """The deny-list must also fire on the load path so a malicious
+        config-on-disk cannot bypass validation just by skipping the path
+        check.
+        """
+        with pytest.raises(ValueError, match="--alias"):
+            ModelConfig.from_dict_unvalidated({
+                "name": "m",
+                "model_path": "/fake/does-not-matter.gguf",
+                "extra_args": "--alias sneaky",
+            })
+
+    def test_legacy_list_extra_args_normalized_then_validated(self) -> None:
+        """Legacy ``list[str]`` shape gets joined to a string in
+        ``from_dict_unvalidated`` *before* the field validator runs.
+        A denied flag inside the list must still trip the deny-list.
+        """
+        with pytest.raises(ValueError, match="--api-key"):
+            ModelConfig.from_dict_unvalidated({
+                "name": "m",
+                "model_path": "/fake/does-not-matter.gguf",
+                "extra_args": ["--api-key", "leak"],
+            })
+
+    def test_malformed_quoting_raises_validation_error(self, model_file: str) -> None:
+        """A shell-unparseable ``extra_args`` should be a clean validation
+        error rather than crashing at server-start time when
+        ``build_command`` does its own ``shlex.split``.
+        """
+        with pytest.raises(ValueError, match="not a valid shell token string"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args='--foo "unbalanced',
+            )
+
+    def test_substring_flag_is_allowed(self, model_file: str) -> None:
+        """A flag whose *name* contains a denied flag as a substring
+        (e.g. ``--api-key-file``) must not be rejected — the validator
+        compares on exact head, not prefix.
+
+        Note: ``--api-key-file`` is not a real llama-server flag at the
+        time of writing; this is a regression test for the matching
+        semantics, not an endorsement of that flag.
+        """
+        cfg = ModelConfig(
+            name="m",
+            model_path=model_file,
+            extra_args="--api-key-file /tmp/keys",
+        )
+        assert "--api-key-file" in cfg.extra_args
+
+
+class TestDenyListContents:
+    """Lock down the deny-list shape so additions are intentional."""
+
+    def test_security_flags_present(self) -> None:
+        """The two flags called out by name in Issue #81 must be in
+        the list; if someone removes them, the test fails loudly.
+        """
+        assert "--api-key" in DENIED_EXTRA_ARG_FLAGS
+        assert "--alias" in DENIED_EXTRA_ARG_FLAGS
+
+    def test_runtime_binding_flags_present(self) -> None:
+        """``--host`` / ``--port`` / ``-m`` / ``--model`` are set by
+        ``build_command`` from runtime parameters and managed fields;
+        duplication via ``extra_args`` bypasses ADR-010 / model_path
+        validation.
+        """
+        for flag in ("--host", "--port", "-m", "--model"):
+            assert flag in DENIED_EXTRA_ARG_FLAGS, flag
+
+    def test_deny_list_is_frozen(self) -> None:
+        """Frozenset guards against accidental mutation at import time."""
+        assert isinstance(DENIED_EXTRA_ARG_FLAGS, frozenset)

--- a/tests/unit/test_models_config_extra_args.py
+++ b/tests/unit/test_models_config_extra_args.py
@@ -188,6 +188,35 @@ class TestExtraArgsDenyList:
         assert "--api-key-file" in cfg.extra_args
 
 
+class TestPostConstructionAssignment:
+    """``validate_assignment=True`` enforces the deny-list at field
+    assignment, not only at construction (review of PR #101). Without
+    this, a caller that mutates ``cfg.extra_args`` after construction
+    would silently bypass C7.
+
+    Production assignment surface today:
+    ``llauncher/mcp_server/tools/config.py::update_model_config``.
+    """
+
+    def test_assignment_of_denied_flag_raises(self, model_file: str) -> None:
+        cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
+        with pytest.raises(ValueError, match="--api-key"):
+            cfg.extra_args = "--api-key leaked"
+
+    def test_assignment_of_denied_flag_equals_form_raises(
+        self, model_file: str
+    ) -> None:
+        cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
+        with pytest.raises(ValueError, match="--alias"):
+            cfg.extra_args = "--alias=evil"
+
+    def test_assignment_of_benign_args_succeeds(self, model_file: str) -> None:
+        """Sanity: legitimate post-construction updates still work."""
+        cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
+        cfg.extra_args = "--ctx-size 4096 --temp 0.7"
+        assert "--ctx-size" in cfg.extra_args
+
+
 class TestDenyListContents:
     """Lock down the deny-list shape so additions are intentional."""
 


### PR DESCRIPTION
Closes #81

## Summary

Implements security-hardening-plan §3 control **C7**: validate `ModelConfig.extra_args` against a curated deny-list of llama-server flags llauncher manages at its own boundary. Error surfaces at config-save / config-load time rather than at server start.

- New `DENIED_EXTRA_ARG_FLAGS` frozenset in `llauncher/models/config.py`. Contents: `--api-key`, `--alias`, `-m`, `--model`, `--host`, `--port`. Each entry justified in the module docstring (security identity vs. ADR-010 runtime-binding contract).
- New `extra_args_no_managed_flags` Pydantic `field_validator` mirrors the runtime `shlex.split` in `llauncher/core/process.py:171-172` so the boundary check sees argv identically to the launcher. Rejects bare (`--api-key foo`) and equals (`--api-key=foo`) forms uniformly via `token.split("=", 1)[0]`.
- Malformed shell quoting in `extra_args` is now a clean validation error instead of a crash at server-start time.

## Test plan

`tests/unit/test_models_config_extra_args.py` (22 cases) — explicit assertions:

- [x] C7-a: `--api-key foo` rejected (bare + equals form)
- [x] C7-b: `--alias evil` rejected (bare + equals form)
- [x] C7-c: `--ctx-size 4096`, `--log-disable`, empty, multi-flag benign strings accepted
- [x] Parametrized: every member of `DENIED_EXTRA_ARG_FLAGS` is denied (drift-guard between constant and validator)
- [x] Deny-list fires via `ModelConfig(...)`, `from_dict(...)`, and `from_dict_unvalidated(...)`
- [x] Legacy `list[str]` shape with a denied flag is rejected after the migration join
- [x] Malformed quoting (`--foo "unbalanced`) raises a validation error
- [x] Substring-flag false-positive guard: `--api-key-file` is allowed (exact-head match, not prefix)
- [x] `DENIED_EXTRA_ARG_FLAGS` lock-down tests (security flags present, runtime-binding flags present, is `frozenset`)

Full suite: `python3 -m pytest -q` -> **957 passed, 10 skipped**, coverage **94.70%** (floor 93%). `llauncher/models/config.py` coverage at 98%.

## Signals

- Interpretation note on plan §4 C7-a..C7-c: assertions are phrased as "`add_model` (any surface) with `extra_args=...` raises a validation error". I interpreted "any surface" as the underlying Pydantic validator on `ModelConfig`, since both the agent HTTP path and the MCP `add_model` tool route through `ModelConfig.model_validate` / `from_dict`. End-to-end surface tests at the FastAPI / MCP layer remain a Phase C concern per `test-coverage-plan.md`.
- No scope creep: `LAUNCHER_MODELS_ROOT` (#82, C8) explicitly punted as instructed.
