### PR TITLE
fix(process): make model-name to log-filename mapping injective

### DIFF
--- a/llauncher/core/log_rotation.py
+++ b/llauncher/core/log_rotation.py
@@ -1,6 +1,8 @@
 """Size-based rotation for llauncher per-server log files (ADR-013).
 
-Each `llama-server` process writes to ``{LOG_DIR}/{name}-{port}.log``.
+Each `llama-server` process writes to ``{LOG_DIR}/{stem}-{port}.log``,
+where ``stem`` comes from :func:`llauncher.core.process.log_stem_for`
+(sanitized model name plus a short hash — issues #63/#146).
 Logs are now opened in append mode (so a restart does not destroy the
 previous run's output), which means files grow unboundedly without
 intervention. This module provides a simple size-cap rotation:

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -1,5 +1,6 @@
 """Process management for llama-server instances."""
 
+import hashlib
 import re
 import shlex
 import subprocess
@@ -174,24 +175,52 @@ def build_command(
     return cmd
 
 
+# Hex chars of SHA-256 kept in the log filename stem. 8 chars = 32 bits:
+# more than enough to separate the handful of model configs a single
+# launcher manages, while staying short enough to keep filenames readable.
+_NAME_HASH_LEN = 8
+
+
+def log_stem_for(config_name: str) -> str:
+    """Return the filename stem for ``config_name``: ``{sanitized}-{hash}``.
+
+    The **single mint** for the model-name → log-filename mapping (issues
+    #63 / #146). Every path that writes, reads, or globs a per-server log
+    file derives the name through here — :func:`log_path_for` (writer +
+    readiness reader) and :func:`stream_logs` (name-keyed glob). Do not
+    re-implement this transform elsewhere.
+
+    The mapping is **injective in practice**: the sanitized prefix keeps
+    the filename human-readable/greppable, and the suffix — the first
+    ``_NAME_HASH_LEN`` hex chars of the SHA-256 of the *exact* canonical
+    name — separates names the lossy sanitizer would otherwise collapse
+    (``model.a`` vs ``model_a`` both sanitize to ``model_a`` but hash
+    apart). The canonical name itself (``ModelConfig.name``) is never
+    constrained or altered; only this envelope-side mapping disambiguates.
+
+    The result contains only ``[A-Za-z0-9_-]`` characters, so it is safe
+    to embed literally in a glob pattern (no metacharacters survive the
+    sanitizer, and the hex digest has none).
+    """
+    sanitized = re.sub(r"[^\w\-]", "_", config_name)
+    digest = hashlib.sha256(config_name.encode("utf-8")).hexdigest()
+    return f"{sanitized}-{digest[:_NAME_HASH_LEN]}"
+
+
 def log_path_for(config_name: str, port: int) -> Path:
     """Return the canonical per-server log path for ``(config_name, port)``.
 
-    Single source of truth for the log filename so that the readiness check
+    Single source of truth for the log *path* so that the readiness check
     (:func:`wait_for_server_ready`) reads exactly the file that
     :func:`start_server` writes — see issue #145, where a swap left two
     ``*-{port}.log`` files and a port-only glob could read the stopped
     occupant's log instead of the new one.
 
-    NOTE: the sanitization is *lossy* — ``re.sub`` collapses every non
-    ``[\\w-]`` character to ``_``, so distinct config names that differ
-    only in those characters (e.g. ``LFM2-350M-Pro.f16`` vs
-    ``LFM2-350M-Pro_f16``) map to the same file. That name-collision hazard
-    is tracked as a separate issue; it is safe *here* only because the
-    identical transform is applied on both the write side and the read side.
+    The filename stem comes from :func:`log_stem_for`, which is injective
+    over config names — distinct models never share a log file even when
+    their sanitized names collide (issues #63 / #146).
     """
-    sanitized_name = re.sub(r"[^\w\-]", "_", config_name)
-    return (LOG_DIR / f"{sanitized_name}-{port}.log").resolve()
+    return (LOG_DIR / f"{log_stem_for(config_name)}-{port}.log").resolve()
 
 
 def _newest_log(paths) -> Path | None:
@@ -481,17 +510,17 @@ def stream_logs(pid: int | None = None, model_name: str | None = None, lines: in
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 
-    # If model name provided, search for matching log files. Sanitize the
-    # name with the SAME transform start_server uses (log_path_for): the
-    # files on disk are stored sanitized, and an un-sanitized glob would
-    # both miss the real file (``LFM2-350M-Pro.f16`` vs the stored
-    # ``LFM2-350M-Pro_f16``) and risk interpreting name characters like
-    # ``[`` as glob metacharacters. When several match (a name reused
-    # across runs), prefer the most recently written — glob order is
+    # If model name provided, search for matching log files. Derive the
+    # stem with the SAME mint start_server uses (log_stem_for): the files
+    # on disk are stored under the sanitized-plus-hash stem, and a raw
+    # glob would both miss the real file (``LFM2-350M-Pro.f16`` vs the
+    # stored ``LFM2-350M-Pro_f16-<hash>``) and risk interpreting name
+    # characters like ``[`` as glob metacharacters — the stem is
+    # metachar-free by construction. When several match (a name reused
+    # across ports), prefer the most recently written — glob order is
     # otherwise arbitrary (issue #145).
     if model_name is not None and port is None:
-        safe_name = re.sub(r"[^\w\-]", "_", model_name)
-        match = _newest_log(LOG_DIR.glob(f"{safe_name}-*.log"))
+        match = _newest_log(LOG_DIR.glob(f"{log_stem_for(model_name)}-*.log"))
         if match is not None:
             return _tail_file(match, lines)
 

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -80,7 +80,8 @@ LAUNCHER_AUDIT_PATH = Path(os.getenv(
 ))
 
 # Per-server log directory (ADR-013). Files inside are
-# ``{name}-{port}.log`` plus rotated siblings ``{name}-{port}.log.{N}``.
+# ``{stem}-{port}.log`` plus rotated siblings ``{stem}-{port}.log.{N}``,
+# where ``stem`` is minted by ``core.process.log_stem_for`` (#63/#146).
 # Configurable via env so container deployments can volume-mount it the
 # same way as ``LAUNCHER_RUN_DIR`` and ``LAUNCHER_AUDIT_PATH``.
 LAUNCHER_LOG_DIR = Path(os.getenv(

--- a/tests/integration/test_mcp_flows.py
+++ b/tests/integration/test_mcp_flows.py
@@ -22,6 +22,7 @@ import pytest
 from llauncher.core import audit_log as al
 from llauncher.core import lockfile as lf
 from llauncher.core import marker as mk
+from llauncher.core.process import log_stem_for
 
 
 pytestmark = pytest.mark.integration
@@ -48,8 +49,9 @@ async def test_start_server_happy_path_via_mcp(mcp_env, register_model, mcp_disp
         assert claim is not None and claim.model == "alpha"
 
         # Log file appears with the stub's fixture banner. ``start`` does
-        # not wait for readiness, so we poll briefly for the banner.
-        log_files = list(mcp_env["log_dir"].glob(f"alpha-{port}.log"))
+        # not wait for readiness, so we poll briefly for the banner. The
+        # filename comes from the one mint (core.process.log_stem_for).
+        log_files = list(mcp_env["log_dir"].glob(f"{log_stem_for('alpha')}-{port}.log"))
         assert log_files, "log file not created"
         deadline = time.monotonic() + 3.0
         content = ""

--- a/tests/regression/test_logs_lifecycle_regression.py
+++ b/tests/regression/test_logs_lifecycle_regression.py
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from llauncher.core.process import start_server
+from llauncher.core.process import log_stem_for, start_server
 from llauncher.models.config import ModelConfig
 
 
@@ -182,7 +182,7 @@ def test_rotation_runs_before_banner_write(
     mock_bin.exists.return_value = True
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    log_file = log_dir / "test-model-8081.log"
+    log_file = log_dir / f"{log_stem_for('test-model')}-8081.log"
     # Pre-existing oversized content.
     log_file.write_text("X" * 500)
 
@@ -218,4 +218,4 @@ def test_rotation_runs_before_banner_write(
         f"rotation must precede banner write; order={call_order}"
     )
     # Rotation actually happened (file is .log.1 now).
-    assert (log_dir / "test-model-8081.log.1").exists()
+    assert (log_dir / f"{log_stem_for('test-model')}-8081.log.1").exists()

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -8,6 +8,7 @@ import psutil
 from llauncher.core.process import (
     find_available_port,
     build_command,
+    log_stem_for,
     start_server,
     stop_server_by_port,
     stop_server_by_pid,
@@ -837,8 +838,8 @@ class TestStartServerLogsLifecycle:
 
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
-        # Sanitized name for "test-model" is "test-model" (kept as-is).
-        existing_log = log_dir / "test-model-8081.log"
+        # Stem derived via the one mint (sanitized name + short hash).
+        existing_log = log_dir / f"{log_stem_for('test-model')}-8081.log"
         existing_log.write_text("previous run line 1\nprevious run line 2\n")
 
         with patch("llauncher.core.process.DEFAULT_SERVER_BINARY", mock_bin), \
@@ -865,7 +866,7 @@ class TestStartServerLogsLifecycle:
 
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
-        log_file = log_dir / "test-model-8081.log"
+        log_file = log_dir / f"{log_stem_for('test-model')}-8081.log"
         # Write 200 bytes of content; we'll cap rotation at 100 below so
         # this file gets rotated.
         log_file.write_text("X" * 200)
@@ -878,7 +879,7 @@ class TestStartServerLogsLifecycle:
             mock_popen.return_value = MagicMock()
             start_server(minimal_config, port=8081)
 
-        rotated = log_dir / "test-model-8081.log.1"
+        rotated = log_dir / f"{log_stem_for('test-model')}-8081.log.1"
         assert rotated.exists(), "rotation did not happen; .log.1 missing"
         assert rotated.read_text() == "X" * 200
         # New live log contains only the banner (no previous content).

--- a/tests/unit/test_process_log_resolution.py
+++ b/tests/unit/test_process_log_resolution.py
@@ -1,7 +1,7 @@
-"""Regression tests for issue #145 — per-server log resolution.
+"""Regression tests for issues #145 and #146/#63 — per-server log resolution.
 
-`wait_for_server_ready` confirms a server is up by scanning its log for a
-"listening" line. The bug: it resolved the log by **port alone**
+#145: `wait_for_server_ready` confirms a server is up by scanning its log
+for a "listening" line. The bug: it resolved the log by **port alone**
 (`glob("*-{port}.log")`, first match), but across a swap two such files
 coexist — the stopped occupant's and the new one's — so it could read the
 stopped model's log (whose tail is shutdown noise, no "listening") and time
@@ -9,11 +9,18 @@ the swap out even though the new server was healthy.
 
 The fix threads the model name through `wait_for_server_ready` so it reads
 that model's *exact* log via `log_path_for`, and hardens `stream_logs` to
-sanitize the model name and prefer the most-recently-written match.
+derive the on-disk stem via the same mint and prefer the most-recently-
+written match.
+
+#146/#63: the original name→filename sanitizer was lossy (`model.a` and
+`model_a` collapsed onto one file, silently interleaving two models' logs
+under ADR-013 append mode). `log_stem_for` is now the single injective
+mint: sanitized stem plus a short stable hash of the exact canonical name.
 """
 
 from __future__ import annotations
 
+import re
 import socket
 from contextlib import closing
 
@@ -35,21 +42,48 @@ def _write(path, *lines):
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-# ─────────────────────── log_path_for ────────────────────────────
+# ─────────────────── log_stem_for / log_path_for ──────────────────
 
 
-def test_log_path_for_sanitizes_dot_to_underscore(log_dir):
-    """The on-disk name matches what start_server writes (dots → underscores)."""
+def test_log_path_for_keeps_sanitized_stem_readable(log_dir):
+    """The on-disk name stays greppable: sanitized name (dots → underscores)
+    plus an 8-hex-char disambiguator, then the port."""
     p = proc.log_path_for("LFM2-350M-Pro.f16", 8082)
-    assert p.name == "LFM2-350M-Pro_f16-8082.log"
+    assert re.fullmatch(r"LFM2-350M-Pro_f16-[0-9a-f]{8}-8082\.log", p.name)
     assert p.parent == log_dir
 
 
-def test_log_path_for_is_lossy_collision_is_characterized(log_dir):
-    """Characterization of the KNOWN lossy-sanitization collision (filed
-    separately): names differing only in non-[\\w-] chars collapse to the
-    same file. Pinned so the follow-up fix has a guard to flip."""
-    assert proc.log_path_for("a.b", 9000) == proc.log_path_for("a_b", 9000)
+def test_log_path_for_separates_names_that_sanitize_alike(log_dir):
+    """#146/#63 regression: names differing only in non-[\\w-] chars used to
+    collapse onto ONE file (lossy sanitizer), silently interleaving two
+    models' logs. The hash suffix must map them apart. Inverts the old
+    `test_log_path_for_is_lossy_collision_is_characterized` guard."""
+    assert proc.log_path_for("a.b", 9000) != proc.log_path_for("a_b", 9000)
+    # The exact pairs from the issue reports:
+    assert proc.log_path_for("LFM2-350M-Pro.f16", 8080) != proc.log_path_for(
+        "LFM2-350M-Pro_f16", 8080
+    )
+    assert proc.log_path_for("Gemma-2-9b-ä", 8080) != proc.log_path_for(
+        "Gemma-2-9b-!", 8080
+    )
+
+
+def test_log_stem_for_is_stable_and_port_independent(log_dir):
+    """The mapping is deterministic (same name → same stem, every call) and
+    carries no port: the port belongs to log_path_for's envelope only."""
+    stem1 = proc.log_stem_for("model.v1")
+    stem2 = proc.log_stem_for("model.v1")
+    assert stem1 == stem2
+    # Same name across ports shares the stem; only the port suffix differs.
+    assert proc.log_path_for("model.v1", 8081).name == f"{stem1}-8081.log"
+    assert proc.log_path_for("model.v1", 8082).name == f"{stem1}-8082.log"
+
+
+def test_log_stem_for_is_glob_safe(log_dir):
+    """The stem contains only [\\w-] chars — no glob metacharacters survive,
+    so stream_logs can embed it literally in a glob pattern."""
+    for name in ("Llama[5B]", "a*b?", "weird name!.gguf"):
+        assert re.fullmatch(r"[\w\-]+", proc.log_stem_for(name))
 
 
 # ─────────────────────── stream_logs ─────────────────────────────
@@ -79,23 +113,36 @@ def test_newest_log_empty_is_none(log_dir):
     assert proc._newest_log(log_dir.glob("*-9999.log")) is None
 
 
-def test_stream_logs_by_model_name_sanitizes(log_dir):
-    """A raw model name with a dot resolves to the sanitized file on disk."""
-    f = log_dir / "LFM2-350M-Pro_f16-8083.log"
+def test_stream_logs_by_model_name_round_trips_the_mint(log_dir):
+    """A file written under log_path_for resolves back via the raw config
+    name — write side and read side share the one mint (log_stem_for)."""
+    f = proc.log_path_for("LFM2-350M-Pro.f16", 8083)
     _write(f, "server is listening on http://0.0.0.0:8083")
-    # Caller passes the UN-sanitized config name.
+    # Caller passes the raw, canonical config name.
     lines = proc.stream_logs(model_name="LFM2-350M-Pro.f16", lines=20)
     assert any("listening" in ln for ln in lines)
 
 
 def test_stream_logs_by_model_name_handles_glob_metachars(log_dir):
     """A name containing glob metachars (``[``) must not be treated as a
-    pattern; sanitization renders it literal so the lookup is well-defined."""
-    # "Llama[5B]" sanitizes to "Llama_5B_"
-    f = log_dir / "Llama_5B_-8080.log"
+    pattern; the stem is metachar-free so the lookup is well-defined."""
+    f = proc.log_path_for("Llama[5B]", 8080)
     _write(f, "rest api listening")
     lines = proc.stream_logs(model_name="Llama[5B]", lines=20)
     assert any("listening" in ln for ln in lines)
+
+
+def test_stream_logs_colliding_names_read_back_only_their_own_lines(log_dir):
+    """#146/#63 round-trip: two models whose names sanitize identically each
+    write to their own file and each read back ONLY their own lines."""
+    _write(proc.log_path_for("model.v1", 8081), "DOTTED model line")
+    _write(proc.log_path_for("model_v1", 8081), "UNDERSCORE model line")
+
+    dotted = proc.stream_logs(model_name="model.v1", lines=20)
+    underscored = proc.stream_logs(model_name="model_v1", lines=20)
+
+    assert dotted == ["DOTTED model line"]
+    assert underscored == ["UNDERSCORE model line"]
 
 
 # ─────────────────── wait_for_server_ready (#145 core) ────────────
@@ -151,5 +198,28 @@ def test_ready_keys_on_named_model_only(log_dir, listening_port):
 
     ready, _ = proc.wait_for_server_ready(
         port, timeout=0.3, check_interval=0.02, model_name="OldModel"
+    )
+    assert ready is False
+
+
+def test_ready_not_shadowed_by_sanitize_alike_sibling(log_dir, listening_port):
+    """#146 readiness round-trip: a sibling whose name sanitizes identically
+    (``model_v1`` vs ``model.v1``) must not satisfy — or pollute — the
+    readiness read for the model actually being waited on."""
+    port = listening_port
+    # The sanitize-alike sibling HAS the indicator…
+    _write(
+        proc.log_path_for("model_v1", port),
+        f"server is listening on http://0.0.0.0:{port}",
+    )
+    # …but the model we wait on does not. Pre-fix these were ONE file and
+    # the sibling's "listening" line leaked into model.v1's readiness read.
+    _write(
+        proc.log_path_for("model.v1", port),
+        "loading model",
+    )
+
+    ready, _ = proc.wait_for_server_ready(
+        port, timeout=0.3, check_interval=0.02, model_name="model.v1"
     )
     assert ready is False


### PR DESCRIPTION
Closes #146. Closes #63.

## Problem

Per-server log filenames were derived from the canonical model name with a lossy sanitizer (`re.sub(r"[^\w\-]", "_", name)`). Distinct names that collapse under it — `model.v1` vs `model_v1`, `LFM2-350M-Pro.f16` vs `LFM2-350M-Pro_f16` — mapped onto **one** log file. Under ADR-013 append-mode logs, the second model silently interleaved into the first's file, and any log-file→model attribution could name the wrong model. This is the named gap keeping ADR-013 out of `completed/`.

## Fix — envelope space only (`IDENTITY⊥ENVELOPE`, `ONE-MINT`)

The canonical name (`ModelConfig.name`) is never altered or constrained. The filename **envelope** is disambiguated instead:

- **`log_stem_for(config_name)` → `{sanitized}-{hash8}`** — the single mint for the name→filename mapping. Keeps the sanitized name for greppability; appends the first 8 hex chars of SHA-256 of the *exact* canonical name, separating every pair the sanitizer collapses. The stem is `[\w-]`-only by construction (glob-safe).
- `log_path_for()` derives its stem through the mint; the #145 write/read symmetry (`start_server` writes, `wait_for_server_ready` reads the same exact path) is preserved.
- `stream_logs()`'s model-name branch drops its second inline copy of the sanitizer and globs `{log_stem_for(name)}-*.log` — no parallel implementation of the mapping remains.
- Rotation unaffected; the lifecycle regression suite now exercises it under the new naming.

## Migration posture (no backcompat shims)

Old-scheme `{sanitized}-{port}.log` files become orphans that age out. They are deliberately not resolvable by model name: a colliding old file may contain interleaved output from two models, and attributing it to either would repeat the bug. The pid/port-keyed lookup still globs `*-{port}.log` with newest-wins, so a stale old-scheme file loses to the current occupant's log on first start. No code dual-parses two naming schemes.

## Tests

- Collision regression: `a.b` vs `a_b` plus both issue-reported pairs map apart (inverts the #145 characterization guard `test_log_path_for_is_lossy_collision_is_characterized`).
- Stem stability / idempotence and port-independence; glob-safety of the stem.
- Round-trip: sanitize-alike names each read back **only** their own lines via `stream_logs`; readiness (`wait_for_server_ready`) not shadowed by a sanitize-alike sibling.
- Banner/append/rotation lifecycle tests re-pointed at the minted stem (behavior unchanged).

## Gates

- `python -m pytest tests/ -q`: 1054 passed, 11 skipped, **1 pre-existing failure unrelated to this change** — `test_no_legacy_env_var_names_in_tracked_source` flags `scripts/systemd/install.sh:110` (comment introduced in d42fbb7, present on `origin/main`; fails identically with this branch's changes stashed). That file is outside this PR's scope; fix is a one-line comment reword or test-allowlist entry.
- `--cov-fail-under=93`: **94.99%** — passes.

Note for merge: `docs/adrs/README.md`'s ADR-013 gap note is to be updated at merge time (out of scope here per contract).