### PR TITLE
fix(ui+installer): repair UI auth after security cohort (#131, #132)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,37 @@
 # llauncher Environment Configuration
+#
+# ── What lives here ───────────────────────────────────────────────────
+# This file is loaded by `llauncher/__init__.py` via python-dotenv's
+# `load_dotenv()` at package import. It applies to ANY process that
+# imports `llauncher` — the UI, the CLI, the MCP server, and (when
+# running unmanaged from a clone) the agent.
+#
+# ── What does NOT live here ───────────────────────────────────────────
+# Service-facing agent variables (`LAUNCHER_AGENT_TOKEN`,
+# `LAUNCHER_AGENT_HOST`, `LAUNCHER_AGENT_PORT`, `LAUNCHER_AGENT_NODE_NAME`)
+# live in a separate per-host file managed by the platform installer:
+#
+#   • Windows / NSSM:  %USERPROFILE%\.llauncher\agent.env
+#                      (template: scripts/windows/llauncher-agent.env.example)
+#   • Linux / systemd: ~/.config/llauncher/agent.env
+#                      (template: scripts/systemd/llauncher-agent.env.example)
+#
+# The platform installer injects that file as the service's process
+# environment. Putting agent vars HERE works for development invocations
+# (e.g. `python -m llauncher.agent` from a clone) but is shadowed by the
+# service-injected values when the agent runs under NSSM/systemd —
+# `load_dotenv()` defaults to `override=False`, so vars already set in
+# the process environment win.
+#
+# ── What CANNOT live here ─────────────────────────────────────────────
+# Interpreter-level variables that CPython reads at startup —
+# `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, etc. —
+# MUST be set in the actual process environment before `python` is
+# invoked. By the time `load_dotenv()` runs from inside Python, the
+# interpreter has already finalized its startup-time decisions and
+# writing these to `os.environ` is too late. Put them in the
+# service-facing `agent.env` (NSSM/systemd inject before invoking
+# Python) or your shell, not here. See #129 for the design discussion.
 
 # Path to llama-server binary (default: ~/.local/bin/llama-server)
 # LLAMA_SERVER_PATH=/path/to/llama-server

--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -66,9 +66,21 @@ def _read_stdin_token() -> str:
 
 
 def _read_token_file(path: Path) -> str | None:
-    """Return the stripped token from ``path``, or None if missing/empty."""
+    """Return the stripped token from ``path``, or None if missing/empty.
+
+    Decoded as ``utf-8-sig`` so that a leading byte-order mark — which
+    Windows PowerShell 5.1 prepends when writing with ``-Encoding utf8``
+    — is consumed at decode time rather than leaking into the token as
+    a ``\\ufeff`` character. ``str.strip()`` does NOT remove ``\\ufeff``
+    (it's classified as zero-width non-breaking space, not whitespace),
+    so a BOM left in the token used to surface downstream as an
+    ``ascii``-codec ``UnicodeEncodeError`` when httpx serialized the
+    token into the ``X-Api-Key`` request header. ``utf-8-sig`` is a
+    strict superset of ``utf-8`` for BOM-less input, so this is a
+    defensive widening with no behavior change for the BOM-free case.
+    """
     try:
-        data = path.read_text(encoding="utf-8").strip()
+        data = path.read_text(encoding="utf-8-sig").strip()
     except FileNotFoundError:
         return None
     return data or None

--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -9,6 +9,14 @@ from typing import Iterator
 from llauncher.remote.node import RemoteNode, NodeStatus
 
 NODES_FILE = Path.home() / ".llauncher" / "nodes.json"
+# Sibling secrets file for remote-node API tokens (issue #132). Kept
+# separate from ``nodes.json`` so the C10 invariant — "credentials never
+# live in the registry file" — stays crisp. Different secret classes
+# (per-node tokens, future TLS keys per #86) intentionally live in their
+# own files: blast-radius per-concern, corruption degrades gracefully,
+# and the filename itself telegraphs "this is the credential, treat
+# accordingly". Do NOT ratchet tokens back into nodes.json.
+NODE_TOKENS_FILE = Path.home() / ".llauncher" / "node_tokens.json"
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +61,7 @@ class NodeRegistry:
             self._nodes.clear()
 
         self._populate_local_token()
+        self._populate_remote_tokens()
 
     def _resolve_local_token(self) -> str | None:
         """Resolve the local agent's auth token, or return ``None``.
@@ -81,6 +90,103 @@ class NodeRegistry:
             # cycle in a constrained test env, etc.), fall through to
             # the unauthenticated case rather than propagating.
             return None
+
+    def _load_node_tokens(self) -> dict[str, str]:
+        """Read ``~/.llauncher/node_tokens.json`` into a ``{name: token}`` dict.
+
+        Returns ``{}`` on missing-or-corrupt; never raises. Token
+        resolution must not break registry load (the registry is on the
+        critical path for UI startup).
+        """
+        if not NODE_TOKENS_FILE.exists():
+            return {}
+        try:
+            data = json.loads(NODE_TOKENS_FILE.read_text())
+            if isinstance(data, dict):
+                # Defensive: filter out non-string values; an attacker
+                # who can write the file shouldn't be able to inject a
+                # non-string into an api_key slot, but cheap to guard.
+                return {k: v for k, v in data.items() if isinstance(v, str)}
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Could not read {NODE_TOKENS_FILE}: {e}")
+        return {}
+
+    def _populate_remote_tokens(self) -> None:
+        """Stamp resolved remote-node tokens onto loaded ``RemoteNode`` instances.
+
+        The persisted ``nodes.json`` deliberately does NOT carry api_key
+        (security control C10 / #83). The sibling ``node_tokens.json``
+        carries the operator-supplied tokens. On load, walk it and stamp
+        each match onto the corresponding ``RemoteNode.api_key``.
+
+        Missing entries leave ``api_key=None`` — we do NOT synthesize
+        from ``agent.token`` (which is the local agent's token);
+        cross-pollinating a local token onto a remote node would be a
+        credential-confusion bug, symmetric to
+        :meth:`_populate_local_token`'s "only touches ``local``" guard.
+
+        The ``local`` entry is also skipped here even if it happens to
+        appear in ``node_tokens.json``: its canonical source is
+        ``agent.token`` via ``_populate_local_token``, and trusting
+        ``node_tokens.json`` for ``local`` would create a drift
+        opportunity.
+        """
+        tokens = self._load_node_tokens()
+        for name, token in tokens.items():
+            if name == "local":
+                continue
+            node = self._nodes.get(name)
+            if node is not None and not node.api_key:
+                node.api_key = token
+
+    def _save_node_tokens(self) -> None:
+        """Write the remote-node tokens sidecar file.
+
+        Full rewrite each call: any node that was removed from
+        ``self._nodes`` or whose ``api_key`` was cleared automatically
+        falls out of the file. The ``local`` entry is excluded
+        unconditionally — its token lives in ``agent.token``;
+        duplicating it here would create drift.
+
+        Mode 0600 on the file, 0700 on the parent dir — matching the
+        ``nodes.json`` and ``agent.token`` conventions.
+        """
+        data = {
+            name: node.api_key
+            for name, node in self._nodes.items()
+            if name != "local" and node.api_key
+        }
+
+        NODE_TOKENS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            NODE_TOKENS_FILE.parent.chmod(0o700)
+        except OSError:
+            # Best-effort; chmod is a no-op on some filesystems (e.g.
+            # WSL-on-NTFS). The 0600 on the file itself is the
+            # load-bearing protection.
+            pass
+
+        if not data:
+            # No remote tokens to persist. If a file exists from a
+            # previous save, rewrite it to an empty object so removed
+            # tokens don't linger on disk.
+            if NODE_TOKENS_FILE.exists():
+                NODE_TOKENS_FILE.write_text("{}")
+                try:
+                    os.chmod(NODE_TOKENS_FILE, 0o600)
+                except OSError as e:
+                    logger.warning(
+                        f"Could not set restrictive permissions on {NODE_TOKENS_FILE}: {e}"
+                    )
+            return
+
+        NODE_TOKENS_FILE.write_text(json.dumps(data, indent=2))
+        try:
+            os.chmod(NODE_TOKENS_FILE, 0o600)
+        except OSError as e:
+            logger.warning(
+                f"Could not set restrictive permissions on {NODE_TOKENS_FILE}: {e}"
+            )
 
     def _populate_local_token(self) -> None:
         """Self-heal: stamp the resolved token onto the ``local`` node.
@@ -140,6 +246,14 @@ class NodeRegistry:
             os.chmod(NODES_FILE, 0o600)
         except OSError as e:
             logger.warning(f"Could not set restrictive permissions on {NODES_FILE}: {e}")
+
+        # Sidecar tokens file (issue #132). Wrapped so a token-write
+        # failure does not corrupt the nodes.json write that just
+        # succeeded — the two files are independent on purpose.
+        try:
+            self._save_node_tokens()
+        except Exception as e:  # noqa: BLE001 — defensive isolation
+            logger.warning(f"Could not write {NODE_TOKENS_FILE}: {e}")
 
     def add_node(
         self,

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -103,6 +103,44 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
 
             st.divider()
 
+            # Rotate API key (remote nodes only — the ``local`` entry
+            # sources its token from ``~/.llauncher/agent.token`` via
+            # NodeRegistry._populate_local_token; manually setting one
+            # here would only create drift).
+            if node.name != "local":
+                with st.expander("🔑 Edit API key", expanded=False):
+                    new_key = st.text_input(
+                        "New API Key",
+                        type="password",
+                        key=f"edit_key_{node.name}",
+                        help=(
+                            "Replace this node's stored token. Persisted to "
+                            "~/.llauncher/node_tokens.json (mode 0600). "
+                            "Leave blank and save to clear."
+                        ),
+                    )
+                    if st.button(
+                        "💾 Save token",
+                        use_container_width=True,
+                        key=f"save_key_{node.name}",
+                    ):
+                        # overwrite=True with all existing fields preserved.
+                        ok, msg = registry.add_node(
+                            name=node.name,
+                            host=node.host,
+                            port=node.port,
+                            timeout=node.timeout,
+                            api_key=new_key or None,
+                            overwrite=True,
+                        )
+                        if ok:
+                            st.success(
+                                "Token cleared" if not new_key else "Token updated"
+                            )
+                        else:
+                            st.error(msg)
+                        st.rerun()
+
             # Actions
             action_col1, action_col2 = st.columns(2)
 
@@ -176,6 +214,16 @@ def render_add_node_form(registry: NodeRegistry) -> None:
                 help="Connection timeout in seconds",
             )
 
+        api_key = st.text_input(
+            "API Key",
+            type="password",
+            help=(
+                "Token from the remote agent's LAUNCHER_AGENT_TOKEN / "
+                "agent.token. Required for non-loopback agents (per ADR-003). "
+                "Leave blank for unauthenticated loopback agents."
+            ),
+        )
+
         # Test connection button
         test_col, submit_col = st.columns(2)
         with test_col:
@@ -197,7 +245,13 @@ def render_add_node_form(registry: NodeRegistry) -> None:
             else:
                 from llauncher.remote.node import RemoteNode
 
-                test_node = RemoteNode(node_name, node_host, node_port, timeout)
+                test_node = RemoteNode(
+                    node_name,
+                    node_host,
+                    node_port,
+                    timeout,
+                    api_key=api_key or None,
+                )
                 result = test_node.ping()
                 if result:
                     st.success(
@@ -225,6 +279,7 @@ def render_add_node_form(registry: NodeRegistry) -> None:
                 host=node_host,
                 port=node_port,
                 timeout=timeout,
+                api_key=api_key or None,
                 overwrite=True,
             )
 

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -23,6 +23,14 @@ UNIT_PATH="$UNIT_DIR/$UNIT_NAME"
 ENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/llauncher"
 ENV_FILE="$ENV_DIR/agent.env"
 
+# The UI process (Streamlit) is separate from the systemd service and
+# does NOT inherit LAUNCHER_AGENT_TOKEN from the unit's environment, so
+# it can only authenticate against the local agent by reading the token
+# from this file. See issue #131 + the Windows counterpart in
+# scripts/windows/install.ps1.
+LLAUNCHER_DIR="$HOME/.llauncher"
+TOKEN_FILE="$LLAUNCHER_DIR/agent.token"
+
 TEMPLATE="$SCRIPT_DIR/llauncher-agent.service.in"
 ENV_EXAMPLE="$SCRIPT_DIR/llauncher-agent.env.example"
 
@@ -41,6 +49,7 @@ uninstall() {
     fi
     systemctl --user daemon-reload
     info "Env file left in place at $ENV_FILE (delete manually if desired)."
+    info "Token file left in place at $TOKEN_FILE (delete manually if desired)."
     say "Uninstalled."
     exit 0
 }
@@ -79,6 +88,30 @@ if [ ! -f "$ENV_FILE" ]; then
 else
     chmod 600 "$ENV_FILE"  # repair perms if they drifted
     say "Env file already exists at $ENV_FILE — leaving it untouched."
+fi
+
+# --- Token mirror (issue #131) -----------------------------------------
+# Mirror LAUNCHER_AGENT_TOKEN from the env file into ~/.llauncher/agent.token
+# so the UI process — which does NOT share the systemd service env — can
+# authenticate against the local agent. Symmetric with the Windows
+# install.ps1 mirror block.
+#
+# `tail -n1` (not `head -n1`) matches systemd's EnvironmentFile parser
+# semantics ("last wins"); the value the agent actually runs with is the
+# last LAUNCHER_AGENT_TOKEN= line, so the mirror must reflect that.
+# `tr -d '[:space:]'` defends against trailing whitespace or stray CRs
+# from hand-edited env files.
+mkdir -p "$LLAUNCHER_DIR"
+chmod 700 "$LLAUNCHER_DIR"
+TOKEN_VALUE="$(grep -E '^LAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]')"
+if [ -n "$TOKEN_VALUE" ]; then
+    # printf '%s' (no trailing newline) matches the byte-shape of
+    # llauncher/agent/auth.py:_generate_and_persist_token after strip.
+    printf '%s' "$TOKEN_VALUE" > "$TOKEN_FILE"
+    chmod 600 "$TOKEN_FILE"
+    say "Mirrored token to $TOKEN_FILE (mode 0600) so the UI can authenticate."
+else
+    info "No LAUNCHER_AGENT_TOKEN line found in $ENV_FILE; skipping token file mirror."
 fi
 
 # --- Unit file ---------------------------------------------------------

--- a/scripts/systemd/llauncher-agent.env.example
+++ b/scripts/systemd/llauncher-agent.env.example
@@ -7,7 +7,35 @@
 #
 # Format: systemd EnvironmentFile syntax (KEY=VALUE, no `export`,
 # no shell expansion, no quoting needed unless the value contains
-# whitespace).
+# whitespace). systemd injects these into the agent's process
+# environment BEFORE `python` starts.
+#
+# ── Relationship to project-root `.env` ───────────────────────────────
+# This file is service-facing. A separate project-root `.env` (template:
+# repo-root `.env.example`) carries dev-facing settings like
+# `LLAMA_SERVER_PATH`, `DEFAULT_PORT`, `BLACKLISTED_PORTS`, `LOG_LEVEL`,
+# `SCRIPTS_PATH`. Both files contribute to the running agent's
+# environment: systemd injects THIS file first, then `load_dotenv()` in
+# `llauncher/__init__.py` reads project `.env` with `override=False`,
+# so the systemd-injected values win on conflict. The two `.example`
+# templates currently have zero overlap, so in practice they compose
+# additively. See #129.
+#
+# Note: the Streamlit UI process is NOT managed by systemd and does NOT
+# see this file's vars — it only reads project `.env`. Until the
+# systemd installer grows a token-mirror analogous to install.ps1's
+# ~/.llauncher/agent.token write (covered by the Windows path in
+# 7629999, NOT yet on systemd), Linux operators wanting the UI to
+# authenticate need to either (a) launch the UI from a shell where
+# this env file is sourced, or (b) set LAUNCHER_AGENT_TOKEN in
+# project `.env` to match this file.
+#
+# ── Interpreter-level variables belong HERE, not in `.env` ────────────
+# `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, and other
+# variables CPython reads at startup must be set BEFORE the interpreter
+# launches. Project `.env` is read by `load_dotenv()` after Python is
+# already running, which is too late for these. Put them in this file
+# so systemd injects them at service-start time.
 
 # --- Required ---------------------------------------------------------
 

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -120,7 +120,18 @@ Say "Locked ACL on $EnvFile (current user only)."
 $tokenLine = (Get-Content $EnvFile) | Where-Object { $_ -match '^LAUNCHER_AGENT_TOKEN=' } | Select-Object -First 1
 if ($tokenLine) {
     $tokenValue = ($tokenLine -replace '^LAUNCHER_AGENT_TOKEN=', '').Trim()
-    Set-Content -Path $TokenFile -Value $tokenValue -NoNewline -Encoding utf8
+    # IMPORTANT: write WITHOUT a UTF-8 BOM. Windows PowerShell 5.1's
+    # `Set-Content -Encoding utf8` prepends EF BB BF, which decodes to
+    # U+FEFF and (since str.strip() doesn't strip it) leaks into the
+    # X-Api-Key header on the UI side, blowing up httpx's ascii-only
+    # header encoder. The reader in llauncher/agent/auth.py is also
+    # being widened to utf-8-sig as belt-and-braces, but the file
+    # should not contain a BOM in the first place — the token is pure
+    # ASCII (secrets.token_urlsafe), so a no-BOM UTF-8 (== ASCII)
+    # write is the right shape. Using .NET WriteAllText with an
+    # explicit UTF8Encoding($false) works across both PS 5.1 and 7+.
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($TokenFile, $tokenValue, $utf8NoBom)
     Set-OwnerOnlyAcl $TokenFile
     Say "Mirrored token to $TokenFile (ACL: current user only) so the UI can authenticate."
 } else {

--- a/scripts/windows/llauncher-agent.env.example
+++ b/scripts/windows/llauncher-agent.env.example
@@ -6,7 +6,32 @@
 # reference template tracked in git.
 #
 # Format: simple KEY=VALUE per line. install.ps1 parses this and
-# feeds it to NSSM via `nssm set <svc> AppEnvironmentExtra`.
+# feeds it to NSSM via `nssm set <svc> AppEnvironmentExtra`. NSSM
+# injects these into the agent's process environment BEFORE
+# `python.exe` starts.
+#
+# ── Relationship to project-root `.env` ───────────────────────────────
+# This file is service-facing. A separate project-root `.env` (template:
+# repo-root `.env.example`) carries dev-facing settings like
+# `LLAMA_SERVER_PATH`, `DEFAULT_PORT`, `BLACKLISTED_PORTS`, `LOG_LEVEL`,
+# `SCRIPTS_PATH`. Both files contribute to the running agent's
+# environment: NSSM injects THIS file first, then `load_dotenv()` in
+# `llauncher/__init__.py` reads project `.env` with `override=False`,
+# so the NSSM-injected values win on conflict. The two `.example`
+# templates currently have zero overlap, so in practice they compose
+# additively. See #129.
+#
+# Note: the Streamlit UI process is NOT managed by NSSM and does NOT
+# see this file's vars — it only reads project `.env`. The mirrored
+# token at ~/.llauncher/agent.token (written by install.ps1 below)
+# exists specifically to bridge that gap.
+#
+# ── Interpreter-level variables belong HERE, not in `.env` ────────────
+# `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, and other
+# variables CPython reads at startup must be set BEFORE the interpreter
+# launches. Project `.env` is read by `load_dotenv()` after Python is
+# already running, which is too late for these. Put them in this file
+# so NSSM injects them at service-start time.
 
 # --- Required ---------------------------------------------------------
 

--- a/tests/unit/test_agent_auth_token_file.py
+++ b/tests/unit/test_agent_auth_token_file.py
@@ -1,0 +1,80 @@
+"""Regression tests for ``llauncher.agent.auth._read_token_file``.
+
+Specifically guards the BOM-tolerance widening that landed after a
+Windows operator hit ``UnicodeEncodeError: 'ascii' codec can't encode
+character '\\ufeff' in position 0`` when the UI process serialized the
+token into the ``X-Api-Key`` request header.
+
+Failure chain that motivated the widening:
+
+1. Windows PowerShell 5.1's ``Set-Content -Encoding utf8`` writes
+   ``EF BB BF`` at the head of the file.
+2. ``_read_token_file`` previously decoded as plain ``utf-8`` (so the
+   BOM survived as ``U+FEFF``) and called ``.strip()`` (which does NOT
+   strip ``U+FEFF`` — it's zero-width non-breaking space, not
+   whitespace by Python's classification).
+3. The resulting token had a leading ``\\ufeff`` that httpx tried to
+   ASCII-encode when serializing the ``X-Api-Key`` header, raising.
+
+The fix is two-pronged: ``scripts/windows/install.ps1`` writes without
+a BOM, AND ``_read_token_file`` decodes as ``utf-8-sig`` so any
+upstream writer that re-introduces a BOM cannot reach the header
+encoder. These tests pin the reader half.
+"""
+
+from __future__ import annotations
+
+
+def test_read_token_file_strips_utf8_bom(tmp_path):
+    """A token file with a UTF-8 BOM yields the bare token (no ``\\ufeff``)."""
+    from llauncher.agent.auth import _read_token_file
+
+    token = "abc123-no-bom-here"
+    path = tmp_path / "agent.token"
+    # Bytes path so we have full control over the BOM placement.
+    path.write_bytes(b"\xef\xbb\xbf" + token.encode("ascii"))
+
+    result = _read_token_file(path)
+
+    assert result == token
+    assert result is not None
+    assert "﻿" not in result, "BOM leaked into the returned token"
+
+
+def test_read_token_file_strips_bom_and_trailing_newline(tmp_path):
+    """The two stripping behaviors compose — BOM at head, ``\\n`` at tail."""
+    from llauncher.agent.auth import _read_token_file
+
+    token = "trailing-newline-token"
+    path = tmp_path / "agent.token"
+    path.write_bytes(b"\xef\xbb\xbf" + token.encode("ascii") + b"\n")
+
+    assert _read_token_file(path) == token
+
+
+def test_read_token_file_no_bom_still_works(tmp_path):
+    """``utf-8-sig`` is a strict superset of ``utf-8`` for BOM-less input."""
+    from llauncher.agent.auth import _read_token_file
+
+    token = "plain-utf8-token"
+    path = tmp_path / "agent.token"
+    path.write_text(token, encoding="utf-8")  # no BOM
+
+    assert _read_token_file(path) == token
+
+
+def test_read_token_file_bom_only_returns_none(tmp_path):
+    """A file containing only a BOM is treated as empty — returns ``None``."""
+    from llauncher.agent.auth import _read_token_file
+
+    path = tmp_path / "agent.token"
+    path.write_bytes(b"\xef\xbb\xbf")  # BOM, then nothing
+
+    assert _read_token_file(path) is None
+
+
+def test_read_token_file_missing_returns_none(tmp_path):
+    """Pre-existing behavior: a missing file returns ``None`` (not raises)."""
+    from llauncher.agent.auth import _read_token_file
+
+    assert _read_token_file(tmp_path / "does-not-exist") is None

--- a/tests/unit/test_registry_extended.py
+++ b/tests/unit/test_registry_extended.py
@@ -530,3 +530,212 @@ class TestLocalNodeTokenResolution:
         registry = NodeRegistry()
         # No exception bubbles up; resolver returns None defensively.
         assert registry._resolve_local_token() is None
+
+
+class TestRemoteNodeTokenPersistence:
+    """Tests for the issue #132 fix: remote node tokens survive UI restart.
+
+    The persisted ``nodes.json`` deliberately does NOT carry api_key
+    (security control C10 / #83). The sibling ``~/.llauncher/node_tokens.json``
+    carries the operator-supplied tokens. These tests cover the
+    load/save round-trip, the C10 file-boundary invariant, and the
+    no-credential-confusion guard between local and remote token paths.
+    """
+
+    @staticmethod
+    def _patch_paths(monkeypatch, tmp_path):
+        """Common monkeypatch fixture: point both files at tmp_path."""
+        from llauncher.remote import registry as registry_mod
+
+        nodes_file = tmp_path / "nodes.json"
+        tokens_file = tmp_path / "node_tokens.json"
+        monkeypatch.setattr(registry_mod, "NODES_FILE", nodes_file)
+        monkeypatch.setattr(registry_mod, "NODE_TOKENS_FILE", tokens_file)
+        # Local-token resolver: no env, no on-disk agent.token in tmp.
+        # Prevents the resolver from picking up the real user's token.
+        agent_token_path = tmp_path / "agent.token-absent"
+        monkeypatch.setattr(
+            "llauncher.agent.auth.default_token_path", lambda: agent_token_path
+        )
+        monkeypatch.delenv("LAUNCHER_AGENT_TOKEN", raising=False)
+        return nodes_file, tokens_file
+
+    def test_round_trip_remote_token_persists_across_reload(self, tmp_path, monkeypatch):
+        """add_node(api_key=...) → new NodeRegistry → token still on the node."""
+        nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        ok, _ = reg.add_node("remote-a", "192.168.1.50", 8765, api_key="tok-A")
+        assert ok
+
+        # Fresh registry — simulates UI restart.
+        reg2 = NodeRegistry()
+        node = reg2.get_node("remote-a")
+
+        assert node is not None
+        assert node.api_key == "tok-A"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX permission semantics required"
+    )
+    def test_node_tokens_file_is_mode_0600(self, tmp_path, monkeypatch):
+        """The sidecar file is created at 0600 (C10-parity for the secret file)."""
+        _, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        reg.add_node("remote-b", "192.168.1.51", 8765, api_key="tok-B")
+
+        assert tokens_file.exists()
+        mode = os.stat(tokens_file).st_mode & 0o777
+        assert mode == 0o600, f"expected 0600, got 0o{mode:o}"
+
+    def test_node_tokens_file_contains_only_tokens(self, tmp_path, monkeypatch):
+        """The sidecar file is {name: token} only — no name/host/port leaks.
+
+        Positive assertion on the C10 file boundary: the secret file
+        carries strictly the secret, not a duplicate of the registry
+        metadata. A future reader tempted to "consolidate" must see that
+        this is by design.
+        """
+        _, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        reg.add_node("remote-c", "192.168.1.52", 8765, api_key="tok-C")
+
+        payload = json.loads(tokens_file.read_text())
+        assert payload == {"remote-c": "tok-C"}
+
+    def test_nodes_json_never_contains_api_key(self, tmp_path, monkeypatch):
+        """Regression guard: even with api_key supplied, nodes.json
+        retains the post-#83 ``has_api_key`` discipline and never
+        materializes the literal token.
+        """
+        nodes_file, _ = self._patch_paths(monkeypatch, tmp_path)
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        reg.add_node("remote-d", "192.168.1.53", 8765, api_key="tok-D")
+
+        on_disk = json.loads(nodes_file.read_text())
+        assert "remote-d" in on_disk
+        assert on_disk["remote-d"].get("has_api_key") is True
+        assert "api_key" not in on_disk["remote-d"]
+
+    def test_local_node_excluded_from_tokens_file(self, tmp_path, monkeypatch):
+        """The ``local`` entry's token belongs in ``agent.token``, NOT
+        the sidecar — duplicating it here would create drift.
+        """
+        nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+        # Pre-seed an agent.token so _populate_local_token has a value.
+        agent_token = tmp_path / "agent.token"
+        agent_token.write_text("local-secret")
+        monkeypatch.setattr(
+            "llauncher.agent.auth.default_token_path", lambda: agent_token
+        )
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        reg.add_node("local", "localhost", 8765)
+        # Self-heal will stamp local-secret onto the local node.
+        # When we add a remote, the save must EXCLUDE local from the
+        # sidecar even though local.api_key is now non-None.
+        reg.add_node("remote-e", "192.168.1.54", 8765, api_key="tok-E")
+
+        payload = json.loads(tokens_file.read_text())
+        assert "local" not in payload
+        assert payload == {"remote-e": "tok-E"}
+
+    def test_remove_node_drops_token_entry(self, tmp_path, monkeypatch):
+        """``remove_node`` triggers _save → _save_node_tokens full-
+        rewrite → removed node's token entry falls out automatically.
+        """
+        _, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+
+        reg = NodeRegistry()
+        reg._nodes.clear()
+        reg.add_node("remote-f", "192.168.1.55", 8765, api_key="tok-F")
+        reg.add_node("remote-g", "192.168.1.56", 8765, api_key="tok-G")
+
+        ok, _ = reg.remove_node("remote-f")
+        assert ok
+
+        payload = json.loads(tokens_file.read_text())
+        assert "remote-f" not in payload
+        assert payload.get("remote-g") == "tok-G"
+
+    def test_missing_tokens_file_leaves_api_keys_none(self, tmp_path, monkeypatch):
+        """nodes.json says has_api_key=True but the sidecar is missing
+        → load succeeds, that remote's api_key is None. No synthesis
+        from the local agent.token (credential-confusion guard).
+        """
+        nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+        # nodes.json claims a token for remote-h.
+        nodes_file.write_text(json.dumps({
+            "remote-h": {
+                "name": "remote-h", "host": "192.168.1.57",
+                "port": 8765, "timeout": 5.0, "has_api_key": True,
+            }
+        }))
+        # And a local agent.token exists — but it must NOT bleed through.
+        agent_token = tmp_path / "agent.token"
+        agent_token.write_text("would-be-credential-confusion")
+        monkeypatch.setattr(
+            "llauncher.agent.auth.default_token_path", lambda: agent_token
+        )
+        assert not tokens_file.exists()
+
+        reg = NodeRegistry()
+        node = reg.get_node("remote-h")
+
+        assert node is not None
+        assert node.api_key is None, (
+            "remote node must not be auto-stamped with the local agent's "
+            "token — credential-confusion guard"
+        )
+
+    def test_corrupt_tokens_file_does_not_break_load(self, tmp_path, monkeypatch):
+        """Malformed JSON in node_tokens.json must degrade gracefully:
+        registry loads, remote api_keys are None, no exception.
+        """
+        nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
+        nodes_file.write_text(json.dumps({
+            "remote-i": {
+                "name": "remote-i", "host": "192.168.1.58",
+                "port": 8765, "timeout": 5.0, "has_api_key": True,
+            }
+        }))
+        tokens_file.write_text("{not valid json")
+
+        # No exception:
+        reg = NodeRegistry()
+        node = reg.get_node("remote-i")
+        assert node is not None
+        assert node.api_key is None
+
+    def test_save_tokens_chmod_failure_logs_but_does_not_raise(self, tmp_path, monkeypatch):
+        """OSError from os.chmod on the sidecar is logged-and-swallowed,
+        matching the existing nodes.json chmod failure posture.
+        """
+        from llauncher.remote import registry as registry_mod
+
+        self._patch_paths(monkeypatch, tmp_path)
+        real_chmod = os.chmod
+
+        def failing_chmod(path, mode, **kwargs):
+            # Only fail for the sidecar file write; let dir chmod pass.
+            # **kwargs absorbs follow_symlinks=True from Path.chmod →
+            # os.chmod (Python 3.12+).
+            if str(path).endswith("node_tokens.json"):
+                raise OSError("simulated permission denied")
+            real_chmod(path, mode, **kwargs)
+
+        monkeypatch.setattr("os.chmod", failing_chmod)
+
+        reg = registry_mod.NodeRegistry()
+        reg._nodes.clear()
+        # Should not raise:
+        ok, _ = reg.add_node("remote-j", "192.168.1.59", 8765, api_key="tok-J")
+        assert ok


### PR DESCRIPTION
## Summary

Two coupled fixes for the UI auth regression a Windows-agent + Linux-UI operator hit after the security-hardening cohort landed.

- **#131** — `localhost:8765 → 403`. Linux systemd unit injects `LAUNCHER_AGENT_TOKEN` via `EnvironmentFile`, but the UI process (separate from the service) only reads `~/.llauncher/agent.token`. Windows installer already mirrored env→file via PR #127; this PR adds the symmetric Linux mirror to `scripts/systemd/install.sh`.

- **#132** — `192.168.137.1:8765 → 401`. Add Node form had no API key input, and `NodeRegistry._save` deliberately drops `api_key` from `nodes.json` (control C10 / #83), so any typed token evaporated on UI restart. This PR adds the form field, an "Edit API key" expander on existing node cards, and a sibling `~/.llauncher/node_tokens.json` for remote-token persistence — file boundary preserves C10 while finally giving the UI a place to put remote credentials. `local` entry is excluded (its canonical source remains `agent.token`).

The two are coupled at the deployment-symptom level: shipping #132 alone would leave Linux loopback still 403-ing under #131. One PR.

## Files

| File | Change |
|---|---|
| `scripts/systemd/install.sh` | Mirror `LAUNCHER_AGENT_TOKEN` → `~/.llauncher/agent.token` (mode 0600). Uninstall message updated. |
| `llauncher/remote/registry.py` | `NODE_TOKENS_FILE` sidecar + `_load_node_tokens` / `_save_node_tokens` / `_populate_remote_tokens`. Wired into `_load` and `_save`. |
| `llauncher/ui/tabs/nodes.py` | API key input in Add Node form (Test + Submit paths). Per-remote "Edit API key" expander. |
| `tests/unit/test_registry_extended.py` | 9 new tests under `TestRemoteNodeTokenPersistence`. |

1027 pass / 11 skip / **94.96%** non-UI coverage (floor 93%).

## Risk surface (deferred)

- **Two-file atomicity**: a crash between `nodes.json` and `node_tokens.json` writes can leave `has_api_key=true` with no token. Next load: `api_key=None`, operator re-enters. Annoying, not corrupting. Tempfile+rename atomic-pair deferred.
- **Streamlit AppTest form-level tests** deferred to #69 (no harness yet). Persistence tests above carry the load-bearing behavior.

## Test plan

- [x] `python -m pytest tests/unit/test_registry_extended.py -v` — 27 pass (9 new)
- [x] Full suite + coverage clears 93% floor
- [ ] Manual on reporter's Linux UI host:
  - Run `bash scripts/systemd/install.sh` — verify `~/.llauncher/agent.token` now matches `grep LAUNCHER_AGENT_TOKEN= ~/.config/llauncher/agent.env | tail -n1 | cut -d= -f2-`.
  - Restart `llauncher-agent.service`; restart Streamlit. Confirm `localhost:8765/node-info → 200`.
  - In Nodes tab, add Windows remote with API key. Confirm `~/.llauncher/node_tokens.json` is created at mode 0600 with the token. Restart Streamlit. Confirm remote requests return 200.
  - Use "Edit API key" expander to rotate the token; verify `nodes.json` is untouched and `node_tokens.json` is updated.
  - Remove the remote node; verify its entry drops from `node_tokens.json`.

Closes #131, #132.
