### PR TITLE
fix(gpu): split nvidia-smi into valid device + compute-apps queries (#148)

### DIFF
--- a/llauncher/core/gpu.py
+++ b/llauncher/core/gpu.py
@@ -25,6 +25,21 @@ from llauncher.core.process import find_all_llama_servers
 
 
 # ------------------------------------------------------------------
+# NVIDIA query field lists (issue #148)
+#
+# Device fields must all be valid ``--query-gpu`` fields; per-process
+# fields belong to ``--query-compute-apps``. Mixing them (or appending a
+# ``json`` format token) makes nvidia-smi reject the whole query.
+# ------------------------------------------------------------------
+
+_NVIDIA_DEVICE_FIELDS = (
+    "index,name,uuid,driver_version,memory.total,memory.used,memory.free,"
+    "utilization.gpu,temperature.gpu"
+)
+_NVIDIA_PROCESS_FIELDS = "gpu_uuid,pid,process_name,used_gpu_memory"
+
+
+# ------------------------------------------------------------------
 # Data structures
 # ------------------------------------------------------------------
 
@@ -147,9 +162,6 @@ class GPUHealthCollector:
         except subprocess.TimeoutExpired as e:
             logging.debug("NVIDIA query timed out: %s", e)
             return False
-        except json.JSONDecodeError as e:
-            logging.debug("NVIDIA response parse error: %s", e)
-            return False
 
     def _try_ROCM(self, result: GPUHealthResult) -> bool:
         """Attempt to query via rocm-smi."""
@@ -190,11 +202,21 @@ class GPUHealthCollector:
     # ── NVIDIA SMI queries ────────────────────────────────────────
 
     def _query_NVIDIA(self, simulated_output: bool | str = False) -> dict[str, Any]:
-        """Parse ``nvidia-smi --query-gpu=… --format=json`` output.
+        """Query device and per-process VRAM data via two nvidia-smi calls.
 
-        When *simulated_output* is a string, use it directly instead of
-        invoking the CLI (useful for tests).  If ``True``, fall back to
-        built-in test fixtures below.
+        Devices come from ``--query-gpu``; per-process attribution comes
+        from ``--query-compute-apps`` — its fields (``pid``,
+        ``process_name``, ``used_gpu_memory``) are **not** valid device
+        fields, and mixing them into one ``--query-gpu`` call makes
+        nvidia-smi reject the whole query (issue #148). Both calls use
+        ``--format=csv,noheader,nounits``; there is no JSON format token.
+
+        Processes are attributed to devices via GPU UUID (``uuid`` on the
+        device query, ``gpu_uuid`` on the compute-apps query).
+
+        When *simulated_output* is a string it is used as the device-query
+        CSV (no CLI invocation, no process attribution). ``True`` selects
+        the built-in fixture below.
         """
         if simulated_output is True:
             simulated_output = _NVIDIA_DEFAULT_SIMULATED
@@ -202,85 +224,92 @@ class GPUHealthCollector:
         data: dict[str, Any] = {"driver_version": None, "devices": []}
 
         if isinstance(simulated_output, str):
-            parsed = json.loads(simulated_output)
+            device_csv = simulated_output
+            process_csv = ""
         else:
-            try:
-                out = subprocess.run(
-                    [
-                        "nvidia-smi",
-                        "--query-gpu=index,name,memory.total,memory.used,memory.free,"
-                        "utilization.gpu,temperature.gpu,pid,process_name,used_memory_gpu",
-                        "--format=csv,noheader,nounits,json",
-                    ],
-                    capture_output=True, text=True, timeout=10,
-                )
-                parsed = json.loads(out.stdout) if out.returncode == 0 else {"data": []}
-            except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
-                return data
-
-        driver_version = None
-        # Also try the text-based nvidia-smi for driver version.
-        if simulated_output is True or not isinstance(simulated_output, str):
-            try:
-                out2 = subprocess.run(
-                    ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
-                    capture_output=True, text=True, timeout=5,
-                )
-                if out2.returncode == 0:
-                    lines = [l.strip() for l in out2.stdout.splitlines()]
-                    driver_version = lines[0] if lines else None
-            except (PermissionError, FileNotFoundError) as e:
-                logging.debug("NVIDIA driver_version query failed: %s", e)
-            except subprocess.TimeoutExpired as e:
-                logging.debug("NVIDIA driver_version query timed out: %s", e)
-
-        data["driver_version"] = driver_version or (parsed.get("driver_version") if isinstance(parsed, dict) else None)
-        devices_data = parsed.get("data", []) if isinstance(parsed, dict) else parsed
-
-        for entry in devices_data:
-            # CSV format uses positional list; JSON format uses dict keys.
-            if isinstance(entry, list):
-                idx, name, total_mb, used_mb, free_mb, util, temp, pid, pname, gpu_used = (
-                    str(entry[0]),  # index
-                    str(entry[1]),  # name
-                    _to_int(entry[2]) or 0,   # memory.total
-                    _to_int(entry[3]) or 0,   # memory.used
-                    _to_int(entry[4]) or 0,   # memory.free
-                    _to_float(entry[5]) or 0.0, # utilization.gpu
-                    _to_float(entry[6]),       # temperature.gpu (may be None)
-                    str(entry[7]) if entry[7] else "",  # pid
-                    str(entry[8]) if entry[8] else "",  # process_name
-                    _to_int(entry[9]) or 0,   # used_memory_gpu (optional)
-                )
-            elif isinstance(entry, dict):
-                idx = str(entry.get("index", "0"))
-                name = entry.get("name", "Unknown")
-                total_mb = _to_int(entry.get("memory.total")) or 0
-                used_mb = _to_int(entry.get("memory.used")) or 0
-                free_mb = _to_int(entry.get("memory.free")) or 0
-                util = _to_float(entry.get("utilization.gpu")) or 0.0
-                temp = _to_float(entry.get("temperature.gpu"))
-                pid = str(entry.get("pid", ""))
-                pname = entry.get("process_name", "") or ""
-                gpu_used = _to_int(entry.get("used_memory_gpu")) or 0
-
-            dev = GPUDevice(
-                index=int(idx), name=name, total_vram_mb=total_mb,
-                used_vram_mb=used_mb, free_vram_mb=max(free_mb, 0),
-                utilization_pct=util, temperature_c=temp if temp else None,
+            device_csv = self._run_nvidia_smi_csv(
+                "--query-gpu=" + _NVIDIA_DEVICE_FIELDS
             )
-            # Process info: nvidia-smi returns per-device process lists.
-            # When using CSV with PIDs we build a simple list below.
-            if pid and pname:
-                dev.processes.append({
-                    "pid": int(pid),
-                    "name": pname,
-                    "used_memory_mb": gpu_used or used_mb,
-                })
+            if device_csv is None:
+                return data
+            # A compute-apps failure must not discard device data: the
+            # device query already succeeded, so degrade to "no process
+            # attribution" instead of losing the backend.
+            try:
+                process_csv = self._run_nvidia_smi_csv(
+                    "--query-compute-apps=" + _NVIDIA_PROCESS_FIELDS
+                ) or ""
+            except subprocess.TimeoutExpired as e:
+                logging.debug("nvidia-smi compute-apps query timed out: %s", e)
+                process_csv = ""
 
+        devices_by_uuid: dict[str, GPUDevice] = {}
+        for row in _csv_rows(device_csv):
+            # index, name, uuid, driver_version, memory.total, memory.used,
+            # memory.free, utilization.gpu, temperature.gpu
+            if len(row) != 9:
+                logging.debug(
+                    "nvidia-smi device row malformed (want 9 fields, got %d): %r",
+                    len(row), row,
+                )
+                continue
+            idx = _to_int(row[0])
+            if idx is None:
+                logging.debug("nvidia-smi device row has non-numeric index: %r", row)
+                continue
+            dev = GPUDevice(
+                index=idx,
+                name=row[1],
+                total_vram_mb=_to_int(row[4]) or 0,
+                used_vram_mb=_to_int(row[5]) or 0,
+                free_vram_mb=max(_to_int(row[6]) or 0, 0),
+                utilization_pct=_to_float(row[7]) or 0.0,
+                temperature_c=_to_float(row[8]),
+            )
+            if data["driver_version"] is None and row[3]:
+                data["driver_version"] = row[3]
+            devices_by_uuid[row[2]] = dev
             data["devices"].append(dev)
 
+        for row in _csv_rows(process_csv):
+            # gpu_uuid, pid, process_name, used_gpu_memory
+            if len(row) != 4:
+                logging.debug(
+                    "nvidia-smi compute-apps row malformed (want 4 fields, got %d): %r",
+                    len(row), row,
+                )
+                continue
+            dev = devices_by_uuid.get(row[0])
+            pid = _to_int(row[1])
+            pname = row[2]
+            if dev is None or pid is None or not pname:
+                logging.debug("nvidia-smi compute-apps row unattributable: %r", row)
+                continue
+            dev.processes.append({
+                "pid": pid,
+                "name": pname,
+                "used_memory_mb": _to_int(row[3]) or 0,
+            })
+
         return data
+
+    def _run_nvidia_smi_csv(self, query_arg: str) -> str | None:
+        """Run one nvidia-smi CSV query; return stdout, or None on failure.
+
+        ``FileNotFoundError`` / ``TimeoutExpired`` propagate to
+        ``_try_NVIDIA``, which treats the backend as unavailable.
+        """
+        out = subprocess.run(
+            ["nvidia-smi", query_arg, "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if out.returncode != 0:
+            logging.debug(
+                "nvidia-smi %s failed (rc=%d): %s",
+                query_arg, out.returncode, (out.stderr or "").strip(),
+            )
+            return None
+        return out.stdout
 
     def _query_ROCM(self) -> dict[str, Any]:
         """Parse ``rocm-smi --showmeminfo=volatile`` output."""
@@ -423,6 +452,17 @@ def _estimate_apple_unified_mem() -> int:
     return 8192
 
 
+def _csv_rows(text: str) -> list[list[str]]:
+    """Split nvidia-smi CSV output into stripped cell rows, skipping blanks."""
+    rows: list[list[str]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append([cell.strip() for cell in line.split(",")])
+    return rows
+
+
 def _to_int(v) -> int | None:
     try:
         if v is None or v == "":
@@ -442,45 +482,19 @@ def _to_float(v) -> float | None:
 
 
 # ── Simulated NVIDIA output for tests ─────────────────────────
+# Device-query CSV in _NVIDIA_DEVICE_FIELDS order:
+# index, name, uuid, driver_version, memory.total, memory.used,
+# memory.free, utilization.gpu, temperature.gpu
 
-_NVIDIA_DEFAULT_SIMULATED = json.dumps({
-    "driver_version": "535.129.03",
-    "data": [
-        {
-            "index": "0",
-            "name": "NVIDIA GeForce RTX 4090",
-            "memory.total": "24564",
-            "memory.used": "4200",
-            "memory.free": "20364",
-            "utilization.gpu": "12.5",
-            "temperature.gpu": "42",
-            "pid": "",
-            "process_name": "",
-        }
-    ],
-})
+_NVIDIA_DEFAULT_SIMULATED = (
+    "0, NVIDIA GeForce RTX 4090, GPU-11111111-2222-3333-4444-555555555555, "
+    "535.129.03, 24564, 4200, 20364, 12.5, 42\n"
+)
 
 
-_NVIDIA_MULTI_GPU_SIMULATED = json.dumps({
-    "driver_version": "535.129.03",
-    "data": [
-        {
-            "index": "0",
-            "name": "NVIDIA GeForce RTX 4090",
-            "memory.total": "24564",
-            "memory.used": "4200",
-            "memory.free": "20364",
-            "utilization.gpu": "12.5",
-            "temperature.gpu": "42",
-        },
-        {
-            "index": "1",
-            "name": "NVIDIA GeForce RTX 4090",
-            "memory.total": "24564",
-            "memory.used": "8100",
-            "memory.free": "16464",
-            "utilization.gpu": "45.0",
-            "temperature.gpu": "55",
-        },
-    ],
-})
+_NVIDIA_MULTI_GPU_SIMULATED = (
+    "0, NVIDIA GeForce RTX 4090, GPU-11111111-2222-3333-4444-555555555555, "
+    "535.129.03, 24564, 4200, 20364, 12.5, 42\n"
+    "1, NVIDIA GeForce RTX 4090, GPU-66666666-7777-8888-9999-aaaaaaaaaaaa, "
+    "535.129.03, 24564, 8100, 16464, 45.0, 55\n"
+)

--- a/llauncher/core/gpu.py
+++ b/llauncher/core/gpu.py
@@ -242,6 +242,9 @@ class GPUHealthCollector:
             except subprocess.TimeoutExpired as e:
                 logging.debug("nvidia-smi compute-apps query timed out: %s", e)
                 process_csv = ""
+            except (FileNotFoundError, PermissionError) as e:
+                logging.debug("nvidia-smi compute-apps query failed: %s", e)
+                process_csv = ""
 
         devices_by_uuid: dict[str, GPUDevice] = {}
         for row in _csv_rows(device_csv):

--- a/tests/integration/test_gpu_real_nvidia_smi.py
+++ b/tests/integration/test_gpu_real_nvidia_smi.py
@@ -1,0 +1,95 @@
+"""Real-hardware grounding for the nvidia-smi query shape (issue #148).
+
+These tests run the **real** ``nvidia-smi`` binary and skip cleanly on
+hosts without one. They exist because #148 was exactly the failure mode a
+mocked suite cannot see: every parse-path unit test passed while the real
+binary rejected the query string outright (per-process fields mixed into
+``--query-gpu`` plus a bogus ``json`` format token), leaving ``devices``
+permanently empty and VRAM monitoring non-functional.
+
+Contract pinned here, against the real binary:
+
+- the exact device field list ``core.gpu`` builds is accepted by
+  ``--query-gpu``;
+- the exact per-process field list is accepted by ``--query-compute-apps``;
+- the *old* broken query is rejected (regression pin — if a future
+  nvidia-smi started accepting it, the unit-level pin still holds the
+  two-query split);
+- end-to-end: ``GPUHealthCollector.refresh()`` on real hardware yields a
+  populated ``devices`` list with plausible VRAM numbers.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from llauncher.core import gpu as gpu_mod
+from llauncher.core.gpu import (
+    GPUHealthCollector,
+    _NVIDIA_DEVICE_FIELDS,
+    _NVIDIA_PROCESS_FIELDS,
+)
+
+
+requires_nvidia_smi = pytest.mark.skipif(
+    shutil.which("nvidia-smi") is None,
+    reason="real nvidia-smi binary not on PATH",
+)
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["nvidia-smi", *args], capture_output=True, text=True, timeout=10,
+    )
+
+
+@pytest.mark.integration
+@requires_nvidia_smi
+class TestRealNvidiaSmiAcceptsOurQueries:
+    def test_device_query_fields_are_valid(self):
+        out = _run([
+            "--query-gpu=" + _NVIDIA_DEVICE_FIELDS,
+            "--format=csv,noheader,nounits",
+        ])
+        assert out.returncode == 0, f"device query rejected: {out.stderr!r}"
+        rows = gpu_mod._csv_rows(out.stdout)
+        assert rows, "expected at least one GPU row on this host"
+        assert all(len(r) == 9 for r in rows), rows
+
+    def test_compute_apps_query_fields_are_valid(self):
+        out = _run([
+            "--query-compute-apps=" + _NVIDIA_PROCESS_FIELDS,
+            "--format=csv,noheader,nounits",
+        ])
+        # Empty stdout is fine (no compute apps running) — the field list
+        # itself must be accepted.
+        assert out.returncode == 0, f"compute-apps query rejected: {out.stderr!r}"
+
+    def test_old_broken_query_is_rejected(self):
+        """Regression pin for the #148 bug shape against the real binary."""
+        out = _run([
+            "--query-gpu=index,name,memory.total,memory.used,memory.free,"
+            "utilization.gpu,temperature.gpu,pid,process_name,used_memory_gpu",
+            "--format=csv,noheader,nounits,json",
+        ])
+        assert out.returncode != 0, (
+            "nvidia-smi now accepts the previously-invalid query; "
+            "re-evaluate the regression pin"
+        )
+
+
+@pytest.mark.integration
+@requires_nvidia_smi
+class TestRealCollectorEndToEnd:
+    def test_refresh_populates_devices_with_vram(self):
+        health = GPUHealthCollector().refresh()
+        assert "nvidia" in health.backends
+        assert health.devices, "real GPU present but devices empty (#148 shape)"
+        dev = health.devices[0]
+        assert dev.total_vram_mb > 0
+        assert 0 <= dev.used_vram_mb <= dev.total_vram_mb
+        assert 0 < dev.free_vram_mb <= dev.total_vram_mb
+        assert dev.driver_version, "driver_version should be attached to device 0"

--- a/tests/unit/test_gpu_health_extended.py
+++ b/tests/unit/test_gpu_health_extended.py
@@ -216,6 +216,25 @@ class TestNVIDIACSVPath:
         assert len(out["devices"]) == 2
         assert all(d.processes == [] for d in out["devices"])
 
+    @pytest.mark.parametrize("exc", [FileNotFoundError, PermissionError])
+    def test_query_nvidia_process_query_oserror_keeps_devices(self, exc):
+        """PR #159 review: an OS-level error (FileNotFoundError /
+        PermissionError) on the compute-apps query must not bubble up and
+        discard the already-collected device data — attribution degrades
+        to empty instead."""
+
+        def _run(cmd, **kwargs):
+            if cmd[1].startswith("--query-gpu="):
+                return SimpleNamespace(
+                    returncode=0, stdout=_DEVICE_CSV_TWO_GPUS, stderr="")
+            raise exc("nvidia-smi vanished between queries")
+
+        collector = GPUHealthCollector()
+        with patch.object(gpu_mod.subprocess, "run", side_effect=_run):
+            out = collector._query_NVIDIA(simulated_output=False)
+        assert len(out["devices"]) == 2
+        assert all(d.processes == [] for d in out["devices"])
+
 
 # ---------------------------------------------------------------------------
 # Backend probes: short-circuit when CLI absent

--- a/tests/unit/test_gpu_health_extended.py
+++ b/tests/unit/test_gpu_health_extended.py
@@ -2,8 +2,8 @@
 
 Targets uncovered branches identified in the Phase B coverage baseline:
 
-- ``_query_NVIDIA`` CSV (list) entry parsing, including pid/process attribution.
-- ``_query_NVIDIA`` falls through ``json.JSONDecodeError`` from subprocess output.
+- ``_query_NVIDIA`` two-query CSV parsing (devices + compute-apps), including
+  uuid-keyed pid/process attribution and the #148 valid-field regression pin.
 - ``_try_NVIDIA``/``_try_ROCM``/``_try_MPS`` short-circuit when binaries absent.
 - ``_query_ROCM`` parse heuristic (single GPU line) and non-zero returncode.
 - ``_query_MPS`` returns empty when ``is_apple_mps_available`` is False.
@@ -16,7 +16,6 @@ Targets uncovered branches identified in the Phase B coverage baseline:
 
 from __future__ import annotations
 
-import json
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -71,42 +70,151 @@ class TestToFloatCoercion:
 
 
 # ---------------------------------------------------------------------------
-# NVIDIA CSV path + pid attribution
+# NVIDIA CSV path: two-query shape, parsing, pid attribution (issue #148)
 # ---------------------------------------------------------------------------
 
+_UUID_0 = "GPU-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+_UUID_1 = "GPU-11111111-2222-3333-4444-555555555555"
+
+_DEVICE_CSV_TWO_GPUS = (
+    f"0, Quadro RTX 8000, {_UUID_0}, 550.00, 46080, 4200, 41880, 12.5, 42\n"
+    f"1, Quadro RTX 8000, {_UUID_1}, 550.00, 46080, 8100, 37980, 45.0, 55\n"
+)
+
+_PROCESS_CSV = (
+    f"{_UUID_1}, 1234, /usr/local/bin/llama-server, 2048\n"
+)
+
+
+def _fake_smi_run(device_csv: str, process_csv: str):
+    """Return a subprocess.run stand-in serving the two nvidia-smi queries."""
+
+    def _run(cmd, **kwargs):
+        query_arg = cmd[1]
+        if query_arg.startswith("--query-gpu="):
+            return SimpleNamespace(returncode=0, stdout=device_csv, stderr="")
+        if query_arg.startswith("--query-compute-apps="):
+            return SimpleNamespace(returncode=0, stdout=process_csv, stderr="")
+        raise AssertionError(f"unexpected nvidia-smi query: {cmd}")
+
+    return _run
+
+
 class TestNVIDIACSVPath:
-    def test_query_nvidia_csv_list_entry_attaches_process(self):
-        """When entry is a list (CSV form), pid/pname become a process record."""
-        sim = json.dumps({
-            "driver_version": "550.00",
-            "data": [
-                ["0", "RTX 4090", "24564", "4200", "20364", "12.5", "42",
-                 "1234", "llama-server", "2048"],
-            ],
-        })
+    def test_query_nvidia_valid_output_populates_devices(self):
+        """Real-shaped CSV from both queries → devices + uuid-mapped process."""
         collector = GPUHealthCollector()
-        out = collector._query_NVIDIA(simulated_output=sim)
-        assert len(out["devices"]) == 1
-        dev = out["devices"][0]
-        assert dev.index == 0
-        assert dev.processes == [
-            {"pid": 1234, "name": "llama-server", "used_memory_mb": 2048},
+        with patch.object(
+            gpu_mod.subprocess, "run",
+            side_effect=_fake_smi_run(_DEVICE_CSV_TWO_GPUS, _PROCESS_CSV),
+        ):
+            out = collector._query_NVIDIA(simulated_output=False)
+
+        assert out["driver_version"] == "550.00"
+        assert len(out["devices"]) == 2
+        dev0, dev1 = out["devices"]
+        assert (dev0.index, dev0.name) == (0, "Quadro RTX 8000")
+        assert dev0.total_vram_mb == 46080
+        assert dev0.free_vram_mb == 41880
+        assert dev0.utilization_pct == 12.5
+        assert dev0.temperature_c == 42
+        # Process attributed to device 1 via gpu_uuid, not device 0.
+        assert dev0.processes == []
+        assert dev1.processes == [
+            {"pid": 1234, "name": "/usr/local/bin/llama-server",
+             "used_memory_mb": 2048},
         ]
 
-    def test_query_nvidia_csv_no_pid_no_process_list(self):
-        sim = json.dumps({
-            "data": [
-                ["1", "GPU-1", "8192", "1024", "7168", "0", "-",
-                 "", "", "0"],
-            ],
-        })
+    def test_query_nvidia_uses_valid_fields_only(self):
+        """Pin the #148 bug shape: no per-process fields or json token in
+        the device query; per-process fields go to --query-compute-apps."""
         collector = GPUHealthCollector()
-        out = collector._query_NVIDIA(simulated_output=sim)
+        calls: list[list[str]] = []
+
+        def _capture(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(gpu_mod.subprocess, "run", side_effect=_capture):
+            collector._query_NVIDIA(simulated_output=False)
+
+        assert len(calls) == 2
+        device_cmd, process_cmd = calls
+        assert device_cmd[0] == "nvidia-smi"
+        # Format token: CSV only — "json" is not a valid nvidia-smi format.
+        assert device_cmd[2] == "--format=csv,noheader,nounits"
+        assert process_cmd[2] == "--format=csv,noheader,nounits"
+        # Device query carries no per-process fields.
+        device_fields = device_cmd[1].removeprefix("--query-gpu=").split(",")
+        for bogus in ("pid", "process_name", "used_memory_gpu", "used_gpu_memory"):
+            assert bogus not in device_fields
+        # Per-process fields live on the compute-apps query.
+        assert process_cmd[1] == (
+            "--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory"
+        )
+
+    def test_query_nvidia_empty_output_yields_no_devices(self):
+        collector = GPUHealthCollector()
+        with patch.object(
+            gpu_mod.subprocess, "run", side_effect=_fake_smi_run("", ""),
+        ):
+            out = collector._query_NVIDIA(simulated_output=False)
+        assert out == {"driver_version": None, "devices": []}
+
+    def test_query_nvidia_malformed_rows_skipped(self):
+        """Short rows, non-numeric index, and unattributable processes are
+        skipped without crashing; valid rows still parse."""
+        device_csv = (
+            "garbage line without enough fields\n"
+            f"NaN, Bad Index GPU, {_UUID_1}, 550.00, 1, 1, 1, 0, 0\n"
+            f"1, Good GPU, {_UUID_0}, 550.00, 8192, 1024, 7168, 0, [N/A]\n"
+        )
+        process_csv = (
+            "too, few\n"
+            f"{_UUID_1}, 99, ghost-device-process, 10\n"   # uuid not in devices
+            f"{_UUID_0}, , no-pid, 10\n"                    # missing pid
+        )
+        collector = GPUHealthCollector()
+        with patch.object(
+            gpu_mod.subprocess, "run",
+            side_effect=_fake_smi_run(device_csv, process_csv),
+        ):
+            out = collector._query_NVIDIA(simulated_output=False)
+
+        assert len(out["devices"]) == 1
         dev = out["devices"][0]
         assert dev.index == 1
-        assert dev.processes == []
-        # temperature.gpu was "-" → coerced to None
+        assert dev.free_vram_mb == 7168
+        # temperature.gpu "[N/A]" → coerced to None
         assert dev.temperature_c is None
+        assert dev.processes == []
+
+    def test_query_nvidia_device_query_failure_returns_empty(self):
+        """Non-zero returncode on the device query → clean empty result,
+        and the compute-apps query is not attempted."""
+        collector = GPUHealthCollector()
+        fake_run = MagicMock(return_value=SimpleNamespace(
+            returncode=6, stdout="", stderr='Field "pid" is not a valid field to query.',
+        ))
+        with patch.object(gpu_mod.subprocess, "run", fake_run):
+            out = collector._query_NVIDIA(simulated_output=False)
+        assert out == {"driver_version": None, "devices": []}
+        assert fake_run.call_count == 1
+
+    def test_query_nvidia_process_query_failure_keeps_devices(self):
+        """Compute-apps query failing must not discard device data."""
+
+        def _run(cmd, **kwargs):
+            if cmd[1].startswith("--query-gpu="):
+                return SimpleNamespace(
+                    returncode=0, stdout=_DEVICE_CSV_TWO_GPUS, stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+        collector = GPUHealthCollector()
+        with patch.object(gpu_mod.subprocess, "run", side_effect=_run):
+            out = collector._query_NVIDIA(simulated_output=False)
+        assert len(out["devices"]) == 2
+        assert all(d.processes == [] for d in out["devices"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_phase_d_coverage.py
+++ b/tests/unit/test_phase_d_coverage.py
@@ -77,16 +77,6 @@ class TestTryNvidiaExceptionPaths:
              ):
             assert collector._try_NVIDIA(result) is False
 
-    def test_json_decode_error_returns_false(self):
-        collector, result = self._setup()
-        with patch.object(gpu_mod, "shutil_which", return_value="/usr/bin/nvidia-smi"), \
-             patch.object(
-                 collector, "_query_NVIDIA",
-                 side_effect=json.JSONDecodeError("boom", "doc", 0),
-             ):
-            assert collector._try_NVIDIA(result) is False
-
-
 class TestTryRocmExceptionPaths:
     """_try_ROCM exception handlers (158-170)."""
 
@@ -121,47 +111,37 @@ class TestTryMpsExceptionPaths:
             assert collector._try_MPS(result) is False
 
 
-class TestNvidiaDriverVersionSecondarySubprocess:
-    """Driver-version secondary nvidia-smi call (gpu.py L223-235).
+class TestNvidiaComputeAppsSecondarySubprocess:
+    """Secondary nvidia-smi call (``--query-compute-apps``, issue #148).
 
-    The secondary ``subprocess.run`` (driver_version query) only runs when
-    ``simulated_output`` is falsy (default ``False``) — i.e. the primary
-    query path actually invoked the CLI. Tests below drive ``_query_NVIDIA``
-    with ``simulated_output=False`` and stub ``subprocess.run`` with a
-    side-effect sequence: first call returns valid JSON, second call raises
-    the handled exception, exercising the L232 / L234 except branches.
+    The compute-apps query only runs when ``simulated_output`` is falsy
+    (default ``False``) — i.e. the device query actually invoked the CLI
+    and succeeded. A secondary failure must degrade to "no process
+    attribution", never discard the already-collected devices.
     """
 
-    _PRIMARY_JSON = json.dumps({"data": [
-        ["0", "Sim GPU", "8000", "100", "7900", "10.0", "55.0", "", "", "0"],
-    ]})
+    _PRIMARY_CSV = (
+        "0, Sim GPU, GPU-00000000-0000-0000-0000-000000000000, "
+        "550.00, 8000, 100, 7900, 10.0, 55.0\n"
+    )
 
     def _primary_ok(self):
-        return SimpleNamespace(returncode=0, stdout=self._PRIMARY_JSON, stderr="")
+        return SimpleNamespace(returncode=0, stdout=self._PRIMARY_CSV, stderr="")
 
-    def test_driver_version_filenotfound_swallowed(self):
-        """L232 — secondary subprocess FileNotFoundError handled; devices kept."""
-        collector = GPUHealthCollector()
-        with patch.object(
-            gpu_mod.subprocess, "run",
-            side_effect=[self._primary_ok(), FileNotFoundError()],
-        ):
-            data = collector._query_NVIDIA(simulated_output=False)
-        assert len(data["devices"]) == 1
-        assert data["driver_version"] is None
-
-    def test_driver_version_timeout_swallowed(self):
-        """L234 — secondary subprocess TimeoutExpired handled; devices kept."""
+    def test_compute_apps_timeout_swallowed(self):
+        """Secondary subprocess TimeoutExpired handled; devices kept."""
         collector = GPUHealthCollector()
         with patch.object(
             gpu_mod.subprocess, "run",
             side_effect=[
                 self._primary_ok(),
-                subprocess.TimeoutExpired(cmd="nvidia-smi", timeout=5),
+                subprocess.TimeoutExpired(cmd="nvidia-smi", timeout=10),
             ],
         ):
             data = collector._query_NVIDIA(simulated_output=False)
         assert len(data["devices"]) == 1
+        assert data["devices"][0].processes == []
+        assert data["driver_version"] == "550.00"
 
 
 class TestGPUDeviceToDict:


### PR DESCRIPTION
## Problem (#148)

`_query_NVIDIA` built one `nvidia-smi --query-gpu` call that mixed per-process fields (`pid`, `process_name`, `used_memory_gpu`) into the device query and appended a bogus `json` format token. nvidia-smi rejects the whole call (`Field "pid" is not a valid field to query.`), the parse fell through to empty, and `GPUHealthCollector` reported `backends: ["nvidia"]` with `devices: []` — no VRAM visibility, silent ADR-006 preflight no-op, broken `/status` GPU data.

## Fix

Two correct CSV queries in `llauncher/core/gpu.py`, per the issue's suggested scope:

- **Devices:** `--query-gpu=index,name,uuid,driver_version,memory.total,memory.used,memory.free,utilization.gpu,temperature.gpu --format=csv,noheader,nounits`
- **Per-process:** `--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory --format=csv,noheader,nounits`, attributed to devices by GPU UUID (correct on multi-GPU hosts)
- `driver_version` folded into the device query — drops the previous driver-only third subprocess call
- CSV-only parsing (`_csv_rows`); malformed rows skipped with debug logging
- Compute-apps failure degrades to "no process attribution" rather than discarding already-collected devices; device-query failure returns a clean empty result (loudness is #150's scope)
- Removed the now-unreachable `json.JSONDecodeError` handler in `_try_NVIDIA`

## Tests

- **Unit** (`test_gpu_health_extended.py`, `test_phase_d_coverage.py`): valid output, empty output, malformed rows (short row, non-numeric index, `[N/A]`, unattributable process rows), device-query failure (no second call), process-query failure keeps devices, secondary-timeout swallowed, and a regression pin asserting the device query contains no per-process fields and no `json` format token.
- **Integration** (`tests/integration/test_gpu_real_nvidia_smi.py`, skipif no `nvidia-smi`): both field lists accepted by the real binary; the old broken query pinned as *rejected*; end-to-end `refresh()` populates devices on real hardware.

## Real-hardware evidence (RTX 8000 host, driver 580.159.04)

```json
{"backends": ["nvidia"], "devices": [{"index": 0, "name": "Quadro RTX 8000",
  "total_vram_mb": 49152, "used_vram_mb": 39893, "free_vram_mb": 8506,
  "temperature_c": 57.0, "driver_version": "580.159.04",
  "processes": [
    {"pid": 1137691, "name": ".../llama-server", "used_memory_mb": 1416},
    {"pid": 1482139, "name": ".../llama-server", "used_memory_mb": 36064}]}]}
```

## Gates

- `python -m pytest tests/ -q`: 1056 passed, 11 skipped, **1 pre-existing failure unrelated to this change** — `test_no_legacy_env_var_names_in_tracked_source` trips on `scripts/systemd/install.sh:110` (comment text added in d42fbb7, before this branch; file untouched here, left out of scope deliberately).
- Coverage: **94.97%** (floor 93) — `Required test coverage of 93% reached.`

## Notes for #150 (chained)

- `_query_NVIDIA` still returns `{"driver_version": None, "devices": []}` on device-query failure and `_try_NVIDIA` then reports the backend as available with zero devices — preflight currently can't distinguish "no GPU data" from "plenty of free VRAM". `_run_nvidia_smi_csv` is the seam that knows about failure (returncode + stderr, debug-logged); surfacing that distinction is where fail-loud should hook in.

Fixes #148