### PR TITLE
fix(process): resolve server logs by model, not arbitrary port glob (#145)

### DIFF
--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -174,6 +174,47 @@ def build_command(
     return cmd
 
 
+def log_path_for(config_name: str, port: int) -> Path:
+    """Return the canonical per-server log path for ``(config_name, port)``.
+
+    Single source of truth for the log filename so that the readiness check
+    (:func:`wait_for_server_ready`) reads exactly the file that
+    :func:`start_server` writes — see issue #145, where a swap left two
+    ``*-{port}.log`` files and a port-only glob could read the stopped
+    occupant's log instead of the new one.
+
+    NOTE: the sanitization is *lossy* — ``re.sub`` collapses every non
+    ``[\\w-]`` character to ``_``, so distinct config names that differ
+    only in those characters (e.g. ``LFM2-350M-Pro.f16`` vs
+    ``LFM2-350M-Pro_f16``) map to the same file. That name-collision hazard
+    is tracked as a separate issue; it is safe *here* only because the
+    identical transform is applied on both the write side and the read side.
+    """
+    sanitized_name = re.sub(r"[^\w\-]", "_", config_name)
+    return (LOG_DIR / f"{sanitized_name}-{port}.log").resolve()
+
+
+def _newest_log(paths) -> Path | None:
+    """Return the most-recently-modified path from ``paths`` (or ``None``).
+
+    Disambiguates when several log files match a port/name pattern: the
+    freshest file belongs to the current occupant. Robust to a file
+    vanishing mid-scan — a stat failure sorts the path last rather than
+    raising. Replaces the previous "return the first glob hit" behavior,
+    whose ordering was arbitrary (issue #145).
+    """
+    def _mtime(p: Path) -> float:
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return float("-inf")
+
+    candidates = list(paths)
+    if not candidates:
+        return None
+    return max(candidates, key=_mtime)
+
+
 def start_server(
     config: ModelConfig,
     port: int,
@@ -205,11 +246,10 @@ def start_server(
     # Create logs directory
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Sanitize config name to prevent path traversal and invalid characters
-    sanitized_name = re.sub(r'[^\w\-]', '_', config.name)
-    log_file = LOG_DIR / f"{sanitized_name}-{port}.log"
-    # Resolve to ensure we stay within LOG_DIR
-    log_file = log_file.resolve()
+    # Canonical per-server log path. Shared with wait_for_server_ready via
+    # log_path_for() so readiness reads exactly the file we write here, and
+    # resolved to stay within LOG_DIR (path-traversal guard). See #145.
+    log_file = log_path_for(config.name, port)
 
     # Rotate before opening, per ADR-013. Prevents an unbounded log from
     # absorbing yet another run on top of however much it already has.
@@ -441,15 +481,26 @@ def stream_logs(pid: int | None = None, model_name: str | None = None, lines: in
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 
-    # If model name provided, search for matching log files
+    # If model name provided, search for matching log files. Sanitize the
+    # name with the SAME transform start_server uses (log_path_for): the
+    # files on disk are stored sanitized, and an un-sanitized glob would
+    # both miss the real file (``LFM2-350M-Pro.f16`` vs the stored
+    # ``LFM2-350M-Pro_f16``) and risk interpreting name characters like
+    # ``[`` as glob metacharacters. When several match (a name reused
+    # across runs), prefer the most recently written — glob order is
+    # otherwise arbitrary (issue #145).
     if model_name is not None and port is None:
-        for log_file in LOG_DIR.glob(f"{model_name}-*.log"):
-            return _tail_file(log_file, lines)
+        safe_name = re.sub(r"[^\w\-]", "_", model_name)
+        match = _newest_log(LOG_DIR.glob(f"{safe_name}-*.log"))
+        if match is not None:
+            return _tail_file(match, lines)
 
     if port:
-        # Find matching log file
-        for log_file in LOG_DIR.glob(f"*-{port}.log"):
-            return _tail_file(log_file, lines)
+        # Multiple models can leave a ``*-{port}.log`` behind across a swap;
+        # the freshest belongs to the current occupant (issue #145).
+        match = _newest_log(LOG_DIR.glob(f"*-{port}.log"))
+        if match is not None:
+            return _tail_file(match, lines)
 
     return []
 
@@ -500,6 +551,7 @@ def wait_for_server_ready(
     timeout: int = 120,
     check_interval: float = 1.0,
     cancel_check=None,
+    model_name: str | None = None,
 ) -> tuple[bool, list[str]]:
     """Wait for a llama-server to become ready to accept requests.
 
@@ -515,6 +567,15 @@ def wait_for_server_ready(
             ``(False, last_logs)`` immediately. Per ADR-014 — used by
             ``operations.swap``/``start`` to react to a cancel request
             without spinning a separate thread.
+        model_name: Config name of the server being launched. When given,
+            readiness reads that model's **exact** log file
+            (:func:`log_path_for`) instead of resolving by port. This is
+            the fix for issue #145: across a swap two ``*-{port}.log``
+            files coexist (stopped + new occupant), and a port-only lookup
+            could read the stopped model's log — whose tail lacks the
+            "listening" line — making a perfectly healthy new server look
+            like it never came up and timing the swap out. Callers that
+            don't name a model fall back to the legacy port-based lookup.
 
     Returns:
         Tuple of (is_ready, recent_log_lines).
@@ -524,15 +585,29 @@ def wait_for_server_ready(
     import socket
     import time
 
+    def _attempt_logs(n: int) -> list[str]:
+        # Prefer the exact log for the model we're waiting on so a stale
+        # ``*-{port}.log`` from a prior occupant cannot shadow it (#145).
+        if model_name is not None:
+            return _tail_file(log_path_for(model_name, port), n)
+        found = find_server_by_port(port)
+        return stream_logs(pid=found.pid, lines=n) if found else []
+
+    # Check for various ready indicators (hoisted: constant per call).
+    ready_indicators = (
+        "listening",
+        "server started",
+        "ready to serve",
+        "rest api listening",
+    )
+
     start_time = time.time()
-    last_logs = []
+    last_logs: list[str] = []
 
     while time.time() - start_time < timeout:
         # ADR-014: check cancel at the natural poll cadence — no new threads.
         if cancel_check is not None and cancel_check():
-            proc = find_server_by_port(port)
-            if proc:
-                last_logs = stream_logs(pid=proc.pid, lines=50)
+            last_logs = _attempt_logs(50) or last_logs
             return False, last_logs
 
         # Check if port is listening
@@ -547,31 +622,18 @@ def wait_for_server_ready(
             pass
 
         if port_ready:
-            # Port is listening, now check logs for "listening" or "ready"
-            proc = find_server_by_port(port)
-            if proc:
-                logs = stream_logs(pid=proc.pid, lines=20)
+            # Port is listening, now check the server's log for a ready line.
+            logs = _attempt_logs(20)
+            if logs:
                 last_logs = logs
-                log_text = "\n".join(logs).lower()
-
-                # Check for various ready indicators
-                ready_indicators = [
-                    "listening",
-                    "server started",
-                    "ready to serve",
-                    "rest api listening",
-                ]
-
-                if any(indicator in log_text for indicator in ready_indicators):
-                    return True, logs
+            log_text = "\n".join(logs).lower()
+            if any(indicator in log_text for indicator in ready_indicators):
+                return True, logs
 
         time.sleep(check_interval)
 
     # Timeout - return whatever logs we have
-    proc = find_server_by_port(port)
-    if proc:
-        last_logs = stream_logs(pid=proc.pid, lines=50)
-
+    last_logs = _attempt_logs(50) or last_logs
     return False, last_logs
 
 

--- a/llauncher/operations/swap.py
+++ b/llauncher/operations/swap.py
@@ -122,7 +122,13 @@ def _launch_and_await_ready(
         return False, popen.pid, [], "lockfile race: another writer claimed the port"
 
     ready, logs = proc.wait_for_server_ready(
-        port, timeout=readiness_timeout, cancel_check=cancel_check
+        port,
+        timeout=readiness_timeout,
+        cancel_check=cancel_check,
+        # Read THIS model's exact log, not whatever ``*-{port}.log`` glob
+        # order returns — a stale stopped-occupant log would otherwise
+        # shadow the new server's "listening" line (issue #145).
+        model_name=config.name,
     )
     if not ready:
         # Distinguish cancel from genuine timeout (ADR-014).

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -1525,8 +1525,11 @@ def test_swap_cancel_during_readiness_rolls_back_as_cancelled(
         cancel_calls["n"] += 1
         return cancel_calls["n"] >= 2
 
-    # Simulate wait_for_server_ready honoring cancel_check.
-    def fake_wait(port, timeout=120, check_interval=1.0, cancel_check=None):
+    # Simulate wait_for_server_ready honoring cancel_check. Accepts
+    # model_name (added in #145) so the mock matches the real signature.
+    def fake_wait(
+        port, timeout=120, check_interval=1.0, cancel_check=None, model_name=None
+    ):
         if cancel_check is not None and cancel_check():
             return False, ["cancelled by caller"]
         return True, ["listening"]

--- a/tests/unit/test_process_log_resolution.py
+++ b/tests/unit/test_process_log_resolution.py
@@ -1,0 +1,155 @@
+"""Regression tests for issue #145 — per-server log resolution.
+
+`wait_for_server_ready` confirms a server is up by scanning its log for a
+"listening" line. The bug: it resolved the log by **port alone**
+(`glob("*-{port}.log")`, first match), but across a swap two such files
+coexist — the stopped occupant's and the new one's — so it could read the
+stopped model's log (whose tail is shutdown noise, no "listening") and time
+the swap out even though the new server was healthy.
+
+The fix threads the model name through `wait_for_server_ready` so it reads
+that model's *exact* log via `log_path_for`, and hardens `stream_logs` to
+sanitize the model name and prefer the most-recently-written match.
+"""
+
+from __future__ import annotations
+
+import socket
+from contextlib import closing
+
+import pytest
+
+from llauncher.core import process as proc
+
+
+@pytest.fixture
+def log_dir(tmp_path, monkeypatch):
+    """Point process.LOG_DIR at an isolated, resolved tmp dir."""
+    d = (tmp_path / "logs").resolve()
+    d.mkdir()
+    monkeypatch.setattr(proc, "LOG_DIR", d)
+    return d
+
+
+def _write(path, *lines):
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ─────────────────────── log_path_for ────────────────────────────
+
+
+def test_log_path_for_sanitizes_dot_to_underscore(log_dir):
+    """The on-disk name matches what start_server writes (dots → underscores)."""
+    p = proc.log_path_for("LFM2-350M-Pro.f16", 8082)
+    assert p.name == "LFM2-350M-Pro_f16-8082.log"
+    assert p.parent == log_dir
+
+
+def test_log_path_for_is_lossy_collision_is_characterized(log_dir):
+    """Characterization of the KNOWN lossy-sanitization collision (filed
+    separately): names differing only in non-[\\w-] chars collapse to the
+    same file. Pinned so the follow-up fix has a guard to flip."""
+    assert proc.log_path_for("a.b", 9000) == proc.log_path_for("a_b", 9000)
+
+
+# ─────────────────────── stream_logs ─────────────────────────────
+
+
+def test_newest_log_prefers_freshest_match(log_dir):
+    """The port/name glob disambiguator returns the freshest file, not an
+    arbitrary first glob hit — the heart of the #145 fix. Two models left a
+    ``*-{port}.log`` behind across a swap; the new occupant's is newer."""
+    import os
+    import time
+
+    old = log_dir / "OldModel-8082.log"
+    new = log_dir / "NewModel-8082.log"
+    _write(old, "cleaning up before exit")
+    _write(new, "server is listening on http://0.0.0.0:8082")
+    now = time.time()
+    os.utime(old, (now - 100, now - 100))
+    os.utime(new, (now, now))
+
+    chosen = proc._newest_log(log_dir.glob("*-8082.log"))
+    assert chosen == new
+
+
+def test_newest_log_empty_is_none(log_dir):
+    """No matches → None (callers fall through to an empty log list)."""
+    assert proc._newest_log(log_dir.glob("*-9999.log")) is None
+
+
+def test_stream_logs_by_model_name_sanitizes(log_dir):
+    """A raw model name with a dot resolves to the sanitized file on disk."""
+    f = log_dir / "LFM2-350M-Pro_f16-8083.log"
+    _write(f, "server is listening on http://0.0.0.0:8083")
+    # Caller passes the UN-sanitized config name.
+    lines = proc.stream_logs(model_name="LFM2-350M-Pro.f16", lines=20)
+    assert any("listening" in ln for ln in lines)
+
+
+def test_stream_logs_by_model_name_handles_glob_metachars(log_dir):
+    """A name containing glob metachars (``[``) must not be treated as a
+    pattern; sanitization renders it literal so the lookup is well-defined."""
+    # "Llama[5B]" sanitizes to "Llama_5B_"
+    f = log_dir / "Llama_5B_-8080.log"
+    _write(f, "rest api listening")
+    lines = proc.stream_logs(model_name="Llama[5B]", lines=20)
+    assert any("listening" in ln for ln in lines)
+
+
+# ─────────────────── wait_for_server_ready (#145 core) ────────────
+
+
+@pytest.fixture
+def listening_port():
+    """Bind+listen a real socket so the port-open precheck passes; yield port."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        yield s.getsockname()[1]
+
+
+def test_ready_reads_model_specific_log_not_stale_sibling(log_dir, listening_port):
+    """#145: with a stale ``*-{port}.log`` (no indicator) AND the new model's
+    log (has 'listening'), readiness keyed by model_name must succeed."""
+    port = listening_port
+    # Stale stopped-occupant log: shutdown noise, NO ready indicator.
+    _write(
+        proc.log_path_for("OldModel", port),
+        "=== started ===",
+        "cleaning up before exit",
+    )
+    # New occupant's log: contains the ready indicator.
+    _write(
+        proc.log_path_for("NewModel", port),
+        "=== started ===",
+        "loading model",
+        f"server is listening on http://0.0.0.0:{port}",
+    )
+
+    ready, logs = proc.wait_for_server_ready(
+        port, timeout=3, check_interval=0.02, model_name="NewModel"
+    )
+    assert ready is True
+    assert any("listening" in ln.lower() for ln in logs)
+
+
+def test_ready_keys_on_named_model_only(log_dir, listening_port):
+    """Negative side of the asymmetry: pointed at a model whose own log has
+    no indicator, readiness times out — it must NOT fall through to a
+    sibling's 'listening' line on the same port."""
+    port = listening_port
+    _write(
+        proc.log_path_for("OldModel", port),
+        "cleaning up before exit",  # no indicator
+    )
+    _write(
+        proc.log_path_for("NewModel", port),
+        f"server is listening on http://0.0.0.0:{port}",
+    )
+
+    ready, _ = proc.wait_for_server_ready(
+        port, timeout=0.3, check_interval=0.02, model_name="OldModel"
+    )
+    assert ready is False


### PR DESCRIPTION
## Summary
Fixes #145 — swaps to a healthy model would hit the 120 s readiness timeout and roll back, even though the new `llama-server` loaded and was serving.

## Root cause
`wait_for_server_ready` confirms readiness by scanning the server's log for a `listening` line, but it resolved the log by **port alone** (`glob("*-{port}.log")`, first match). After a swap, two such files coexist — the just-stopped model's and the new one's — and the first glob hit could be the stopped model's log, whose tail is shutdown noise. The new server never appeared "ready", so the swap timed out and rolled back. A fresh **start** on a clean port has only one matching file, which is why starting the same model directly worked while swapping to it failed.

## Fix
- `log_path_for(config_name, port)` — one canonical per-server log path, shared by `start_server` (writer) and the readiness check (reader).
- `wait_for_server_ready(..., model_name=...)` — when the caller names the model, readiness tails that model's **exact** log instead of resolving by port; `operations.swap` now passes `config.name`. A stale same-port sibling can no longer shadow the new server's `listening` line.
- `stream_logs` hardened: sanitize `model_name` before globbing (files are stored sanitized — a raw glob both mismatched dotted names like `LFM2-350M-Pro.f16` and treated metacharacters in names like `Llama[5B]` as a pattern), and when several files match, return the **most recently written** (`_newest_log`) rather than an arbitrary first hit.

No API/contract change; `wait_for_server_ready`'s new arg is optional and legacy callers keep the port-based behavior.

## Tests
`tests/unit/test_process_log_resolution.py`:
- #145 regression: readiness keyed by `model_name` succeeds with a stale, indicator-less `*-{port}.log` sibling present (uses a real bound socket for the port-open precheck), and the negative side — pointed at a model whose own log lacks the indicator, it times out rather than falling through to a sibling.
- `_newest_log` returns the freshest match; `stream_logs` model-name sanitization (dotted names + glob metachars).

Full suite: 1048 passed, 12 skipped (2 pre-existing unrelated failures — a Typer/Rich CLI line-wrap artifact and a legacy-env-var doc scan — confirmed on a clean tree).

## Related / scope
- Filed #146 for the underlying **lossy-sanitization collision** (distinct model names collapsing to one log file). This PR adds a characterization test pinning the current lossy behavior so #146's fix has a guard to invert.
- `operations.start` does not poll readiness, so it was never affected; the legacy `LauncherState` readiness path (ADR-008, not on the verb path) is intentionally left untouched.