### PR TITLE
fix(systemd): prevent install.sh silent exit on token grep miss

### DIFF
--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -103,7 +103,12 @@ fi
 # from hand-edited env files.
 mkdir -p "$LLAUNCHER_DIR"
 chmod 700 "$LLAUNCHER_DIR"
-TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]')"
+# `|| true` keeps a grep miss (no matching line) from tripping `set -e`
+# via the failing command-substitution — an empty TOKEN_VALUE then routes
+# to the informative else-branch below instead of a silent exit 1. This
+# is the failure mode when a pre-rename env file still uses the old
+# single-L LAUNCHER_AGENT_TOKEN key (see #138/#139).
+TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]' || true)"
 if [ -n "$TOKEN_VALUE" ]; then
     # printf '%s' (no trailing newline) matches the byte-shape of
     # llauncher/agent/auth.py:_generate_and_persist_token after strip.


### PR DESCRIPTION
## Problem
Running `scripts/systemd/install.sh` against an existing env file that
still used the old single-L `LAUNCHER_AGENT_TOKEN` key (pre-rename, see
#138/#139) failed with a bare `exit 1` and **no error message**.

Root cause: the token-mirror block greps for `^LLAUNCHER_AGENT_TOKEN=`.
Under `set -euo pipefail`, a grep miss made the command-substitution
fail, which tripped `set -e` and killed the script *before* the
informative "No token line found" else-branch could print.

## Fix
Append `|| true` to the pipeline so a grep miss yields an empty
`TOKEN_VALUE` and routes to the intended else-branch message instead of
a silent failure. The installer now completes (and clearly reports the
skipped mirror) regardless of whether the env file matches the current
key naming.

## Verification
- Reproduced the silent `exit 1` against a stale (single-L) env file.
- With the fix, the installer runs to completion and the token-mirror
  step reports its outcome explicitly.