### PR TITLE
fix(agent): keep agent responsive during model swap (#143)

### DIFF
--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -119,7 +119,7 @@ async def health_check() -> dict:
 
 
 @router.get("/node-info")
-async def node_info() -> dict:
+def node_info() -> dict:
     """Get information about this node."""
     import platform
 
@@ -142,7 +142,7 @@ async def node_info() -> dict:
 
 
 @router.get("/status")
-async def get_status() -> dict:
+def get_status() -> dict:
     """Get current status of running servers on this node.
 
     Returns GPU health data (ADR-006) when a GPU backend is available.
@@ -194,7 +194,7 @@ async def get_status() -> dict:
 
 
 @router.get("/orphans")
-async def list_orphans_endpoint() -> dict:
+def list_orphans_endpoint() -> dict:
     """List unmanaged ``llama-server`` processes on this node (ADR-015).
 
     An orphan is a live ``llama-server`` whose ``(port, pid)`` does not
@@ -220,7 +220,7 @@ async def list_orphans_endpoint() -> dict:
 
 
 @router.get("/footer-context/{port}")
-async def get_footer_context(port: int) -> dict:
+def get_footer_context(port: int) -> dict:
     """Minimal footer payload for ``port`` (ADR-012).
 
     Response shape is **pinned** by ADR-012; do not extend without
@@ -236,7 +236,7 @@ async def get_footer_context(port: int) -> dict:
 
 
 @router.get("/models")
-async def list_models() -> list[dict]:
+def list_models() -> list[dict]:
     """List all configured models on this node."""
     state = get_state()
     state.refresh()
@@ -270,7 +270,7 @@ async def list_models() -> list[dict]:
 
 
 @router.get("/models/health")
-async def models_health() -> list[dict]:
+def models_health() -> list[dict]:
     """Health status for *all* configured models (ADR-005)."""
     from llauncher.core.model_health import check_model_health
 
@@ -290,7 +290,7 @@ async def models_health() -> list[dict]:
 
 
 @router.get("/models/health/{model_name}")
-async def model_health_detail(model_name: str) -> dict:
+def model_health_detail(model_name: str) -> dict:
     """Health status for a single model (ADR-005)."""
     from llauncher.core.model_health import check_model_health
 
@@ -313,10 +313,24 @@ async def model_health_detail(model_name: str) -> dict:
 
 
 # ───────────────────── Verb endpoints (ADR-010) ──────────────────
+#
+# CONCURRENCY (issue #143): these handlers — and the blocking read
+# endpoints above — are deliberately plain ``def``, NOT ``async def``.
+# The underlying ops (``ops.start`` / ``ops.swap`` / ``ops.stop``) are
+# synchronous and spend most of their wall-clock time in
+# ``proc.wait_for_server_ready``'s ``time.sleep`` poll loop while a
+# llama-server loads a model into GPU memory. Starlette runs sync path
+# operations in a worker threadpool, so the event loop stays free to
+# serve ``/health`` and ``/status`` concurrently. If any of these are
+# changed back to ``async def``, the blocking op will run directly on the
+# single event loop and stall every other request (including health
+# checks) for the whole GPU load — the exact regression #143 fixed.
+# ``health_check`` stays ``async def`` so it is always answered on the
+# event loop without waiting for a threadpool slot.
 
 
 @router.post("/start/{port}")
-async def start_server(port: int, body: StartRequest) -> dict:
+def start_server(port: int, body: StartRequest) -> dict:
     """Start ``body.model`` on ``port``.
 
     Per ADR-010, port is at the call site; the model name is the body.
@@ -334,7 +348,7 @@ async def start_server(port: int, body: StartRequest) -> dict:
 
 
 @router.post("/swap/{port}")
-async def swap_server(port: int, body: SwapRequest) -> dict:
+def swap_server(port: int, body: SwapRequest) -> dict:
     """Swap the model on ``port`` to ``body.model`` per ADR-011.
 
     Performs the 5-phase swap (pre-flight → marker → stop → start →
@@ -353,7 +367,7 @@ async def swap_server(port: int, body: SwapRequest) -> dict:
 
 
 @router.post("/stop/{port}")
-async def stop_server(port: int) -> dict:
+def stop_server(port: int) -> dict:
     """Stop whatever is running on ``port`` per ADR-010.
 
     Idempotent: returns 200 with ``action="already_empty"`` if the port
@@ -369,7 +383,7 @@ async def stop_server(port: int) -> dict:
 
 
 @router.post("/cancel/{port}")
-async def cancel_op(port: int) -> dict:
+def cancel_op(port: int) -> dict:
     """Signal cancellation of an in-flight start/swap on ``port`` (ADR-014).
 
     Sets ``cancelled=True`` on the in-flight marker. The actual abandonment
@@ -393,7 +407,7 @@ async def cancel_op(port: int) -> dict:
 
 
 @router.delete("/models/{model_name}")
-async def delete_model(model_name: str) -> dict:
+def delete_model(model_name: str) -> dict:
     """Remove ``model_name`` from the config per ADR-008 §4.1.
 
     Refuses with 409 when the model is currently running on any port.
@@ -412,7 +426,7 @@ async def delete_model(model_name: str) -> dict:
 
 
 @router.get("/logs/{port}")
-async def get_logs(port: int, lines: Annotated[int, None] = None) -> dict:
+def get_logs(port: int, lines: Annotated[int, None] = None) -> dict:
     """Get recent log lines for a server."""
     from llauncher.core.process import stream_logs
 
@@ -440,7 +454,7 @@ async def get_logs(port: int, lines: Annotated[int, None] = None) -> dict:
 
 
 @router.get("/audit")
-async def get_audit(
+def get_audit(
     limit: Annotated[int, None] = None,
     action: Annotated[str, None] = None,
     result: Annotated[str, None] = None,

--- a/tests/unit/test_agent_nonblocking.py
+++ b/tests/unit/test_agent_nonblocking.py
@@ -1,0 +1,136 @@
+"""Regression tests for issue #143 — agent stays responsive during a swap.
+
+The agent verb handlers (``/swap``, ``/start``, ``/stop``) call synchronous
+operations that block for the entire duration of a GPU model load (most of
+that time is spent in ``proc.wait_for_server_ready``'s ``time.sleep`` poll
+loop). Before #143 those handlers were ``async def``, so FastAPI ran them
+directly on the single event loop — a swap stalled *every* concurrent
+request, including ``GET /health``. Auto-restart/monitoring systems then
+falsely declared the agent dead mid-load.
+
+The fix declares the blocking handlers as plain ``def`` so Starlette
+dispatches them to a worker threadpool, leaving the event loop free to
+answer ``/health`` immediately.
+
+Test strategy: drive the in-process ASGI app over ``httpx.ASGITransport``
+on one event loop. Replace ``ops.swap`` with a fake that performs a **real**
+``time.sleep`` (a faithful stand-in for a blocking GPU load). Fire the swap
+as a background task, then call ``/health``.
+
+The crisp regression signal is **ordering**, not wall-clock timing: on a
+single event loop, if the swap blocks the loop, the test's own ``await``s
+also stall, so the swap runs to completion *before* ``/health`` can even
+start. We therefore assert that ``/health`` returns while the swap task is
+still in flight (``not swap_task.done()``). With the ``async def``
+regression that assertion fails; with the ``def`` fix it passes because the
+blocking sleep runs off-loop in the threadpool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import time
+
+import httpx
+import pytest
+
+from llauncher.agent import routing
+from llauncher.agent.server import create_app_unauthenticated
+from llauncher.operations.swap import SwapResult
+
+
+# The fake swap blocks for this long. It must be comfortably larger than the
+# time the event loop needs to dispatch the handler to the threadpool and
+# answer /health, so the ordering assertion has a wide margin and does not
+# flake on a busy CI host.
+_SWAP_BLOCK_SECONDS = 2.0
+
+
+@pytest.fixture
+def app():
+    """In-process agent app with auth disabled (test-only constructor)."""
+    return create_app_unauthenticated()
+
+
+def test_blocking_verb_handlers_are_sync_def() -> None:
+    """Structural guard: the blocking handlers must NOT be coroutine functions.
+
+    A coroutine handler would run its synchronous, blocking op directly on
+    the event loop. Keeping them plain ``def`` is what lets Starlette offload
+    them to a threadpool. ``health_check`` stays ``async def`` so it is always
+    answered on the loop without waiting for a threadpool slot.
+    """
+    for fn in (routing.swap_server, routing.start_server, routing.stop_server):
+        assert not inspect.iscoroutinefunction(fn), (
+            f"{fn.__name__} must be a plain `def` so Starlette offloads its "
+            "blocking op to a worker thread (issue #143). Reverting it to "
+            "`async def` re-introduces the event-loop stall."
+        )
+
+    assert inspect.iscoroutinefunction(routing.health_check), (
+        "health_check must stay `async def` so it is served on the event "
+        "loop and never waits for a threadpool slot."
+    )
+
+
+async def test_health_responsive_during_blocking_swap(
+    app, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``GET /health`` returns while a blocking swap is still in progress."""
+    swap_entered = threading.Event()
+
+    def fake_swap(model_name, port, *, caller="unknown", **_kwargs):
+        # Signal that we're executing, then block like a real GPU load would.
+        swap_entered.set()
+        time.sleep(_SWAP_BLOCK_SECONDS)
+        return SwapResult(
+            success=True,
+            action="swapped",
+            port_state="serving",
+            port=port,
+            model=model_name,
+            previous_model="OldModel.f16",
+            pid=4321,
+            message=f"Swapped OldModel.f16 → {model_name} on port {port}",
+        )
+
+    # routing calls ``ops.swap(...)``; ``routing.ops`` is the operations
+    # package, so patching its ``swap`` attribute redirects the handler.
+    monkeypatch.setattr(routing.ops, "swap", fake_swap)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://agent.test"
+    ) as client:
+        swap_task = asyncio.create_task(
+            client.post("/swap/8082", json={"model": "LFM2-350M-Pro.f16"})
+        )
+
+        # Yield to the loop so the swap request reaches the handler and the
+        # blocking op is handed to the threadpool. If the handler were
+        # ``async def``, this sleep would itself stall for the full block
+        # because the loop is blocked — and the swap would already be done
+        # below.
+        await asyncio.sleep(0.05)
+
+        health_resp = await client.get("/health")
+
+        # The load-bearing assertion: health came back while the swap is
+        # still running. A blocked event loop would have finished the swap
+        # before health could start.
+        assert not swap_task.done(), (
+            "swap completed before /health returned — the event loop was "
+            "blocked by the synchronous swap (issue #143 regression)."
+        )
+        assert health_resp.status_code == 200
+        assert health_resp.json()["status"] == "healthy"
+
+        # The swap was genuinely executing, not skipped.
+        assert swap_entered.is_set()
+
+        # Drain the background swap so the task doesn't outlive the client.
+        swap_resp = await swap_task
+        assert swap_resp.status_code == 200
+        assert swap_resp.json()["action"] == "swapped"


### PR DESCRIPTION
## Summary
Fixes #143 — the `/swap/{port}` endpoint blocked the entire agent process during GPU model loading, so `/health`, `/status`, and every other endpoint hung until the load finished.

## Root cause
The agent verb handlers in `llauncher/agent/routing.py` were declared `async def` but call **synchronous, blocking** operations (`ops.swap`, `ops.start`, `ops.stop`). Those ops spend most of their wall-clock time in `proc.wait_for_server_ready()`'s `time.sleep` poll loop after spawning llama-server. FastAPI runs `async def` path operations directly on the single event loop, so a blocking call inside one stalls the whole loop — no concurrent request (including health checks) can be served until the GPU load completes.

## Fix (threadpool offload)
Declare the blocking handlers — and the blocking read endpoints — as plain `def`. Starlette automatically dispatches sync path operations to a worker threadpool, freeing the event loop. `health_check` stays `async def` so it is always answered on the loop without waiting for a threadpool slot. A doctrine comment in `routing.py` explains why these must not revert to `async def`.

**No API contract change**: clients still receive the final swap result on the same request; `/health` and `/status` now stay responsive throughout.

## Tests
`tests/unit/test_agent_nonblocking.py`:
- Structural guard: `swap_server`/`start_server`/`stop_server` are not coroutine functions; `health_check` is.
- ASGI regression test: with `ops.swap` faked to a real `time.sleep`, `/health` returns **while the swap is still in flight** (`not swap_task.done()`) — an assertion that fails under the `async def` regression and passes with the fix.

Full suite: 1041 passed, 11 skipped. (Two pre-existing failures unrelated to this change — a Typer/Rich CLI line-wrap artifact and a legacy-env-var doc-scan — were confirmed to reproduce on a clean tree.)

## Out of scope
The background-job + polling model (issue Option B) is deferred; the threadpool fix fully restores availability without an API change.