### PR TITLE
docs(security): Streamlit loopback-bind guidance (#85, C12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ run.bat ui
 
 The UI automatically starts a local agent if one isn't running. You can also start the agent separately with `./run.sh agent` or `run.bat agent`.
 
+> **Bind to loopback (no built-in auth).** Streamlit binds wherever the
+> operator launches it; the default is loopback. The runner scripts
+> launch with `--server.address 127.0.0.1`, and that is the recommended
+> invocation for typical single-operator use. The dashboard itself has
+> **no built-in authentication** — anything that can reach the port can
+> drive every mutate path (start/stop servers, edit configs, manage
+> nodes). Do not expose it beyond loopback without an operator-supplied
+> gateway in front: Tailscale, an SSH tunnel, or a reverse proxy that
+> enforces auth. Passing `--server.address 0.0.0.0` (or a LAN IP)
+> without one of those is equivalent to publishing an unauthenticated
+> admin console on your network. See
+> `docs/plans/security-hardening-plan.md` §2.8 (control C12) for the
+> threat-model rationale.
+
 #### Dashboard Tab
 - Grid view of all configured models with status indicators (🟢 Running / ⚫ Stopped)
 - Quick **Start** and **Stop** buttons for each model

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -77,7 +77,12 @@ goto :help
 
 :ui
     echo [INFO] Starting Streamlit UI...
-    "%PYTHON_EXECUTABLE%" -m streamlit run "%PROJECT_DIR%\llauncher\ui\app.py"
+    REM Bind to loopback by default. The dashboard has no built-in auth;
+    REM see README "Streamlit UI" + docs/plans/security-hardening-plan.md
+    REM section 2.8 (C12). Override with LAUNCHER_UI_HOST only behind a
+    REM gateway (Tailscale / SSH tunnel / reverse proxy with auth).
+    if "%LAUNCHER_UI_HOST%"=="" set "LAUNCHER_UI_HOST=127.0.0.1"
+    "%PYTHON_EXECUTABLE%" -m streamlit run "%PROJECT_DIR%\llauncher\ui\app.py" --server.address %LAUNCHER_UI_HOST%
     goto :end
 
 :agent

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -55,7 +55,12 @@ case "${1:-}" in
         ;;
     ui)
         print_info "Starting Streamlit UI..."
-        streamlit run "$PROJECT_DIR/llauncher/ui/app.py"
+        # Bind to loopback by default. The dashboard has no built-in auth;
+        # see README "Streamlit UI" + docs/plans/security-hardening-plan.md
+        # §2.8 (C12). Override with LAUNCHER_UI_HOST only behind a gateway
+        # (Tailscale / SSH tunnel / reverse proxy with auth).
+        streamlit run "$PROJECT_DIR/llauncher/ui/app.py" \
+            --server.address "${LAUNCHER_UI_HOST:-127.0.0.1}"
         ;;
     agent)
         print_info "Starting remote management agent..."

--- a/tests/manual/m4-smoke.md
+++ b/tests/manual/m4-smoke.md
@@ -4,7 +4,7 @@ After landing M4 Slice 13 (#50). Run this once on a real workstation before tagg
 
 ## Setup
 - [ ] `llauncher-agent` running in a terminal
-- [ ] `streamlit run llauncher/ui/app.py` opens cleanly
+- [ ] `streamlit run llauncher/ui/app.py --server.address 127.0.0.1` opens cleanly (loopback-bind per C12)
 
 ## Sidebar
 - [ ] `node_selector` renders with `local` as the first option


### PR DESCRIPTION
## Summary
- README: add a "Bind to loopback (no built-in auth)" blockquote next to the existing `### Streamlit UI` launch section. Recommends `--server.address 127.0.0.1`, calls out the absence of built-in auth, and lists the three operator-supplied gateways (Tailscale / SSH tunnel / reverse proxy with auth) per plan section 2.8.
- `scripts/run.sh` + `scripts/run.bat`: pass `--server.address 127.0.0.1` explicitly to `streamlit run`, with a `LAUNCHER_UI_HOST` override for operators deliberately fronting the dashboard with a gateway. Adds inline comments cross-referencing the README + plan section 2.8.
- `tests/manual/m4-smoke.md`: update the manual smoke checklist so the documented invocation matches.
- Closes #85; addresses control C12 from `docs/plans/security-hardening-plan.md`.

Documentation-only - no Python or test source touched. Style precedent: PR #98 (#80 / C5).

## Test plan
- [x] `python -m pytest -q` - 976 pass / 10 skip; one pre-existing failure in `tests/unit/test_phase_d_coverage.py::TestStartServerValidationEarlyReturn::test_start_server_validation_error_recorded` is the known issue #107 port 8081 OS-bind flake, unrelated to this change.
- [ ] Eyeball-render the README blockquote on GitHub.
- [ ] Manual: run `./run.sh ui` and confirm it binds on `127.0.0.1:8501` (and that `LAUNCHER_UI_HOST=0.0.0.0 ./run.sh ui` still works for the gateway-fronted case).
