### PR TITLE
docs: ADR-017 draft (session tokens) + ground-physics adoption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# llauncher — agent instructions
+
+**Constitutions, by reference** (read before structural work; cite handles in
+PRs and commits):
+
+- `~/github/shanevcantwell/design-docs/ecosystem-ground-physics/CODE_CONSTITUTION.md`
+  — ecosystem rules. The *why* is in `GROUND_PHYSICS.md` beside it; the
+  alignment plan in `ALIGNMENT_ROADMAP.md`.
+- `.claude/architecture.md` — layer map and forbidden import edges.
+
+## llauncher's position in the ecosystem physics
+
+- **llauncher is the mint** (`ONE-MINT`): `ModelConfig.name` is the single
+  authority for local-model identity across the ecosystem. Everything else —
+  port, adapter, log filename, process title, sanitized string — is an
+  *envelope*. Envelope defects (e.g. log-filename sanitization collisions,
+  #146/#63) are fixed in envelope space, never by bending the name.
+- **Keystone obligation** (`EMIT-CANONICAL`): the wire must report the
+  canonical name — `--alias = <ModelConfig.name>` at server start so
+  `/v1/models` emits it (#120; parked in `DENIED_EXTRA_ARG_FLAGS` pending
+  #87/#10). Until this lands, every downstream re-stringification dialect in
+  the ecosystem is llauncher's externalized debt
+  (`ALIGNMENT_ROADMAP.md` Phase 1 — the single highest-leverage fix).
+
+## Local rule: no backwards-compatibility shims
+
+Pre-1.0, single operator, every consumer in-ecosystem. When a persisted shape
+changes, **migrate deterministically at the door, once** (rewrite in place),
+or **fail loud**. Never dual-parse two shapes of the same artifact; never
+trust-and-degrade on an unrecognized one (`PARSE-AT-THE-DOOR`).
+
+- Observed anchors (no invariant without a violation): ADR-003's original
+  opt-in-auth compat posture, removed by the security cohort (PR #75/#87);
+  ADR-017 first draft's bare-string `node_tokens.json` dual-parse, caught in
+  review 2026-06-10.
+- Enforcement surface: PR review — a diff that parses two shapes of one
+  artifact, or justifies itself as "backcompat" for a persisted format, fails
+  review. Prose-backed until a CI gate exists; treat as provisional per
+  `CODE_CONSTITUTION.md` §Use.
+- Not a shim, unaffected: default-off / opt-in *feature* posture
+  (security stance, ADR-003 / ADR-017).
+
+## Autonomy contract (operator-ratified 2026-06-10)
+
+- **Tier labels** are the standing dispatch contract:
+  `auto:fix` — agent end-to-end: branch → fix + tests profiled against the
+  changed behavior → gates → PR → merge on green after a dispatched review.
+  `auto:draft` — agent produces the artifact (ADR, design, schema); operator
+  ratifies before implementation begins.
+  `user:gate` — operator hands or hardware required.
+- **Gates before any merge:** full pytest; non-UI coverage ≥93%
+  (`--cov-fail-under=93`); coverage profile maximized over changed paths;
+  dispatched code review.
+- **Runtime verification:** the live GPU runtime may be driven freely
+  (start/stop/swap real servers), including alongside the resident
+  :8081/:8082 services.
+- **Issue hygiene:** full agent authority — label, milestone, acceptance
+  criteria, follow-up filing, close-on-merge.
+- **The bounce rule:** an `auto:fix` that uncovers a design decision mid-fix
+  surfaces it as a named signal and bounces to `auto:draft` — never absorbs
+  it silently.
+- **Parked:** Windows-deployment quartet (#127/#128/#130/#132) until the
+  operator next touches the Windows box.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -8,7 +8,7 @@ state of the decision**, not the maturity of the ADR document itself.
 | [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 10 |
 | [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 5 |
 | [`superseded/`](./superseded/) | Replaced by a later ADR; preserved as historical record | 1 |
-| `draft/` | Not yet ratified | (currently empty) |
+| [`draft/`](./draft/) | Not yet ratified | 1 |
 
 ADR statuses inside the documents themselves follow the canon laid out
 in `docs/v2-handoff.md` §Conventions:
@@ -37,6 +37,10 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-008 — LauncherState as Stateless Facade](./accepted/008-launcher-state-stateless-facade.md) — `state._start_with_eviction_impl` retained for eviction-API smoke contract; M5/M6 cleanup pending
 - [ADR-013 — Per-Server Log Lifecycle (Append, Rotate, Bounded Tail)](./accepted/013-logs-lifecycle.md) — log filename sanitization tracked in #63
 - [ADR-015 — Orphan Policy (Annotation and Listing)](./accepted/015-orphan-policy.md) — `adopt` verb deferred per §Deferred Work
+
+### Draft
+
+- [ADR-017 — Trusted-Host Session-Token Issuance (Design B)](./draft/017-session-token-issuance.md) — Phase 1 of the provisioning roadmap (#135 / #137); supersedes the static-token-only framing of ADR-003 on ratification
 
 ### Superseded
 

--- a/docs/adrs/draft/017-session-token-issuance.md
+++ b/docs/adrs/draft/017-session-token-issuance.md
@@ -1,0 +1,206 @@
+# ADR-017: Trusted-Host Session-Token Issuance (Design B)
+
+**Status:** Draft
+**Date:** 2026-06-10
+**Tracking:** #135 (Phase 1 of the provisioning roadmap, #137). Target: v0.4.0 ("v3 alpha").
+**Doctrine:** `design-docs/ecosystem-ground-physics/` — `PARSE-AT-THE-DOOR`; no-shim migration posture.
+
+## Context
+
+ADR-003 and the security-hardening cohort (Wave 1+2, v2-final) landed the
+*enforcement* layer for agent authentication: loopback-default bind,
+refuse-to-start non-loopback without `LLAUNCHER_AGENT_TOKEN`, `X-Api-Key`
+middleware with `hmac.compare_digest`, audit-logged endpoints. The
+*provisioning* layer stayed manual: an operator adding a remote node copies a
+32-byte secret across boxes by hand. PR #133 fixed the mechanical gap (the UI
+can now store and send remote tokens via `~/.llauncher/node_tokens.json`), but
+the copy step itself remains the dominant UX friction in the dominant
+deployment shape — a small set of boxes administered by one operator on a
+trusted LAN (see #137 §Threat-model anchor).
+
+This ADR ratifies **Design B** from the 2026-05-25 planning session
+(`docs/handoffs/2026-05-25-ui-auth-fix-and-provisioning-roadmap.md`): agents
+mint short-lived session tokens for clients connecting from
+operator-whitelisted source addresses, so adding a remote node from a
+trusted UI host becomes "type host and port."
+
+### Design constraints
+
+1. Static-token auth (ADR-003) remains intact as the fallback for any client
+   outside the trusted range. This ADR supersedes only the *static-token-only*
+   language of ADR-003, not the ADR itself.
+2. Existing v0.3.x deployments must upgrade with **zero configuration change
+   and zero new attack surface**. The feature is strictly opt-in.
+3. The threat-model honesty must be loud (see below) so trusted-host issuance
+   is never mistaken for mutual authentication.
+4. **No backwards-compatibility shims** (ecosystem ground physics,
+   `PARSE-AT-THE-DOOR`): persisted shapes migrate deterministically at the
+   door, once, or fail loud. Dual-parse paths are not carried. Default-off
+   *feature* posture (constraint 2) is security posture, not a shim, and is
+   unaffected by this.
+
+## Decision
+
+Add a trusted-host session-token issuance path on top of the existing static
+token machinery.
+
+### Whitelist configuration — `llauncher/agent/config.py`
+
+- New env var **`LLAUNCHER_AGENT_TRUSTED_HOSTS`**: comma-separated list parsed
+  into `ipaddress.ip_network` objects. CIDR and IPv6 supported. Parse errors
+  (including ambiguous inputs like `192.168.1.1/33`) **fail loud at startup**:
+  the agent refuses to bind, matching the PR #75 posture for missing tokens.
+- **Unset or empty ⇒ the feature is off.** `POST /session` returns 403 for
+  every caller, *including loopback*. This resolves an ambiguity in #135's
+  spec ("loopback always implicit" vs. "empty ⇒ 403 for everyone"): implicit
+  loopback applies only when the whitelist is non-empty and the feature is
+  therefore enabled. Loopback clients never need `/session` — they resolve the
+  static token from `~/.llauncher/agent.token` — so disabling the endpoint
+  outright preserves the no-new-attack-surface invariant for upgrades.
+- When non-empty, loopback (`127.0.0.0/8`, `::1/128`) is implicitly appended.
+
+*(Note: #135 predates the #151 env-var rename and uses the `LAUNCHER_AGENT_*`
+prefix; this ADR uses the post-rename `LLAUNCHER_AGENT_*` family throughout.)*
+
+### Issuance endpoint — `llauncher/agent/server.py`
+
+- New route **`POST /session`**. Not behind `verify_token`; instead an
+  explicit check of `request.client.host` against the parsed whitelist.
+- Success returns `{"token": "<urlsafe>", "expires_at": "<iso8601 UTC>"}`.
+- Every request — success and reject — is **audit-logged unconditionally**
+  with source IP.
+- `request.client.host` is wrong behind a reverse proxy. Trusted-host mode
+  **requires direct client connections**; no `X-Forwarded-For` trust is
+  implemented, deliberately (header trust is its own spoofing surface).
+  Documented in README.
+
+### Token store — `llauncher/agent/auth.py`
+
+- New **`SessionTokenStore`**: in-process dict keyed by token, value
+  `expires_at`. Expired entries swept on access — no background task.
+- TTL configurable via **`LLAUNCHER_AGENT_SESSION_TTL_SECONDS`**, default
+  **24h** — a deliberate midpoint: longer widens the stolen-token window,
+  shorter makes the UI re-bootstrap frequently.
+- In-process means **agent restart revokes all session tokens**. That is the
+  rotation/revocation mechanism for this phase (see §Deferred Work).
+
+### Middleware — `llauncher/agent/middleware.py`
+
+- `AuthenticationMiddleware` accepts *either* the static
+  `LLAUNCHER_AGENT_TOKEN` *or* an unexpired session token, both compared via
+  `hmac.compare_digest`. 401/403 separation unchanged.
+
+### Client bootstrap — `llauncher/remote/node.py`, `llauncher/remote/registry.py`
+
+- New **`RemoteNode.bootstrap_session()`**: when `api_key` is `None` on first
+  contact, attempt `POST /session`; on success persist `{token, expires_at}`
+  through the registry's normal save path into `node_tokens.json` (mode 0600,
+  C10 invariant preserved — creds never in `nodes.json`). On expiry,
+  re-bootstrap silently. The bootstrap result is cached for the session
+  lifetime so issuance happens once per UI start, not per poll.
+- `node_tokens.json` carries **exactly one schema**: `{token, expires_at}`
+  per node, with `expires_at: null` meaning a static (non-expiring) token.
+  PR #133's bare-string entries are **migrated once, at first load** —
+  rewritten in place to `{token, expires_at: null}` — after which the old
+  shape is never parsed again. A missing file is the normal empty state; a
+  corrupt or unrecognized entry **fails loud at load** rather than degrading
+  to `api_key=None`. This deliberately revises #133's silent-degrade posture
+  per `PARSE-AT-THE-DOOR`: never trust-and-degrade on an unknown shape.
+- A manually supplied API key in the Add Node form remains an override; the
+  bootstrap path only fires when no key is configured.
+
+### End state
+
+An operator on a UI box whose IP is inside `LLAUNCHER_AGENT_TRUSTED_HOSTS`
+adds a remote node by typing host + port. No token copy. Static-token flow
+unchanged for everyone else.
+
+## Threat model — read before relying on this
+
+This design protects what the static-token design protects (operator opt-in
+for non-loopback bind, no public-internet exposure) **plus** removes manual
+provisioning *within the trusted network*. It does **not** defend against:
+
+- LAN-resident attackers who can spoof a trusted source IP (ARP spoofing etc.)
+- Passive sniffers on the network path — there is still no TLS
+- Coresident user-level processes on the agent host
+
+Source-IP trust is a *convenience* boundary, not an *adversarial* one. The
+adversarial answer is Phase 3 (mTLS / pubkey pinning, #86). For two-box
+home/office deployments administered by one operator — the project's actual
+deployment shape — this posture is the right fit, and the README must say all
+of this where operators will read it.
+
+## Alternatives considered
+
+- **Status quo + documentation (Phase 0, #134).** Ships regardless; does not
+  remove the copy step. Kept as the floor, not the answer.
+- **Design D — out-of-band pairing CLI (#136).** Better UX for first-time and
+  roaming clients (6-digit codes), but depends on this ADR's
+  `SessionTokenStore` anyway and adds interactive-CLI surface. Sequenced as
+  Phase 2, not skipped.
+- **Design C — mTLS / pubkey pinning (#86).** The real answer for hostile
+  networks; heavyweight for the trusted-LAN posture and unplannable in detail
+  today. Deliberately deferred to Phase 3. If a hostile-network use case
+  arrives, Phase 3 jumps the queue and this ADR's path remains the UX layer
+  on top.
+- **Trusting `X-Forwarded-For` to support reverse proxies.** Rejected:
+  header-based source trust is trivially spoofable from exactly the positions
+  this feature implicitly trusts. Direct connections only.
+
+## Testing requirements
+
+- Middleware: session token accepted; rejected after TTL; unknown rejected;
+  static-token path regression-free.
+- `/session`: 403 for non-whitelist IPs (even with empty body); 200 for
+  whitelist IPs without static token; 200 for loopback **when the feature is
+  enabled**; 403 for everyone — loopback included — when
+  `LLAUNCHER_AGENT_TRUSTED_HOSTS` is unset/empty.
+- CIDR parsing: typos and invalid masks rejected at startup; IPv6 matches;
+  loopback implicit when enabled.
+- Bootstrap: first ping with no `api_key` triggers `/session`; subsequent
+  pings reuse the stored token; silent re-bootstrap on expiry.
+- Migration: a #133-shape (bare-string) `node_tokens.json` is rewritten once
+  to `{token, expires_at: null}` and round-trips thereafter; corrupt or
+  unrecognized entries refuse load loudly; a missing file yields an empty
+  store.
+- Audit log records every `/session` request (success + reject) with source IP.
+
+## Consequences
+
+**Positive:**
+- "Type host and port" provisioning inside the trusted range; the roadmap's
+  Phase 1 exit criteria (#135) are met.
+- Strictly opt-in; no change of any kind for upgrading v0.3.x deployments.
+- `SessionTokenStore` is the substrate Phase 2's pairing CLI builds on.
+- Single persisted schema for `node_tokens.json` — no dual-parse drift
+  surface carried forward.
+
+**Negative:**
+- Two accepted credential classes in the middleware instead of one — auth
+  reasoning now has a second path to audit.
+- Source-IP trust invites misreading as real authentication; mitigated by
+  loud documentation, not eliminated.
+- Reverse-proxy deployments cannot use the feature.
+- A corrupt `node_tokens.json` now fails loud at load instead of silently
+  pinging unauthenticated — intended, but a behavior change from #133.
+
+**Same-orbit cleanups bundled with this phase:**
+- **#126** — ADR-003 exempt-paths drift vs. live middleware: resolve while
+  the middleware is open.
+- **#125** — `/node-info` self-loop short-circuit: cooperative, would remove
+  the local-node auth path entirely; bundle if cheap.
+
+## Deferred Work
+
+- Token revocation / rotation UX — agent restart is the mechanism this phase.
+- First-time provisioning from outside the trusted range (fresh laptop,
+  coffee-shop network) — static-token fallback covers it manually; Phase 2
+  (#136) eliminates the corner.
+- mTLS / pubkey pinning — Phase 3 (#86).
+
+## Supersession note
+
+Supersedes the static-token-*only* framing of ADR-003 §Decision. ADR-003
+remains in force for the static path and stays in `completed/`; on
+ratification, add an Amendment Note there pointing here.

--- a/docs/handoffs/2026-05-25-ui-auth-fix-and-provisioning-roadmap.md
+++ b/docs/handoffs/2026-05-25-ui-auth-fix-and-provisioning-roadmap.md
@@ -1,0 +1,127 @@
+# Session handoff — UI auth fix + cross-node auth provisioning roadmap (2026-05-25)
+
+Companion to `docs/handoffs/2026-05-24-v03-alpha-release-and-adr-reorg.md` (PM session). Pointers to source files inline; artifact contents not pasted here.
+
+## 1. Where we are
+
+Branch `main` at `b5101ef` (`fix(ui+installer): repair UI auth after security cohort (#131, #132) (#133)`). Working tree clean; `origin/main` synced. Pre-release `v0.3.0-alpha` tag unchanged.
+
+The reporter's deployment that motivated this session: **Linux UI host (systemd-installed agent) + Windows remote agent (NSSM-installed)** over a Windows ICS subnet (192.168.137.x). Both bug surfaces (#131 + #132) reproduced and fixed.
+
+## 2. What landed this session
+
+### Code
+
+| Ref | Type | Impact |
+|---|---|---|
+| PR #133 (merged → `b5101ef`) | code+tests | Mechanical fix for the UI auth regression after the security cohort. Three deliverables in one squash: |
+| | | (a) `scripts/systemd/install.sh` mirrors `LAUNCHER_AGENT_TOKEN` from `~/.config/llauncher/agent.env` into `~/.llauncher/agent.token` so the UI process (separate from the systemd unit) can authenticate. Symmetric with PR #127's Windows install.ps1 mirror. |
+| | | (b) `llauncher/ui/tabs/nodes.py` Add Node form gained an `api_key` password field (threaded through both Test and Submit paths); per-remote "🔑 Edit API key" expander in `render_node_list` lets operators rotate without delete+re-add (skipped for `local` since its token comes from `agent.token`). |
+| | | (c) `llauncher/remote/registry.py` got a new sibling secrets file `~/.llauncher/node_tokens.json` (mode 0600) carrying `{name: token}` for remote nodes — preserves C10 invariant ("creds never in nodes.json") while finally giving the UI a place to persist remote tokens. `local` excluded; missing/corrupt file degrades to `api_key=None` (NOT credential-confusion from local agent.token). |
+| | | Tests: 9 new in `tests/unit/test_registry_extended.py::TestRemoteNodeTokenPersistence`. 1027 pass / 11 skip / **94.96%** non-UI coverage (floor 93%). |
+
+### Issues filed
+
+| # | Phase | Target | What |
+|---|---|---|---|
+| #131 | — | v0.3.x (closed by #133) | Linux systemd installer token mirror |
+| #132 | — | v0.3.x (closed by #133) | Add Node form + remote token persistence |
+| #134 | 0 | v0.3.1 | Operability docs for the current manual-token-copy provisioning flow |
+| #135 | 1 | v0.4.0 ("v3 alpha") | Design B — trusted-host session-token issuance |
+| #136 | 2 | v0.4.x / v0.5.0 | Design D — out-of-band pairing CLI |
+| #137 | tracking | — | Cross-node auth provisioning roadmap (links #134/#135/#136 + #86) |
+
+### Sibling-repo change
+
+`design-docs` repo: commit `548e7b8` updates the user-level git subagent definition (`agents/git.md`). Description rewritten in prescribing/incentive form; every `git`/`gh` operation now defaults into the subagent (narrow exclusion table for *authorial GitHub text* only — PR/issue bodies, release notes, review comments). The "Doubt or failure" return shape is renamed **Sub-panic** with explicit always-available escape semantics.
+
+Operationally this means: the next session should route ALL git/gh ops through the git subagent. `git status`, `gh pr view`, `gh pr merge` are now in scope for the subagent because output shape and failure mode are unpredictable from the dispatcher's vantage.
+
+## 3. The cross-node auth provisioning roadmap
+
+PR #133 fixed the *mechanical* gap (UI can now send tokens). The *provisioning* gap — operators still copy a 32-byte secret across boxes by hand, with no in-product guidance — stayed open and was decomposed into a phased roadmap.
+
+Tracking issue **#137** holds the phase table, threat-model anchor, dependency map, and per-phase pointers (#134 / #135 / #136 / existing #86). The roadmap is calibrated for the **trusted-LAN** posture the reporter's deployment (Windows ICS subnet, two own boxes) inhabits; Phase 3 (#86) is what's needed for stronger postures and stays deferred. See #137 for full design content; the per-phase issues carry scope/exit-criteria/risk.
+
+## 4. Notable findings worth carrying forward
+
+### a. The squash-merge ancestor anomaly
+
+`b5101ef` (the PR #133 squash) has a single parent of `7629999` — two commits *before* the actual main tip at the time of merge (`435b312`). The intermediate commits `33cbf6f` (#127) and `435b312` (#129) are not in `b5101ef`'s commit-graph ancestry but their *file content* is folded into the squash (verified file-by-file).
+
+Practical impact: after the merge, local main was "ahead 2, behind 1" from origin/main as a pure topology artifact. Resolved by `git reset --hard origin/main` after confirming all #127/#129 touched files were byte-identical on both sides. No code lost.
+
+Open question: why did the GitHub squash pick `7629999` as base instead of `435b312`? Not investigated. Possible causes: PR branch was rebased to an earlier base at some point in the session, or the GitHub web UI was used in a way that rewound the base. Worth keeping in mind if it recurs — could indicate a workflow issue with how PRs are based when the operator interleaves UI and CLI git operations.
+
+### b. Provisional Handling fired ~10 times this session
+
+TaskCreate / task-tools nudges fired roughly every 3–5 turns. All dismissed per the constitution; the durable record (PR, filed issues, this dossier) is the task list. The nudge volume suggests harness heuristics over-trigger on long single-task sessions; previous dossiers noted the same pattern.
+
+### c. Working-tree intentional revert mid-session
+
+Mid-session the working tree was reset to pre-fix state by the user (intentional, per system reminders). This happened around the time of the PR #133 merge attempt. The reset preceded the `git reset --hard origin/main` cleanup in §a. Mechanism unclear but presumed user-driven via terminal or IDE outside the harness. Worth flagging as something the harness *did* observe but couldn't predict.
+
+### d. The git subagent expansion (sibling repo)
+
+A mid-session tangent rewrote the git subagent's contract to absorb all `git` + `gh` operations (previously `gh` was excluded). Shipped as `design-docs/548e7b8` — survives the user's planned rewind of this conversation's tangent portion. Next session should reach for the subagent by default for VCS work.
+
+## 5. Carry-forward
+
+### Open issues this session left untouched
+
+- **#134** — Phase 0 docs. Smallest unit of work; can ship in a single session. Recommended next move if continuing the provisioning thread.
+- **#135** — Phase 1 (Design B session tokens). 2-3 sessions including ADR draft (would file as `docs/adrs/draft/017-session-token-issuance.md`, supersedes the static-token-only portion of ADR-003).
+- **#136** — Phase 2 (Design D pairing CLI). Depends on Phase 1's `SessionTokenStore`.
+- **#86** — Phase 3 (mTLS). User-punted; ADR-shaped design work, not code.
+
+### Pre-existing carry-forward from prior dossiers (unchanged)
+
+- **#117** — cross-repo doc link for ADR-016 (blocked on sibling pi-coding-agent repo). v2-final, non-blocking.
+- **#122** — Streamlit `use_container_width` deprecation. The warning continued to appear in this session's runtime logs. v2-final, non-blocking.
+- **#119** (UI IA pass), **#120** (`--alias` to llama-server), **#69** (Streamlit AppTest harness) — v3-alpha milestone.
+- **#121** (model-card surface) — v4-alpha milestone.
+- **#42** (vLLM backend adapter) — gates `v2.0.0`.
+- **#125** — `/node-info` self-loop short-circuit. Tangential to Phase 1 (would obviate auth path entirely for the local node) — worth bundling.
+- **#126** — ADR-003 exempt-paths drift vs live middleware. Same orbit as Phase 1's ADR work.
+- Worktree shelf cleanup (`worktree-agent-*` + `agent-*` paths) still deferred from prior sessions.
+
+### Stale branches likely safe to delete
+
+- `sec-81-fix-on-main`, `temp-sec-81-fix` (per 2026-05-21 dossier §infrastructure-debt).
+- Multiple `sec-*` and `cleanup-*` branches still local — all corresponding PRs merged per prior dossiers. Confirm with `git branch -vv` + `gh pr list --state merged --head <name>` before bulk delete.
+
+## 6. Pre-work verification (next session)
+
+```bash
+# State
+git log --oneline -6           # tip should be b5101ef or later
+git status -sb                 # should be clean, tracking origin/main
+gh pr list --state open        # should not include #131/#132/#133
+
+# Tests
+python -m pytest tests/ -q | tail -3            # expect 1027 pass / 11 skip
+python -m pytest tests/ --cov-fail-under=93     # expect ~94.96% non-UI
+
+# Provisioning roadmap
+gh issue view 137              # tracking issue with full phase table
+gh issue list --label security --state open    # should show #134, #135, #136 + carry-forward
+
+# Sibling repo (subagent definition)
+ls -la ~/.claude/agents/git.md  # symlink into design-docs/agent-constitution/agents/git.md
+( cd ~/github/shanevcantwell/design-docs && git log --oneline -3 )
+# expect 548e7b8 at or near the tip
+```
+
+## 7. Suggested first move for the *next* session
+
+**Pick one of:**
+
+1. **Phase 0 (#134) — operability docs.** Smallest unit, ships in one session, unblocks operator self-service against the current manual flow. Right answer if you want to keep momentum on the provisioning thread without committing to design work yet.
+
+2. **Phase 1 (#135) — Design B session tokens.** Starts with the ADR draft; implementation lands in a follow-up PR after ratification. Right answer if you want to commit the design direction now and start the design conversation.
+
+3. **Local branch + worktree shelf cleanup.** Lower priority but the shelf has been growing across sessions. Quick palette cleanser.
+
+4. **Unrelated v3-alpha or v4-alpha work** (#119, #120, #69, #121).
+
+The reporter's actual deployment is now functional after PR #133 — there's no on-fire user pressure forcing the choice. Pacing is yours.

--- a/llauncher/ui/launch.py
+++ b/llauncher/ui/launch.py
@@ -1,0 +1,75 @@
+"""Console-script entry point for the Streamlit dashboard.
+
+Exists so operators launch the UI with a single command (``llauncher-ui``)
+instead of the ``cd <repo> && scripts/run.sh ui`` ritual. Mirrors the
+``llauncher-agent`` / ``llauncher-mcp`` entry-point convention in
+``pyproject.toml`` ``[project.scripts]``.
+
+Launches Streamlit in a subprocess (``python -m streamlit run app.py``)
+rather than importing it: ``ui/`` is an endpoint-layer sibling, and
+shelling out keeps this free of any cross-layer Python import (see
+``.claude/architecture.md``) and stable across Streamlit's internal CLI
+module reshuffles.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+# The dashboard ships with no built-in auth (security-hardening §2.8 / C12),
+# so the default bind is loopback. Operators opt into LAN exposure
+# explicitly via LLAUNCHER_UI_HOST, and only behind a gateway
+# (Tailscale / SSH tunnel / authenticating reverse proxy).
+DEFAULT_UI_HOST = "127.0.0.1"
+
+# NB: deliberately the two-L spelling. scripts/run.sh still reads the
+# legacy single-L LAUNCHER_UI_HOST; that drift is tracked for rename so
+# both converge on LLAUNCHER_UI_HOST.
+UI_HOST_ENV = "LLAUNCHER_UI_HOST"
+
+
+def resolve_ui_host(environ: Mapping[str, str] | None = None) -> str:
+    """Return the UI bind address, defaulting to loopback.
+
+    An empty or unset ``LLAUNCHER_UI_HOST`` falls back to loopback so a
+    blank export never silently publishes the no-auth dashboard.
+    """
+    env = os.environ if environ is None else environ
+    return env.get(UI_HOST_ENV) or DEFAULT_UI_HOST
+
+
+def build_streamlit_argv(app_path: Path, host: str) -> list[str]:
+    """Assemble the ``python -m streamlit run`` command line."""
+    return [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_path),
+        "--server.address",
+        host,
+    ]
+
+
+def main() -> int:
+    """Launch the Streamlit dashboard. Returns Streamlit's exit code."""
+    try:
+        import streamlit  # noqa: F401
+    except ImportError:
+        sys.stderr.write(
+            "Streamlit is not installed. Install the UI extra:\n"
+            '    pip install "llauncher[ui]"\n'
+        )
+        return 1
+
+    app_path = Path(__file__).resolve().parent / "app.py"
+    argv = build_streamlit_argv(app_path, resolve_ui_host())
+    return subprocess.call(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
 llauncher = "llauncher.cli:app"
 llauncher-mcp = "llauncher.mcp_server.server:main"
 llauncher-agent = "llauncher.agent:main"
+llauncher-ui = "llauncher.ui.launch:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -25,7 +25,6 @@ REM Now parse and execute command
 if /i "%~1"=="mcp" goto :mcp
 if /i "%~1"=="ui" goto :ui
 if /i "%~1"=="agent" goto :agent
-if /i "%~1"=="agent-bg" goto :agent-bg
 if /i "%~1"=="stop" goto :stop
 if /i "%~1"=="discover" goto :discover
 
@@ -65,7 +64,6 @@ goto :help
     echo Commands available:
     echo   run.bat mcp       - Start MCP server
     echo   run.bat agent     - Start remote management agent (foreground)
-    echo   run.bat agent-bg  - Start remote management agent (background)
     echo   run.bat ui        - Start Streamlit UI (requires agent; start it first)
     echo   run.bat stop      - Stop running agent
     echo   run.bat discover  - List discovered launch scripts
@@ -95,13 +93,6 @@ goto :help
     llauncher-agent
     goto :end
 
-:agent-bg
-    echo [INFO] Starting remote management agent in background...
-    start /B "" llauncher-agent > "%PROJECT_DIR%\agent.log" 2>&1
-    echo [OK] Agent started in background
-    echo Logs: %PROJECT_DIR%\agent.log
-    goto :end
-
 :stop
     echo [INFO] Stopping remote management agent...
     llauncher-agent --stop
@@ -121,7 +112,6 @@ goto :help
     echo   install    Install llauncher and dependencies
     echo   mcp        Start MCP server (for LLM clients)
     echo   agent      Start remote management agent (foreground)
-    echo   agent-bg   Start remote management agent (background)
     echo   ui         Start Streamlit UI (requires agent; start it first)
     echo   stop       Stop running agent
     echo   discover   List discovered launch scripts

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -38,17 +38,13 @@ source "$PROJECT_DIR/.venv/bin/activate"
 
 case "${1:-}" in
     install)
-        print_info "Installing llauncher and dependencies..."
-        pip install -e ".[ui]" --quiet
-        print_status "Installation complete"
-        echo ""
-        echo "Commands available:"
-        echo "  ./run.sh mcp       - Start MCP server"
-        echo "  ./run.sh agent     - Start remote management agent (foreground)"
-        echo "  ./run.sh agent-bg  - Start remote management agent (background)"
-        echo "  ./run.sh ui        - Start Streamlit UI (requires agent; start it first)"
-        echo "  ./run.sh stop      - Stop running agent"
-        echo "  ./run.sh discover  - List discovered launch scripts"
+        # Disabled: this installed into the repo-local .venv (activated above),
+        # disconnected from the operator's global commands — the "complete"
+        # banner implied a global readiness it never delivered. See issue #154.
+        print_error "run.sh install is disabled: it installed into a repo-local .venv,"
+        print_error "disconnected from your global commands. For a global install:"
+        echo "    pip install --user -e \".[ui]\"   # from this repo, with no venv active"
+        exit 1
         ;;
     mcp)
         print_info "Starting MCP server..."
@@ -69,14 +65,6 @@ case "${1:-}" in
         print_info "Set LLAUNCHER_AGENT_PORT and LLAUNCHER_AGENT_NODE_NAME to customize"
         llauncher-agent
         ;;
-    agent-bg)
-        print_info "Starting remote management agent in background..."
-        nohup llauncher-agent > "$PROJECT_DIR/agent.log" 2>&1 &
-        echo $! > "$PROJECT_DIR/agent.pid"
-        print_status "Agent started (PID: $!)"
-        echo "Logs: $PROJECT_DIR/agent.log"
-        echo "Stop with: kill \$(cat $PROJECT_DIR/agent.pid)"
-        ;;
     stop)
         print_info "Stopping remote management agent..."
         llauncher-agent --stop
@@ -91,10 +79,8 @@ case "${1:-}" in
         echo "Usage: $0 [command]"
         echo ""
         echo "Commands:"
-        echo "  install   Install llauncher and dependencies"
         echo "  mcp       Start MCP server (for LLM clients)"
         echo "  agent     Start remote management agent (foreground)"
-        echo "  agent-bg  Start remote management agent (background)"
         echo "  ui        Start Streamlit UI (requires agent; start it first)"
         echo "  stop      Stop running agent"
         echo "  discover  List discovered launch scripts"

--- a/tests/unit/test_ui_launch.py
+++ b/tests/unit/test_ui_launch.py
@@ -1,0 +1,32 @@
+"""Unit tests for the ``llauncher-ui`` console-script entry point."""
+
+from pathlib import Path
+
+from llauncher.ui import launch
+
+
+def test_resolve_ui_host_defaults_to_loopback():
+    # No override -> loopback, per the no-auth-dashboard default (C12).
+    assert launch.resolve_ui_host({}) == "127.0.0.1"
+
+
+def test_resolve_ui_host_honors_env_override():
+    assert launch.resolve_ui_host({"LLAUNCHER_UI_HOST": "0.0.0.0"}) == "0.0.0.0"
+
+
+def test_resolve_ui_host_blank_override_falls_back_to_loopback():
+    # A blank export must not silently publish the dashboard.
+    assert launch.resolve_ui_host({"LLAUNCHER_UI_HOST": ""}) == "127.0.0.1"
+
+
+def test_build_streamlit_argv_runs_the_packaged_app():
+    app = Path("/opt/llauncher/ui/app.py")
+    argv = launch.build_streamlit_argv(app, "127.0.0.1")
+
+    assert argv[1:4] == ["-m", "streamlit", "run"]
+    assert str(app) in argv
+
+
+def test_build_streamlit_argv_binds_resolved_host():
+    argv = launch.build_streamlit_argv(Path("/x/app.py"), "192.168.1.5")
+    assert argv[argv.index("--server.address") + 1] == "192.168.1.5"


### PR DESCRIPTION
## What
- **ADR-017 (draft)** — trusted-host session-token issuance (Design B), unblocking Phase 1 (#135) of the provisioning roadmap (#137). Resolves the loopback/empty-whitelist ambiguity in #135 (empty = feature off, even for loopback); uses post-#151 `LLAUNCHER_AGENT_*` env names; rejects X-Forwarded-For trust explicitly.
- **No-backcompat posture** — `node_tokens.json` carries exactly one schema; #133-shape bare strings migrate once at first load; corrupt entries fail loud (deliberate revision of #133's silent degrade, per `PARSE-AT-THE-DOOR`).
- **CLAUDE.md** — ecosystem constitution by reference + llauncher-specific physics (mint role, keystone #120, no-shim rule) + the operator-ratified autonomy contract.

## Ratification
ADR-017 stays in `draft/` — Accepted status and the ADR-003 amendment note land when the operator ratifies on #135.

## Note
Branch currently carries 3 pre-existing local-main commits (0c75c67, 2eb2bec, 0b6e539); pushing local main shrinks this PR to its one docs commit.