### PR TITLE
chore(security): XS follow-up batch — #107 #111 #112 #113 #114 #115

### DIFF
--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -208,17 +208,21 @@ def create_app(auth_token: str) -> FastAPI:
 
     Args:
         auth_token: Non-empty token to enforce on incoming requests via
-            the ``X-Api-Key`` header. Passing ``None`` or an empty
-            string raises ``ValueError`` — callers that genuinely want
-            an unauthenticated app must use
+            the ``X-Api-Key`` header. Passing ``None``, an empty string,
+            or a whitespace-only string raises ``ValueError`` — callers
+            that genuinely want an unauthenticated app must use
             :func:`create_app_unauthenticated`.
 
     Raises:
-        ValueError: If ``auth_token`` is ``None`` or an empty string.
+        ValueError: If ``auth_token`` is ``None``, empty, or whitespace
+            only. A whitespace-only value indicates a malformed env-var
+            assignment (e.g., ``LAUNCHER_AGENT_TOKEN=" "``) that would
+            otherwise construct an app whose auth middleware compared
+            ``X-Api-Key`` against a whitespace string — see issue #111.
     """
-    if not auth_token:
+    if not auth_token or not auth_token.strip():
         raise ValueError(
-            "create_app requires a non-empty auth_token. "
+            "create_app requires a non-empty, non-whitespace auth_token. "
             "Use create_app_unauthenticated() for test-only no-auth construction."
         )
     return _build_app(auth_token=auth_token)
@@ -233,19 +237,24 @@ def create_app_unauthenticated() -> FastAPI:
     enforced at the ``run_agent`` callsite, not here, so this helper
     must never be reached from a production entry point.
 
-    The ``__debug__`` tripwire below makes it observable when this
-    helper is invoked in an optimized build (``python -O``): production
-    deployments running with ``-O`` will trip the assertion and refuse
-    to construct, while normal pytest runs (``__debug__`` is True) keep
-    working unchanged.
+    The ``__debug__`` guard below refuses to construct when the
+    interpreter is running in optimized mode (``python -O``), which is
+    the conventional posture for production deployment. In dev/test
+    (``__debug__`` is ``True``) the guard is a no-op. This is a real
+    runtime check — not an ``assert`` — because ``python -O`` strips
+    ``assert`` statements at compile time, so an ``assert __debug__``
+    would become a no-op under exactly the configuration it was meant
+    to guard against (see issue #112).
     """
-    # Tripwire: ``python -O`` strips asserts, so this fails fast in any
-    # build flagged as a release/production interpreter. In dev/test
-    # (``__debug__`` is True) the assertion is a no-op.
-    assert __debug__, (
-        "create_app_unauthenticated() must not be reached in optimized "
-        "(production) builds — use create_app(auth_token=...) instead."
-    )
+    # Runtime tripwire: __debug__ is False under `python -O`. We do not
+    # use `assert __debug__` because -O would strip the assert itself.
+    if not __debug__:
+        raise RuntimeError(
+            "create_app_unauthenticated() must not be reached in "
+            "optimized (production) builds — use create_app(auth_token=...) "
+            "instead. The C1 invariant forbids no-auth construction in any "
+            "code path that could be reached from a production entry point."
+        )
     return _build_app(auth_token=None)
 
 

--- a/tests/integration/test_agent_cors.py
+++ b/tests/integration/test_agent_cors.py
@@ -45,6 +45,30 @@ def _cors_headers(headers) -> dict[str, str]:
     }
 
 
+def _assert_no_cors_signal(resp, label: str) -> None:
+    """Assert no ``Access-Control-*`` headers AND no ``Vary: Origin`` echo.
+
+    The ``Vary: Origin`` check (issue #115) catches a CORS middleware
+    that is mounted but happens to decline echoing on a given request
+    — Starlette's ``CORSMiddleware`` sets ``Vary: Origin`` defensively
+    whenever it is in the stack, even when the request shape causes it
+    to suppress the ``Access-Control-Allow-Origin`` header. Asserting
+    only the ``Access-Control-*`` absence would miss that "middleware
+    is mounted, just declining today" regression shape.
+    """
+    leaked = _cors_headers(resp.headers)
+    assert leaked == {}, (
+        f"{label} leaked Access-Control-* headers: {leaked}. "
+        "Plan §3 C4 forbids any Access-Control-* response headers."
+    )
+    vary = resp.headers.get("vary", "").lower()
+    assert "origin" not in vary, (
+        f"{label} emitted Vary: {vary!r} — 'origin' in Vary is the "
+        "smoking-gun signal that CORSMiddleware is mounted in the "
+        "stack even when it declines to echo. Plan §3 C4 / issue #115."
+    )
+
+
 # ─────── C4-a: OPTIONS /status emits no Access-Control-* headers ───────────
 
 
@@ -57,11 +81,7 @@ def test_options_status_no_cors_headers(agent_client):
     only that no CORS posture is signalled.
     """
     resp = agent_client.options("/status")
-    leaked = _cors_headers(resp.headers)
-    assert leaked == {}, (
-        f"OPTIONS /status leaked CORS headers: {leaked}. "
-        "Plan §3 C4 / §4 C4-a requires no Access-Control-* headers."
-    )
+    _assert_no_cors_signal(resp, "OPTIONS /status (no Origin)")
     # Belt-and-suspenders: the specific header named in the plan.
     assert "access-control-allow-origin" not in {
         k.lower() for k in resp.headers
@@ -69,48 +89,47 @@ def test_options_status_no_cors_headers(agent_client):
 
 
 def test_options_status_no_cors_headers_with_origin_request(agent_client):
-    """Same as above, but with an ``Origin:`` header on the request.
+    """Same as above, but with an ``Origin:`` header and a state-changing preflight.
 
     A misconfigured CORS middleware would typically only echo
     ``Access-Control-Allow-Origin`` when the client supplied an
-    ``Origin``. This test makes sure the absence is real, not just
-    a side effect of the request shape.
+    ``Origin``. CORS-bypass concerns center on state-changing
+    requests (POST/PUT/DELETE), so the preflight names ``POST`` for
+    its ``Access-Control-Request-Method`` (issue #114) — the threat
+    shape a real attacker page would emit before issuing a credentialed
+    state-changing call. This pins absence under the realistic
+    preflight, not just the trivial GET preflight.
     """
     resp = agent_client.options(
         "/status",
         headers={
             "Origin": "https://evil.example",
-            "Access-Control-Request-Method": "GET",
-            "Access-Control-Request-Headers": "X-Api-Key",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Api-Key, Content-Type",
         },
     )
-    leaked = _cors_headers(resp.headers)
-    assert leaked == {}, (
-        "OPTIONS /status with Origin: still leaked CORS headers: "
-        f"{leaked}. Plan §3 C4 forbids any Access-Control-* response "
-        "headers."
-    )
+    _assert_no_cors_signal(resp, "OPTIONS /status (POST preflight)")
 
 
 # ─────── GET flavor: /health emits no Access-Control-* headers ─────────────
 
 
 def test_get_health_no_cors_headers_with_origin(agent_client):
-    """Representative GET endpoint check.
+    """Representative GET endpoint check (real 2xx success path).
 
     ``/health`` is exempt from auth and so reachable in every config
     flavor — it's the most leak-prone endpoint if a CORS middleware
-    were silently added in front of the auth layer.
+    were silently added in front of the auth layer. This is also a
+    deterministic 2xx response, so the absence assertion exercises the
+    success-path code in every middleware (a future CORS middleware
+    that only attaches headers on 2xx would be caught here).
     """
     resp = agent_client.get(
         "/health",
         headers={"Origin": "https://evil.example"},
     )
     assert resp.status_code == 200
-    leaked = _cors_headers(resp.headers)
-    assert leaked == {}, (
-        f"GET /health leaked CORS headers: {leaked}"
-    )
+    _assert_no_cors_signal(resp, "GET /health (2xx with Origin)")
 
 
 # ─────── POST flavor: a POST with Origin: emits no Access-Control-* ────────
@@ -134,36 +153,30 @@ def test_post_with_origin_header_no_cors_headers(agent_client_with_token):
     # We expect the auth middleware to reject this — body shape is not
     # under test, only the response headers.
     assert resp.status_code in (401, 403)
-    leaked = _cors_headers(resp.headers)
-    assert leaked == {}, (
-        f"POST /start/{{port}} leaked CORS headers: {leaked}"
-    )
+    _assert_no_cors_signal(resp, "POST /start/9999 (auth-rejected)")
 
 
-def test_post_with_origin_header_no_cors_headers_authed(agent_client_with_token):
-    """Same POST flavor, but with a valid token so the route actually runs.
+def test_post_with_origin_header_no_cors_headers_authed_2xx(agent_client_with_token):
+    """Authed POST that reaches a real 2xx handler response (issue #113).
 
-    Covers the success / handler-emitted-response path: even when a
-    route handler is the one writing the response, no CORS headers
-    should be attached by any middleware on the way out.
+    ``/stop/{port}`` is idempotent and returns ``200 action=already_empty``
+    when nothing is running on the port (ADR-010). We use it as the
+    cheapest authed POST that exercises a true success-path handler
+    response — no spawn, no port binding, no side effects — so the
+    absence assertion covers the case where a hypothetical future
+    ``CORSMiddleware(add_only_on_2xx=...)`` would attach headers only
+    on successful state-changing requests.
     """
     client, token = agent_client_with_token
-    # The model does not need to exist — any non-401/403 response is
-    # fine; we only inspect headers, not the body. Use an obviously-
-    # missing model so we hit a fast 4xx/5xx path with no side effects.
     resp = client.post(
-        "/start/9999",
-        json={"model": "definitely-not-a-real-model"},
+        "/stop/9999",
         headers={
             "X-Api-Key": token,
             "Origin": "https://evil.example",
         },
     )
-    # Sanity: auth passed (we did not get a 401/403 from the middleware).
-    assert resp.status_code not in (401, 403), (
-        f"Unexpected auth failure with valid token: {resp.status_code}"
+    assert resp.status_code == 200, (
+        f"Expected 200 from idempotent /stop on idle port, got "
+        f"{resp.status_code}: {resp.text!r}"
     )
-    leaked = _cors_headers(resp.headers)
-    assert leaked == {}, (
-        f"Authed POST /start/{{port}} leaked CORS headers: {leaked}"
-    )
+    _assert_no_cors_signal(resp, "POST /stop/9999 (authed 2xx)")

--- a/tests/unit/test_agent_create_app_auth_required.py
+++ b/tests/unit/test_agent_create_app_auth_required.py
@@ -26,7 +26,7 @@ def test_create_app_rejects_explicit_none() -> None:
     """C1 (#87): create_app(auth_token=None) raises ValueError, not silent no-auth."""
     from llauncher.agent.server import create_app
 
-    with pytest.raises(ValueError, match="non-empty auth_token"):
+    with pytest.raises(ValueError, match="non-empty"):
         create_app(auth_token=None)  # type: ignore[arg-type]
 
 
@@ -39,8 +39,25 @@ def test_create_app_rejects_empty_string() -> None:
     """
     from llauncher.agent.server import create_app
 
-    with pytest.raises(ValueError, match="non-empty auth_token"):
+    with pytest.raises(ValueError, match="non-empty"):
         create_app(auth_token="")
+
+
+@pytest.mark.parametrize("ws_token", [" ", "  ", "\t", "\n", " \t \n "])
+def test_create_app_rejects_whitespace_only_token(ws_token: str) -> None:
+    """C1 (#111): whitespace-only tokens must be rejected.
+
+    A typo like ``LAUNCHER_AGENT_TOKEN=" "`` (or a trailing newline from
+    a misread token file) is non-falsy but semantically empty. Without
+    a ``strip()`` check, ``create_app`` would build an app whose auth
+    middleware compares incoming ``X-Api-Key`` against the whitespace
+    string — effectively no protection. The whitespace cases here pin
+    that the check is content-based, not just truthiness-based.
+    """
+    from llauncher.agent.server import create_app
+
+    with pytest.raises(ValueError, match="non-whitespace"):
+        create_app(auth_token=ws_token)
 
 
 def test_create_app_with_token_wires_auth_middleware() -> None:
@@ -74,3 +91,64 @@ def test_create_app_unauthenticated_tripwire_documented() -> None:
     doc = create_app_unauthenticated.__doc__ or ""
     assert "SECURITY" in doc
     assert "test-only" in doc.lower()
+
+
+def test_create_app_unauthenticated_uses_runtime_guard_not_assert() -> None:
+    """C1 (#112): the production-mode guard must survive ``python -O``.
+
+    ``assert __debug__`` would be stripped by the optimizer at the
+    exact configuration it is meant to defend against, leaving the
+    no-auth builder silently reachable in optimized production
+    builds. The guard must be a real runtime check
+    (``if not __debug__: raise RuntimeError(...)``) — pin that shape
+    in source via ``ast`` so a future refactor cannot quietly regress
+    to an ``assert`` form. We parse the function rather than substring-
+    match because the docstring legitimately mentions ``assert __debug__``
+    when explaining why we don't use it.
+    """
+    import ast
+    import inspect
+
+    from llauncher.agent.server import create_app_unauthenticated
+
+    src = inspect.getsource(create_app_unauthenticated)
+    tree = ast.parse(src)
+    # The function is the sole top-level node of the parsed source.
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
+
+    # No `assert __debug__` statement may appear in the function body.
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assert) and isinstance(node.test, ast.Name):
+            assert node.test.id != "__debug__", (
+                "create_app_unauthenticated has `assert __debug__` in its "
+                "body — python -O strips asserts, so this becomes a no-op "
+                "in optimized production builds (issue #112). Use "
+                "`if not __debug__: raise RuntimeError(...)` instead."
+            )
+
+    # And the runtime-guard shape must be present.
+    found_runtime_guard = False
+    for node in ast.walk(func):
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.UnaryOp)
+            and isinstance(node.test.op, ast.Not)
+            and isinstance(node.test.operand, ast.Name)
+            and node.test.operand.id == "__debug__"
+        ):
+            # Body must include a `raise RuntimeError(...)`.
+            for child in ast.walk(node):
+                if isinstance(child, ast.Raise) and isinstance(child.exc, ast.Call):
+                    exc_name = (
+                        child.exc.func.id
+                        if isinstance(child.exc.func, ast.Name)
+                        else ""
+                    )
+                    if exc_name == "RuntimeError":
+                        found_runtime_guard = True
+                        break
+    assert found_runtime_guard, (
+        "create_app_unauthenticated must contain "
+        "`if not __debug__: raise RuntimeError(...)` (issue #112)."
+    )

--- a/tests/unit/test_phase_d_coverage.py
+++ b/tests/unit/test_phase_d_coverage.py
@@ -308,10 +308,23 @@ class TestStrictRollbackValidationBranches:
 class TestStartServerValidationEarlyReturn:
     """start_server validation-error path (285-286)."""
 
-    def test_start_server_validation_error_recorded(self, state_with_running):
+    def test_start_server_validation_error_recorded(self, state_with_running, monkeypatch):
+        """Issue #107: this test must not depend on OS-level port state.
+
+        ``LauncherState.validate_start`` does an OS-level
+        ``is_port_in_use`` check *before* delegating to
+        ``rules.validate_start``. If port 8081 is bound on the host
+        running the suite (e.g. a developer running llama-server), the
+        OS check fires first and the test never reaches the rules
+        path it is trying to exercise. Mock the OS check so the test
+        deterministically reaches the validation-error branch.
+        """
         # rules say no.
         state_with_running.rules.validate_start.return_value = (False, "blacklisted caller")
-        state_with_running.running = {}  # avoid port-in-use detection earlier
+        state_with_running.running = {}  # avoid internal port-in-use detection
+        # Mock the OS-level port check (issue #107) so the test does not
+        # leak host port state.
+        monkeypatch.setattr("llauncher.state.is_port_in_use", lambda port: False)
         ok, msg, proc = state_with_running.start_server(
             "new-model", port=8081, caller="t",
         )


### PR DESCRIPTION
## Summary

Closes the post-Wave-2 follow-up shelf with six small fixes landed together — the security cohort exits with a fully green suite and no carried review-pass debt.

| Issue | Shape | Change |
|---|---|---|
| #107 | test isolation | Mock `is_port_in_use` in `test_start_server_validation_error_recorded` — host port-8081 state no longer leaks into the test. |
| #111 | security/agent | `create_app` rejects whitespace-only `auth_token` (`if not auth_token or not auth_token.strip()`). Parametrized regression test pins 5 whitespace shapes. |
| #112 | security/agent | Replace `assert __debug__` with `if not __debug__: raise RuntimeError(...)` — `python -O` strips asserts, so the old guard was a no-op under exactly the build it defended against. Docstring corrected. AST-based test pins the runtime-guard shape. |
| #113 | test/cors | New authed POST 2xx test against `/stop/{port}` (idempotent, no spawn) — covers a future `CORSMiddleware-on-2xx` regression. |
| #114 | test/cors | Preflight `Access-Control-Request-Method` switched from `GET` to `POST` — matches the real CORS-bypass threat shape. |
| #115 | test/cors | All CORS tests assert absence of `Vary: Origin` via shared `_assert_no_cors_signal` helper — catches a `CORSMiddleware` that is mounted but declines to echo. |

## Test plan

- [x] `python -m pytest tests/unit/test_agent_create_app_auth_required.py tests/unit/test_phase_d_coverage.py::TestStartServerValidationEarlyReturn tests/integration/test_agent_cors.py` — 18 pass
- [x] `python -m pytest -q` — **994 pass / 10 skip / 0 fail** (was 982/10/1 — #107 flake gone)
- [x] Non-UI coverage **94.96%** (was 94.90%, floor 93%)
- [x] No runtime behavior change beyond the two `create_app`/`create_app_unauthenticated` invariant tightenings — both raise earlier on shapes that were already considered invalid.

## Provenance

Wave 2 review pass (PRs #108, #110) surfaced 5 findings (#111–#115); Wave 1 post-merge verification surfaced #107. Tracked in `docs/handoffs/2026-05-23-wave2-merge-and-followup-shelf.md`.
