### PR TITLE
fix(process): pass --alias <ModelConfig.name> to llama-server (EMIT-CANONICAL)

### DIFF
--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -100,6 +100,16 @@ def build_command(
     # Model path
     cmd.extend(["-m", config.model_path])
 
+    # Canonical served-model identity (issue #120, EMIT-CANONICAL):
+    # ``GET /v1/models`` must report the name llauncher minted for this
+    # config — byte-for-byte, no transformation, no sanitization — so
+    # ecosystem routers (local-inference-pool) can match the server
+    # against llauncher's registry. Without ``--alias`` llama-server
+    # reports the GGUF filename/metadata instead. This flag is
+    # launcher-owned: ``DENIED_EXTRA_ARG_FLAGS`` keeps it out of
+    # ``extra_args`` so a config cannot override the minted identity.
+    cmd.extend(["--alias", config.name])
+
     # Multimodal projector (optional)
     if config.mmproj_path:
         cmd.extend(["--mmproj", config.mmproj_path])

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -22,8 +22,11 @@ from llauncher.core.settings import BLACKLISTED_PORTS as _ENV_BLACKLISTED_PORTS
 # in :attr:`ModelConfig.extra_args` because:
 #
 # * ``--api-key`` / ``--alias`` — security-sensitive identity that
-#   llauncher will own once #87/#10 land. A malicious config slipping
-#   one of these in would silently override llauncher's intent.
+#   llauncher owns (#87/#10 landed; ``--alias`` is emitted by
+#   ``build_command`` from :attr:`ModelConfig.name` per issue #120 /
+#   EMIT-CANONICAL). A config slipping one of these in would silently
+#   override llauncher's minted identity — launcher-owned flags stay
+#   launcher-owned.
 # * ``-m`` / ``--model`` — set by ``build_command`` from
 #   :attr:`ModelConfig.model_path` (``core/process.py``). Duplication
 #   bypasses the path validator on ``model_path``.

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -222,6 +222,98 @@ class TestBuildCommand:
         assert "1.5" in cmd
 
 
+def _alias_value(cmd: list[str]) -> str:
+    """Return the argv token immediately following ``--alias``."""
+    idx = cmd.index("--alias")
+    assert idx + 1 < len(cmd), "--alias present but missing its value"
+    return cmd[idx + 1]
+
+
+class TestBuildCommandAlias:
+    """Issue #120 (EMIT-CANONICAL): ``build_command`` must pass
+    ``--alias <ModelConfig.name>`` so ``GET /v1/models`` reports the
+    canonical minted name, byte-for-byte — no transformation, no
+    sanitization. Ecosystem routers (local-inference-pool) match servers
+    against this id.
+    """
+
+    @staticmethod
+    def _config_named(name: str, **overrides) -> ModelConfig:
+        data = {
+            "name": name,
+            "model_path": "/fake/path/model.gguf",
+            **overrides,
+        }
+        return ModelConfig.from_dict_unvalidated(data)
+
+    def test_alias_present_with_exact_name(self, minimal_config):
+        """The spawn argv contains ``--alias`` immediately followed by
+        the exact model name.
+        """
+        cmd = build_command(minimal_config, port=8080)
+        assert "--alias" in cmd
+        assert _alias_value(cmd) == "test-model"
+
+    def test_alias_present_in_full_config(self, full_config):
+        """Alias is emitted regardless of which optional fields are set."""
+        cmd = build_command(full_config, port=8080)
+        assert _alias_value(cmd) == "full-model"
+
+    def test_alias_name_with_spaces_untransformed(self):
+        """A name containing spaces survives as a single argv token —
+        list-form argv needs no quoting and must not introduce any.
+        """
+        cfg = self._config_named("My Local Model 7B")
+        cmd = build_command(cfg, port=8080)
+        assert _alias_value(cmd) == "My Local Model 7B"
+
+    def test_alias_name_with_unicode_untransformed(self):
+        """Unicode names are emitted byte-for-byte."""
+        name = "qwen3-中文-モデル-β"
+        cfg = self._config_named(name)
+        cmd = build_command(cfg, port=8080)
+        assert _alias_value(cmd) == name
+
+    def test_alias_not_sanitized_like_log_names(self):
+        """The lossy ``[^\\w-] -> _`` transform used for log *filenames*
+        (``log_path_for``) must NOT touch the alias: a name with dots
+        and pluses is emitted verbatim, not collapsed to underscores.
+        """
+        name = "LFM2-350M-Pro.f16+test"
+        cfg = self._config_named(name)
+        cmd = build_command(cfg, port=8080)
+        assert _alias_value(cmd) == name
+        assert "LFM2-350M-Pro_f16_test" not in cmd
+
+    def test_alias_emitted_exactly_once_with_extra_args(self):
+        """Benign ``extra_args`` must not produce a second ``--alias``;
+        the launcher's emission is the only one in argv.
+        """
+        cfg = self._config_named(
+            "extra-args-model", extra_args="--log-disable --verbose"
+        )
+        cmd = build_command(cfg, port=8080)
+        assert cmd.count("--alias") == 1
+        assert _alias_value(cmd) == "extra-args-model"
+        # extra_args still land after the managed flags
+        assert "--log-disable" in cmd
+        assert "--verbose" in cmd
+
+    def test_alias_cannot_be_overridden_via_extra_args(self, minimal_config):
+        """Launcher-owned flag stays launcher-owned: ``extra_args``
+        carrying ``--alias`` is rejected by the C7 deny-list before
+        ``build_command`` ever sees it (both bare and equals forms).
+        """
+        with pytest.raises(ValueError, match="--alias"):
+            minimal_config.extra_args = "--alias impostor"
+        with pytest.raises(ValueError, match="--alias"):
+            minimal_config.extra_args = "--alias=impostor"
+        # Config unchanged; argv still carries only the minted name.
+        cmd = build_command(minimal_config, port=8080)
+        assert cmd.count("--alias") == 1
+        assert _alias_value(cmd) == "test-model"
+
+
 class TestStartServer:
     """Tests for start_server function."""
 
@@ -251,6 +343,10 @@ class TestStartServer:
             mock_popen.assert_called_once()
             call_kwargs = mock_popen.call_args[1]
             assert call_kwargs.get("start_new_session") is True
+            # Issue #120 (EMIT-CANONICAL): the spawned argv carries the
+            # canonical minted name via --alias, byte-for-byte.
+            spawned_argv = mock_popen.call_args[0][0]
+            assert _alias_value(spawned_argv) == minimal_config.name
 
     def test_binary_not_found(self, minimal_config):
         """Server binary not found raises FileNotFoundError."""


### PR DESCRIPTION
## What changed

`build_command` (`llauncher/core/process.py`) now emits `--alias <ModelConfig.name>` in the llama-server argv, immediately after the model path. The value is the llauncher-minted name **byte-for-byte** — no transformation, no sanitization. `start_server` inherits it via the existing pass-through, so every start/swap path picks it up with no orchestration-layer change.

The `--alias` entry in `DENIED_EXTRA_ARG_FLAGS` (`llauncher/models/config.py`) is unparked from its "until #87/#10 land" status (both closed) — but the denial itself is **kept deliberately**: launcher-owned flags stay launcher-owned. A config-supplied `--alias` in `extra_args` would silently override the minted identity, so the C7 deny still rejects it (bare and `=` forms); the rationale comment is updated to present tense.

## EMIT-CANONICAL framing

This is the ecosystem identity keystone (CODE_CONSTITUTION `EMIT-CANONICAL`): `GET /v1/models` must report the canonical name llauncher minted, untransformed, so `local-inference-pool`'s `find_and_acquire(model_id)` can match servers against llauncher's registry. Without `--alias`, llama-server reports the GGUF filename/metadata and identity drifts at the data-plane boundary. The change also guards the mint from below: the lossy `[^\w-] → _` sanitizer used for log *filenames* (`log_path_for`) is proven by test not to leak into the alias.

## Test evidence

New `TestBuildCommandAlias` + extended `TestStartServer.test_normal_start` in `tests/unit/test_process.py`:

- `--alias` present with the exact name, adjacency-asserted (`cmd[idx+1] == name`)
- names with spaces (`"My Local Model 7B"`) and unicode (`"qwen3-中文-モデル-β"`) emitted verbatim — `ModelConfig.name` is an unconstrained `str`, so both are permitted
- a dotted/plus-ed name (`"LFM2-350M-Pro.f16+test"`) is NOT collapsed the way log filenames are
- exactly one `--alias` in argv when benign `extra_args` are present
- `extra_args` carrying `--alias`/`--alias=` is rejected by the C7 deny-list (assignment path), and argv still carries only the minted name
- spawn-level: the argv handed to `subprocess.Popen` carries the alias pair

Gates:
- `python -m pytest tests/ -q`: **1057 passed**, 11 skipped, 1 failed — the single failure is `tests/unit/test_env_var_naming_regression.py::test_no_legacy_env_var_names_in_tracked_source`, which is **pre-existing on `origin/main`** and unrelated: `scripts/systemd/install.sh:110` (introduced by #142, commit `d42fbb7`) mentions the legacy `LAUNCHER_AGENT_*` name in a comment and `scripts/` is not in the test's allowlist. Verified by stashing this branch's changes and re-running: still fails. Fixing it requires touching `install.sh`, which is outside this fix's scope — flagged for a one-line follow-up (reword the comment or allowlist the path).
- `python -m pytest tests/ --cov-fail-under=93`: **94.99%** total coverage, gate passed.

## Runtime smoke

Skipped (honest skip): a smoke harness was prepared (start llama-server from worktree `build_command` with a hostile name on a free high port, CPU-only, tiny local GGUF, curl `/v1/models`), but the execution sandbox for this task denies out-of-worktree writes and the llauncher MCP server tools, so a real server could not be launched from this context. The spawn-argv assertion in `TestStartServer` plus llama-server's documented `--alias` semantics carry the claim; a manual `curl http://<host>:<port>/v1/models` after the next start will show the canonical name.

Fixes #120