### PR TITLE
security(agent): cap request body size at 1 MiB (#78, C3)

### DIFF
--- a/llauncher/agent/middleware.py
+++ b/llauncher/agent/middleware.py
@@ -1,18 +1,31 @@
-"""Authentication middleware for the llauncher agent service.
+"""Middleware for the llauncher agent service.
 
-Provides API key-based authentication via the X-Api-Key header,
-with exemptions for health check and OpenAPI documentation endpoints.
+Provides:
+
+* :class:`AuthenticationMiddleware` — API key auth via the ``X-Api-Key``
+  header with exemptions for health/OpenAPI paths.
+* :class:`BodySizeLimitMiddleware` — defense-in-depth cap on inbound
+  HTTP request body size (security plan §3 control C3 / issue #78).
 """
 
 import hmac
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from fastapi import Request
 
 
 # Paths that skip authentication regardless of token configuration
 _AUTH_EXEMPT_PATHS = frozenset({"/health", "/docs", "/redoc", "/openapi.json"})
+
+
+# Maximum allowed inbound HTTP request body size, in bytes.
+# Security plan §3 C3 / issue #78: defense-in-depth against accidental or
+# malicious oversize payloads. 1 MiB comfortably accommodates every legitimate
+# agent payload (model configs, swap/start requests are all small JSON
+# documents) while bounding worst-case memory pressure.
+MAX_REQUEST_BODY_BYTES: int = 1024 * 1024  # 1 MiB
 
 
 class AuthenticationMiddleware(BaseHTTPMiddleware):
@@ -64,3 +77,107 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         return response
+
+
+class BodySizeLimitMiddleware:
+    """Pure-ASGI middleware that rejects oversize HTTP request bodies.
+
+    Rejects with HTTP 413 (Payload Too Large) when an inbound HTTP request
+    body exceeds :data:`MAX_REQUEST_BODY_BYTES`. Implemented at the ASGI
+    layer (not :class:`BaseHTTPMiddleware`) so the body never gets fully
+    buffered into memory before the decision is made.
+
+    Two enforcement paths:
+
+    1. **Fast path** — if the client advertises a ``Content-Length`` header
+       exceeding the cap, reject before reading any body bytes.
+    2. **Streaming path** — otherwise, accumulate ``http.request`` byte
+       counts as they arrive and reject as soon as the total crosses the
+       cap. This covers chunked encoding and missing/lying
+       Content-Length headers.
+
+    Non-HTTP scopes (lifespan, websocket) and HTTP methods that do not
+    carry a body in the usual sense still flow through the size check
+    uniformly: a GET with an honestly-empty body trivially passes.
+    """
+
+    def __init__(self, app: ASGIApp, max_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
+        """Initialize the middleware.
+
+        Args:
+            app: The downstream ASGI application.
+            max_bytes: Maximum allowed body size in bytes. Defaults to
+                :data:`MAX_REQUEST_BODY_BYTES` (1 MiB).
+        """
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Fast path: trust an honest Content-Length header if it exceeds
+        # the cap. (If it lies low, the streaming path still catches it.)
+        for name, value in scope.get("headers", []):
+            if name == b"content-length":
+                try:
+                    declared = int(value)
+                except (TypeError, ValueError):
+                    break
+                if declared > self.max_bytes:
+                    await _send_413(send)
+                    return
+                break
+
+        bytes_seen = 0
+        max_bytes = self.max_bytes
+        rejected = False
+
+        async def limited_receive() -> Message:
+            nonlocal bytes_seen, rejected
+            message = await receive()
+            if message["type"] != "http.request":
+                return message
+            body = message.get("body", b"") or b""
+            bytes_seen += len(body)
+            if bytes_seen > max_bytes:
+                rejected = True
+                # Surface as a sentinel disconnect so the downstream app
+                # stops reading; the 413 response is sent below.
+                return {"type": "http.disconnect"}
+            return message
+
+        # Wrap send so that once we've decided to reject, we suppress any
+        # response the downstream app might have started emitting on the
+        # disconnect signal.
+        response_started = False
+
+        async def guarded_send(message: Message) -> None:
+            nonlocal response_started
+            if rejected:
+                return
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        await self.app(scope, limited_receive, guarded_send)
+
+        if rejected and not response_started:
+            await _send_413(send)
+
+
+async def _send_413(send: Send) -> None:
+    """Emit a minimal HTTP 413 JSON response via raw ASGI ``send``."""
+    body = b'{"detail":"Request body too large"}'
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -27,7 +27,10 @@ from llauncher import __version__
 from llauncher import operations as ops
 from llauncher.agent.auth import is_loopback, resolve_agent_token
 from llauncher.agent.config import AgentConfig
-from llauncher.agent.middleware import AuthenticationMiddleware
+from llauncher.agent.middleware import (
+    AuthenticationMiddleware,
+    BodySizeLimitMiddleware,
+)
 from llauncher.agent.routing import router, get_node_name
 from llauncher.core import lockfile as lf
 from llauncher.core.settings import AGENT_API_KEY
@@ -213,6 +216,12 @@ def create_app(auth_token: str | None = None) -> FastAPI:
     if auth_active:
         # Add authentication middleware when API key is configured
         app.add_middleware(AuthenticationMiddleware, expected_token=token)
+
+    # Body-size cap (security plan §3 C3 / issue #78). Registered last so
+    # it becomes the outermost layer: oversize requests are rejected with
+    # 413 before auth (or anything else) even sees the body, bounding the
+    # worst-case memory pressure from a malicious or buggy client.
+    app.add_middleware(BodySizeLimitMiddleware)
 
     # Include the router
     app.include_router(router, tags=["llauncher"])

--- a/tests/integration/test_agent_body_cap.py
+++ b/tests/integration/test_agent_body_cap.py
@@ -1,0 +1,311 @@
+"""Integration tests for security hardening §3 C3 (issue #78).
+
+Covers:
+
+- **C3-a**: A POST to the agent with a body that exceeds the 1 MiB
+  request-body cap returns HTTP 413, regardless of whether auth is
+  configured. The check must short-circuit before the route handler
+  runs (the route's Pydantic schema would otherwise reject the body
+  with 422 before the size check fired, masking the regression).
+- **C3-normal**: A normal-size request still flows through to its
+  usual handler and receives its usual response.
+- **C3-content-length**: A request advertising an oversize
+  ``Content-Length`` header is rejected on the fast path (no body
+  bytes read).
+
+These tests use the in-process FastAPI TestClient via the
+``agent_client`` / ``agent_client_with_token`` fixtures from
+``tests/integration/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llauncher.agent.middleware import MAX_REQUEST_BODY_BYTES
+
+
+pytestmark = pytest.mark.integration
+
+
+# Sanity check: the documented cap matches the constant the implementation
+# exports. If someone later edits one without the other, this is the
+# canary.
+def test_body_cap_constant_is_one_mib():
+    assert MAX_REQUEST_BODY_BYTES == 1024 * 1024
+
+
+# ─────── C3-a: oversize body → 413 (no-auth app) ──────────────────────────
+
+
+def test_oversize_post_returns_413_no_auth(agent_client):
+    """An oversize POST body is rejected with 413 even when auth is off.
+
+    The body-size middleware lives outside auth and ahead of the router,
+    so the cap fires on the no-auth app exactly as it does on the
+    auth-enabled app.
+    """
+    # 2 MiB of bytes — comfortably over the 1 MiB cap. We aim a POST at
+    # /start/{port}: in a normal flow this would Pydantic-parse a JSON
+    # body, but the size cap must short-circuit before we get there.
+    oversize = b"x" * (2 * 1024 * 1024)
+
+    resp = agent_client.post(
+        "/start/9999",
+        content=oversize,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 413, (
+        f"expected 413 for oversize body, got {resp.status_code}: {resp.text!r}"
+    )
+
+
+# ─────── C3-a (auth path): oversize body → 413 even with valid token ─────
+
+
+def test_oversize_post_returns_413_with_auth(agent_client_with_token):
+    """The body-size cap fires before auth — but a valid token still
+    yields 413 (not 401/403). This confirms the middleware order: size
+    cap is the outermost layer."""
+    client, token = agent_client_with_token
+    oversize = b"x" * (2 * 1024 * 1024)
+
+    resp = client.post(
+        "/start/9999",
+        content=oversize,
+        headers={
+            "Content-Type": "application/json",
+            "X-Api-Key": token,
+        },
+    )
+
+    assert resp.status_code == 413
+
+
+# ─────── C3-content-length fast path ──────────────────────────────────────
+
+
+def test_oversize_content_length_header_rejected(agent_client):
+    """An honest oversize ``Content-Length`` is rejected on the fast path.
+
+    We send an empty body but lie that it is huge. The middleware must
+    trust the declared length and reject without attempting to read.
+    (httpx normalizes some headers, so we exercise the path via the
+    raw ASGI scope by sending an actual oversize body; the practical
+    end-user observation is the same: 413.)
+    """
+    # The httpx TestClient sets Content-Length from the actual body, so
+    # the most reliable way to exercise the header fast path is still to
+    # send a real oversize body. The accumulator path and the header
+    # path converge on the same observable result.
+    oversize = b"y" * (MAX_REQUEST_BODY_BYTES + 1)
+    resp = agent_client.post("/start/9999", content=oversize)
+    assert resp.status_code == 413
+
+
+# ─────── C3-normal: under-cap request still works ────────────────────────
+
+
+def test_normal_request_still_works(agent_client):
+    """A normal-size request passes the cap and reaches its handler.
+
+    We hit ``/health`` (a small GET) and the model-listing endpoint as
+    representatives of read-side traffic; both should respond with their
+    usual 200, demonstrating the middleware is non-disruptive for
+    legitimate payloads.
+    """
+    resp = agent_client.get("/health")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "healthy"
+
+
+def test_under_cap_post_reaches_handler(agent_client):
+    """An under-cap POST flows past the size check and reaches the route.
+
+    We POST a small (~few hundred bytes) JSON body to ``/start/{port}``.
+    The expected response is *not* 413 — the route handler may return
+    anything else (a routed business response — 200, 4xx, 5xx), but the
+    size middleware must not interfere.
+    """
+    small_body = {"model": "nonexistent-model-for-this-test"}
+    resp = agent_client.post("/start/9999", json=small_body)
+    # Any status other than 413 means the size cap correctly let the
+    # request through to the routing/business layer.
+    assert resp.status_code != 413
+
+
+# ─────── Direct-ASGI tests for the streaming / chunked paths ─────────────
+
+
+@pytest.mark.asyncio
+async def test_streaming_path_rejects_chunked_oversize():
+    """No Content-Length header (simulating chunked transfer): the
+    middleware must accumulate body bytes and reject mid-stream when
+    the cap is crossed.
+
+    The httpx TestClient always sets Content-Length on POST bodies, so
+    we exercise this branch by driving the middleware directly over
+    ASGI with a hand-rolled scope/receive/send triple.
+    """
+    from llauncher.agent.middleware import BodySizeLimitMiddleware
+
+    inner_called = False
+
+    async def inner_app(scope, receive, send):
+        # Drain receive — this is what a real downstream app would do.
+        nonlocal inner_called
+        inner_called = True
+        while True:
+            msg = await receive()
+            if msg["type"] == "http.disconnect":
+                return
+            if not msg.get("more_body"):
+                return
+
+    mw = BodySizeLimitMiddleware(inner_app, max_bytes=1024)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/start/9999",
+        # No Content-Length header — force the streaming path.
+        "headers": [(b"content-type", b"application/json")],
+    }
+
+    # Three chunks of 512 bytes — total 1536 > 1024.
+    chunks = [
+        {"type": "http.request", "body": b"a" * 512, "more_body": True},
+        {"type": "http.request", "body": b"b" * 512, "more_body": True},
+        {"type": "http.request", "body": b"c" * 512, "more_body": False},
+    ]
+    chunk_iter = iter(chunks)
+
+    async def receive():
+        try:
+            return next(chunk_iter)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+
+    # Expect a 413 response start + body.
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_content_length_fast_path_short_circuits():
+    """An oversize Content-Length is rejected before any body byte is read.
+
+    The downstream app must not be invoked at all.
+    """
+    from llauncher.agent.middleware import BodySizeLimitMiddleware
+
+    inner_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal inner_called
+        inner_called = True
+
+    mw = BodySizeLimitMiddleware(inner_app, max_bytes=1024)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/start/9999",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"99999"),
+        ],
+    }
+
+    async def receive():
+        raise AssertionError("receive() must not be called on the fast path")
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+
+    assert not inner_called
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_passes_through():
+    """Lifespan / websocket scopes are not the body-size middleware's
+    concern; they must pass through unmodified."""
+    from llauncher.agent.middleware import BodySizeLimitMiddleware
+
+    inner_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal inner_called
+        inner_called = True
+
+    mw = BodySizeLimitMiddleware(inner_app)
+
+    scope = {"type": "lifespan"}
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    await mw(scope, receive, send)
+    assert inner_called
+
+
+@pytest.mark.asyncio
+async def test_malformed_content_length_falls_through():
+    """A non-integer Content-Length header is ignored (the streaming
+    path still protects us)."""
+    from llauncher.agent.middleware import BodySizeLimitMiddleware
+
+    inner_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal inner_called
+        inner_called = True
+        msg = await receive()
+        assert msg["type"] == "http.request"
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = BodySizeLimitMiddleware(inner_app, max_bytes=1024)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/start/9999",
+        "headers": [
+            (b"content-length", b"not-a-number"),
+        ],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"small", "more_body": False}
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+
+    assert inner_called
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200


### PR DESCRIPTION
## Summary
- Adds a pure-ASGI `BodySizeLimitMiddleware` (in `llauncher/agent/middleware.py`) that rejects inbound HTTP requests whose body exceeds `MAX_REQUEST_BODY_BYTES` (1 MiB) with HTTP 413, fulfilling security plan §3 control C3 / assertion C3-a.
- Wires the middleware into `create_app` (`llauncher/agent/server.py`) as the outermost layer: oversize requests are rejected before auth (or anything else) ever sees the body, so worst-case memory pressure is bounded regardless of token state.
- Two enforcement paths: a fast `Content-Length` check that short-circuits before any body bytes are read, and a streaming accumulator that catches chunked / missing / lying-Content-Length cases.
- Cap is a module-level constant (`MAX_REQUEST_BODY_BYTES`); env-var configurability deferred per issue guidance ("configurable via env if needed" — not required for landing).

## Test plan
- [x] `tests/integration/test_agent_body_cap.py` — 10 cases:
  - constant equals 1 MiB (canary)
  - oversize POST → 413 against the no-auth app
  - oversize POST → 413 against the auth-enabled app (with valid token — confirms middleware order)
  - oversize body via TestClient (CL fast path) → 413
  - normal `GET /health` still 200
  - under-cap POST reaches its handler (no 413)
  - direct-ASGI: chunked oversize → 413 via streaming accumulator
  - direct-ASGI: Content-Length fast-path short-circuits without reading any body
  - direct-ASGI: non-HTTP scope (lifespan) passes through
  - direct-ASGI: malformed Content-Length is ignored, streaming path still works
- [x] `python3 -m pytest -q` — 945 passed, 10 skipped, coverage 94.68% (above the 93% floor)

Closes #78
