### PR TITLE
fix(stop): answer POST /stop/{port} before the SIGTERM grace elapses

### DIFF
--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import socket
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel
 
 from llauncher import operations as ops
@@ -76,6 +76,7 @@ def _stop_status_code(action: str) -> int:
     return {
         "stopped": 200,
         "already_empty": 200,
+        "stopping": 202,  # issue #140: accepted; termination in flight
         "error": 500,
     }.get(action, 500)
 
@@ -367,18 +368,33 @@ def swap_server(port: int, body: SwapRequest) -> dict:
 
 
 @router.post("/stop/{port}")
-def stop_server(port: int) -> dict:
+def stop_server(port: int, response: Response) -> dict:
     """Stop whatever is running on ``port`` per ADR-010.
 
+    Non-blocking per issue #140: a live process is acknowledged with
+    **202** and ``action="stopping"`` immediately, and the actual
+    SIGTERM → grace → SIGKILL sequence runs on a background thread
+    inside the agent. The previous synchronous behavior held the
+    connection for the full grace (~8 s at the defaults), which
+    outlived common 5 s client timeouts — callers saw failures on
+    stops that succeeded. Completion is observable via ``GET /status``
+    (the port empties) and the audit log (``STOPPED`` with ``SUCCESS``
+    or ``ERROR``); this mirrors the ADR-014 ``/cancel/{port}`` pattern
+    of acknowledging an in-flight operation without blocking on it.
+
     Idempotent: returns 200 with ``action="already_empty"`` if the port
-    has no live claim. 500 only when termination is attempted and fails.
+    has no live claim, and 202 with ``action="stopping"`` again if a
+    stop is already in flight. A termination *failure* is no longer
+    reported on this response (it happens after the 202); it lands in
+    the audit log and the port remains visibly occupied in status.
     """
-    result = ops.stop(port, caller="agent")
+    result = ops.stop_in_background(port, caller="agent")
     payload = result.to_dict()
     code = _stop_status_code(result.action)
 
     if code >= 400:
         raise HTTPException(status_code=code, detail=payload)
+    response.status_code = code
     return payload
 
 

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -33,6 +33,7 @@ from llauncher.agent.middleware import (
 )
 from llauncher.agent.routing import router, get_node_name
 from llauncher.core import lockfile as lf
+from llauncher.core import settings
 from llauncher.core.settings import AGENT_API_KEY
 
 # Configure logging
@@ -147,6 +148,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     is a behavior change from the previous bare ``KeyboardInterrupt`` path,
     which orphaned children silently. See ``docs/v2-handoff.md`` §What NOT
     To Do for context.
+
+    Coalescing with in-flight background stops (issue #140): a
+    ``POST /stop/{port}`` accepted shortly before shutdown runs its
+    termination on a daemon thread. For each port the reaper first joins
+    any such in-flight stop (:func:`operations.join_inflight_stop`,
+    bounded by the full SIGTERM grace budget) and skips its own blocking
+    stop when the in-flight one completed — otherwise two threads would
+    race SIGTERM/SIGKILL against the same process. Remaining tolerance:
+    a background stop registered after the join, or a stop driven from
+    another process, can still overlap the blocking call; that overlap
+    is at worst a re-termination of an already-dying pid, which
+    ``core.process.stop_server_by_pid`` absorbs.
     """
     # Startup — nothing to do.
     yield
@@ -170,7 +183,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         "Lifespan shutdown: reaping %d managed llama-server child(ren)",
         len(lockfiles),
     )
+    # Full SIGTERM→SIGKILL grace budget; read at call time so env
+    # profiles and test patches take effect (same discipline as
+    # core.process.stop_server_by_pid).
+    grace_budget = (
+        settings.LLAUNCHER_STOP_CHILD_GRACE_S + settings.LLAUNCHER_STOP_GRACE_S
+    )
     for entry in lockfiles:
+        if ops.join_inflight_stop(entry.port, timeout=grace_budget):
+            # An in-flight background stop owned this port and finished;
+            # lockfile removal and audit emission already happened on
+            # its thread. Driving the blocking stop too would double-
+            # terminate.
+            logger.info(
+                "Lifespan shutdown: port=%d coalesced with in-flight stop",
+                entry.port,
+            )
+            continue
         try:
             result = ops.stop(entry.port, caller="agent-shutdown")
         except OSError as exc:

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -322,7 +322,7 @@ def stop_server_by_pid(
     period — children included (issue #140: the previous implementation
     only escalated the main process, so a child that ignored SIGTERM
     leaked past the stop). Grace periods default from settings *at call
-    time* (``LAUNCHER_STOP_CHILD_GRACE_S`` / ``LAUNCHER_STOP_GRACE_S``)
+    time* (``LLAUNCHER_STOP_CHILD_GRACE_S`` / ``LLAUNCHER_STOP_GRACE_S``)
     so env-configured profiles and test patches both take effect — the
     settings module is referenced as an attribute, not imported as a
     bound name, for exactly the import-time-capture reason documented
@@ -331,17 +331,17 @@ def stop_server_by_pid(
     Args:
         pid: Process ID to stop.
         child_grace_s: Seconds to wait for children after SIGTERM before
-            SIGKILL. ``None`` → ``settings.LAUNCHER_STOP_CHILD_GRACE_S``.
+            SIGKILL. ``None`` → ``settings.LLAUNCHER_STOP_CHILD_GRACE_S``.
         grace_s: Seconds to wait for the main process after SIGTERM
-            before SIGKILL. ``None`` → ``settings.LAUNCHER_STOP_GRACE_S``.
+            before SIGKILL. ``None`` → ``settings.LLAUNCHER_STOP_GRACE_S``.
 
     Returns:
         True if process was stopped, False if not found.
     """
     if child_grace_s is None:
-        child_grace_s = settings.LAUNCHER_STOP_CHILD_GRACE_S
+        child_grace_s = settings.LLAUNCHER_STOP_CHILD_GRACE_S
     if grace_s is None:
-        grace_s = settings.LAUNCHER_STOP_GRACE_S
+        grace_s = settings.LLAUNCHER_STOP_GRACE_S
 
     try:
         process = psutil.Process(pid)

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -284,30 +284,65 @@ def start_server(
         raise OSError(f"Failed to create log file {log_file}: {e}")
 
 
-def stop_server_by_port(port: int) -> bool:
+def stop_server_by_port(
+    port: int,
+    *,
+    child_grace_s: float | None = None,
+    grace_s: float | None = None,
+) -> bool:
     """Stop a llama-server running on the given port.
 
     Args:
         port: Port number of the server to stop.
+        child_grace_s: SIGTERM grace for children; see
+            :func:`stop_server_by_pid`.
+        grace_s: SIGTERM grace for the main process; see
+            :func:`stop_server_by_pid`.
 
     Returns:
         True if a server was found and stopped, False otherwise.
     """
     process = find_server_by_port(port)
     if process:
-        return stop_server_by_pid(process.pid)
+        return stop_server_by_pid(
+            process.pid, child_grace_s=child_grace_s, grace_s=grace_s
+        )
     return False
 
 
-def stop_server_by_pid(pid: int) -> bool:
+def stop_server_by_pid(
+    pid: int,
+    *,
+    child_grace_s: float | None = None,
+    grace_s: float | None = None,
+) -> bool:
     """Stop a llama-server process by PID.
+
+    SIGTERM first, then SIGKILL for anything that outlives its grace
+    period — children included (issue #140: the previous implementation
+    only escalated the main process, so a child that ignored SIGTERM
+    leaked past the stop). Grace periods default from settings *at call
+    time* (``LAUNCHER_STOP_CHILD_GRACE_S`` / ``LAUNCHER_STOP_GRACE_S``)
+    so env-configured profiles and test patches both take effect — the
+    settings module is referenced as an attribute, not imported as a
+    bound name, for exactly the import-time-capture reason documented
+    on ``LOG_DIR`` above.
 
     Args:
         pid: Process ID to stop.
+        child_grace_s: Seconds to wait for children after SIGTERM before
+            SIGKILL. ``None`` → ``settings.LAUNCHER_STOP_CHILD_GRACE_S``.
+        grace_s: Seconds to wait for the main process after SIGTERM
+            before SIGKILL. ``None`` → ``settings.LAUNCHER_STOP_GRACE_S``.
 
     Returns:
         True if process was stopped, False if not found.
     """
+    if child_grace_s is None:
+        child_grace_s = settings.LAUNCHER_STOP_CHILD_GRACE_S
+    if grace_s is None:
+        grace_s = settings.LAUNCHER_STOP_GRACE_S
+
     try:
         process = psutil.Process(pid)
 
@@ -316,14 +351,22 @@ def stop_server_by_pid(pid: int) -> bool:
             children = process.children(recursive=True)
             for child in children:
                 child.terminate()
-            psutil.wait_procs(children, timeout=3)
+            _, alive = psutil.wait_procs(children, timeout=child_grace_s)
+            # Grace expired — escalate so no child outlives the stop
+            # (issue #140). A child may exit between the wait and the
+            # kill; that's success, not an error.
+            for child in alive:
+                try:
+                    child.kill()
+                except psutil.NoSuchProcess:
+                    pass
         except psutil.NoSuchProcess:
             pass
 
         # Terminate the main process
         process.terminate()
         try:
-            process.wait(timeout=5)
+            process.wait(timeout=grace_s)
         except psutil.TimeoutExpired:
             process.kill()
 

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -102,14 +102,16 @@ LAUNCHER_LOG_KEEP = int(os.getenv("LAUNCHER_LOG_KEEP", "3"))
 
 # Graceful-shutdown grace periods for terminating a llama-server
 # (issue #140). ``core.process.stop_server_by_pid`` sends SIGTERM and
-# waits up to LAUNCHER_STOP_CHILD_GRACE_S for the process's children,
-# then up to LAUNCHER_STOP_GRACE_S for the main process, before
+# waits up to LLAUNCHER_STOP_CHILD_GRACE_S for the process's children,
+# then up to LLAUNCHER_STOP_GRACE_S for the main process, before
 # escalating to SIGKILL. Worst-case blocking time for a synchronous
 # stop is the sum (~8 s at the defaults). Env-tunable so deployments
 # with slow GPU unloads can lengthen the grace and test profiles can
-# shorten it without real-time sleeps.
-LAUNCHER_STOP_CHILD_GRACE_S = float(os.getenv("LAUNCHER_STOP_CHILD_GRACE_S", "3.0"))
-LAUNCHER_STOP_GRACE_S = float(os.getenv("LAUNCHER_STOP_GRACE_S", "5.0"))
+# shorten it without real-time sleeps. ``LLAUNCHER_*`` prefix per the
+# #151 naming direction — these were never released under the legacy
+# single-L prefix, so no backcompat alias exists.
+LLAUNCHER_STOP_CHILD_GRACE_S = float(os.getenv("LLAUNCHER_STOP_CHILD_GRACE_S", "3.0"))
+LLAUNCHER_STOP_GRACE_S = float(os.getenv("LLAUNCHER_STOP_GRACE_S", "5.0"))
 
 # TTL in seconds for the ``/footer-context/{port}`` per-port cache
 # (ADR-012). Default 1.0 absorbs footer poll cadence (multiple

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -100,6 +100,17 @@ LAUNCHER_LOG_MAX_BYTES = int(os.getenv(
 # ``foo-8081.log`` plus ``foo-8081.log.{1,2,3}``.
 LAUNCHER_LOG_KEEP = int(os.getenv("LAUNCHER_LOG_KEEP", "3"))
 
+# Graceful-shutdown grace periods for terminating a llama-server
+# (issue #140). ``core.process.stop_server_by_pid`` sends SIGTERM and
+# waits up to LAUNCHER_STOP_CHILD_GRACE_S for the process's children,
+# then up to LAUNCHER_STOP_GRACE_S for the main process, before
+# escalating to SIGKILL. Worst-case blocking time for a synchronous
+# stop is the sum (~8 s at the defaults). Env-tunable so deployments
+# with slow GPU unloads can lengthen the grace and test profiles can
+# shorten it without real-time sleeps.
+LAUNCHER_STOP_CHILD_GRACE_S = float(os.getenv("LAUNCHER_STOP_CHILD_GRACE_S", "3.0"))
+LAUNCHER_STOP_GRACE_S = float(os.getenv("LAUNCHER_STOP_GRACE_S", "5.0"))
+
 # TTL in seconds for the ``/footer-context/{port}`` per-port cache
 # (ADR-012). Default 1.0 absorbs footer poll cadence (multiple
 # redraws per second collapse into one lockfile + ConfigStore read).

--- a/llauncher/operations/__init__.py
+++ b/llauncher/operations/__init__.py
@@ -45,7 +45,13 @@ from .preflight import (
     estimate_vram_mb,
 )
 from .start import StartResult, start
-from .stop import StopResult, stop, stop_in_background, wait_for_stop
+from .stop import (
+    StopResult,
+    join_inflight_stop,
+    stop,
+    stop_in_background,
+    wait_for_stop,
+)
 from .swap import (
     DEFAULT_READINESS_TIMEOUT_S,
     PreflightCheck,
@@ -60,6 +66,7 @@ __all__ = [
     "stop",
     "stop_in_background",  # issue #140: async-accept stop for the agent
     "wait_for_stop",  # issue #140: deterministic join point (tests/diagnostics)
+    "join_inflight_stop",  # issue #140: reaper coalesce with in-flight stop
     "swap",
     "delete_model",
     # Result envelopes

--- a/llauncher/operations/__init__.py
+++ b/llauncher/operations/__init__.py
@@ -45,7 +45,7 @@ from .preflight import (
     estimate_vram_mb,
 )
 from .start import StartResult, start
-from .stop import StopResult, stop
+from .stop import StopResult, stop, stop_in_background, wait_for_stop
 from .swap import (
     DEFAULT_READINESS_TIMEOUT_S,
     PreflightCheck,
@@ -58,6 +58,8 @@ __all__ = [
     # Verbs
     "start",
     "stop",
+    "stop_in_background",  # issue #140: async-accept stop for the agent
+    "wait_for_stop",  # issue #140: deterministic join point (tests/diagnostics)
     "swap",
     "delete_model",
     # Result envelopes

--- a/llauncher/operations/stop.py
+++ b/llauncher/operations/stop.py
@@ -3,7 +3,7 @@
 Two entry points share the same reconcile/terminate machinery:
 
 - :func:`stop` — synchronous. Blocks through the full SIGTERM grace
-  (worst case ``LAUNCHER_STOP_CHILD_GRACE_S + LAUNCHER_STOP_GRACE_S``,
+  (worst case ``LLAUNCHER_STOP_CHILD_GRACE_S + LLAUNCHER_STOP_GRACE_S``,
   ~8 s by default) and returns the definitive outcome. Correct for
   in-process callers (CLI, MCP server, the remote self-loop, the agent's
   shutdown reaper) where no transport timeout exists and a short-lived
@@ -222,6 +222,16 @@ def stop_in_background(port: int, *, caller: str = "unknown") -> StopResult:
                 logger.error(
                     "Background stop for port %d failed: %s", port, exc
                 )
+            finally:
+                # Reap this thread's registry entry so a long-lived
+                # agent doesn't accumulate dead Thread objects, one per
+                # completed stop. Only reap if the registered entry is
+                # still *this* thread — a successor stop for the same
+                # port may already have replaced it, and its entry must
+                # survive.
+                with _inflight_lock:
+                    if _inflight.get(port) is threading.current_thread():
+                        del _inflight[port]
 
         thread = threading.Thread(
             target=_run, name=f"llauncher-stop-{port}", daemon=True
@@ -251,5 +261,36 @@ def wait_for_stop(port: int, timeout: float | None = None) -> bool:
         thread = _inflight.get(port)
     if thread is None:
         return True
+    thread.join(timeout)
+    return not thread.is_alive()
+
+
+def join_inflight_stop(port: int, timeout: float | None = None) -> bool:
+    """Join the in-flight background stop for ``port``, if one exists.
+
+    Distinct from :func:`wait_for_stop`, which answers "is anything
+    still in flight?": this answers "did an in-flight stop exist *and*
+    complete?" — the coalescing question the agent's shutdown reaper
+    asks before driving its own blocking :func:`stop` (so reaper and
+    background thread don't both run SIGTERM/SIGKILL against the same
+    port).
+
+    Returns ``True`` only when an in-flight stop was registered and
+    finished within ``timeout`` — the caller's own stop is then
+    redundant and should be skipped. Returns ``False`` when nothing was
+    in flight (the caller must drive its own stop) or when the in-flight
+    stop was still running at timeout (the caller falls back to the
+    blocking path; the overlap is tolerated, see below).
+
+    Remaining tolerance: a background stop that registers *after* this
+    join, or one driven from another process entirely, can still overlap
+    the caller's blocking stop. That worst case is a re-termination of
+    an already-dying pid, which ``proc.stop_server_by_pid`` absorbs
+    (``NoSuchProcess`` → ``False``) — wasteful, never incorrect.
+    """
+    with _inflight_lock:
+        thread = _inflight.get(port)
+    if thread is None:
+        return False
     thread.join(timeout)
     return not thread.is_alive()

--- a/llauncher/operations/stop.py
+++ b/llauncher/operations/stop.py
@@ -1,14 +1,33 @@
-"""``stop`` verb — terminate the model on a port per ADR-010 semantics."""
+"""``stop`` verb — terminate the model on a port per ADR-010 semantics.
+
+Two entry points share the same reconcile/terminate machinery:
+
+- :func:`stop` — synchronous. Blocks through the full SIGTERM grace
+  (worst case ``LAUNCHER_STOP_CHILD_GRACE_S + LAUNCHER_STOP_GRACE_S``,
+  ~8 s by default) and returns the definitive outcome. Correct for
+  in-process callers (CLI, MCP server, the remote self-loop, the agent's
+  shutdown reaper) where no transport timeout exists and a short-lived
+  process must not exit with a half-delivered termination.
+- :func:`stop_in_background` — non-blocking (issue #140). Performs the
+  same fast pre-checks synchronously, then terminates a live process on
+  a background thread and returns ``action="stopping"`` immediately.
+  Used by the HTTP agent so ``POST /stop/{port}`` answers within
+  milliseconds instead of holding the connection for the grace period —
+  callers with short HTTP timeouts (the pi-agent extension defaults to
+  5 s) were observing timeout errors on stops that actually succeeded.
+"""
 
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import asdict, dataclass
 
 from llauncher.core import audit_log as al
 from llauncher.core import lockfile as lf
 from llauncher.core import process as proc
 from llauncher.core.audit_log import AuditAction, AuditResult
+from llauncher.core.lockfile import Lockfile
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +37,7 @@ class StopResult:
     """Outcome of a stop operation."""
 
     success: bool
-    action: str  # stopped | already_empty | error
+    action: str  # stopped | stopping | already_empty | error
     port: int
     model: str | None = None  # what was running, if anything
     pid: int | None = None
@@ -28,21 +47,37 @@ class StopResult:
         return asdict(self)
 
 
-def stop(port: int, *, caller: str = "unknown") -> StopResult:
-    """Stop whatever is running on ``port`` per ADR-010 verb semantics.
+# In-flight background stops keyed by port (issue #140). Process-local
+# bookkeeping, NOT durable state — ADR-008 still holds: the source of
+# truth for "is something on this port" remains the lockfile + process
+# table, both of which the background thread updates exactly as the
+# synchronous path does. This registry only dedupes repeated stop
+# requests landing on the *same* agent while a termination is in
+# flight; a concurrent stop driven from another process at worst
+# re-terminates, which ``proc.stop_server_by_pid`` tolerates.
+_inflight_lock = threading.Lock()
+_inflight: dict[int, threading.Thread] = {}
 
-    - Empty port → idempotent success. Returns ``action="already_empty"``.
-    - Stale lockfile (pid dead) → cleaned up, ``action="already_empty"``.
-    - Live process → terminated, lockfile removed, ``action="stopped"``.
-    - Termination failure → ``action="error"``.
+
+def _reconcile_for_stop(
+    port: int, *, caller: str
+) -> tuple[StopResult | None, Lockfile | None]:
+    """Fast pre-check shared by :func:`stop` and :func:`stop_in_background`.
+
+    Returns ``(early_result, None)`` when the port needs no termination
+    (empty, or stale lockfile that was cleaned up), or ``(None, lockfile)``
+    when a live process must be terminated.
     """
     existing = lf.read_lockfile(port)
     if existing is None:
-        return StopResult(
-            success=True,
-            action="already_empty",
-            port=port,
-            message=f"No server claimed port {port}",
+        return (
+            StopResult(
+                success=True,
+                action="already_empty",
+                port=port,
+                message=f"No server claimed port {port}",
+            ),
+            None,
         )
 
     recon = lf.reconcile_lockfile(existing)
@@ -58,16 +93,28 @@ def stop(port: int, *, caller: str = "unknown") -> StopResult:
             message="reconciliation: stale lockfile removed",
         )
         lf.remove_lockfile(port)
-        return StopResult(
-            success=True,
-            action="already_empty",
-            port=port,
-            model=existing.model,
-            pid=existing.pid,
-            message=f"Lockfile was stale for {existing.model}; cleaned up.",
+        return (
+            StopResult(
+                success=True,
+                action="already_empty",
+                port=port,
+                model=existing.model,
+                pid=existing.pid,
+                message=f"Lockfile was stale for {existing.model}; cleaned up.",
+            ),
+            None,
         )
 
-    # Live process — terminate.
+    return None, existing
+
+
+def _terminate(port: int, existing: Lockfile, *, caller: str) -> StopResult:
+    """Blocking termination tail: SIGTERM → grace → SIGKILL, lockfile, audit.
+
+    Runs inline for :func:`stop`, on a worker thread for
+    :func:`stop_in_background`. Either way the durable record (lockfile
+    removal + audit entry) is emitted here, when the outcome is known.
+    """
     ok = proc.stop_server_by_port(port)
     if not ok:
         al.record(
@@ -105,3 +152,104 @@ def stop(port: int, *, caller: str = "unknown") -> StopResult:
         pid=existing.pid,
         message=f"Stopped {existing.model} on port {port}",
     )
+
+
+def stop(port: int, *, caller: str = "unknown") -> StopResult:
+    """Stop whatever is running on ``port`` per ADR-010 verb semantics.
+
+    - Empty port → idempotent success. Returns ``action="already_empty"``.
+    - Stale lockfile (pid dead) → cleaned up, ``action="already_empty"``.
+    - Live process → terminated, lockfile removed, ``action="stopped"``.
+    - Termination failure → ``action="error"``.
+
+    Blocks through the full termination grace (see module docstring).
+    """
+    early, existing = _reconcile_for_stop(port, caller=caller)
+    if early is not None:
+        return early
+    assert existing is not None  # narrowed by _reconcile_for_stop contract
+    return _terminate(port, existing, caller=caller)
+
+
+def stop_in_background(port: int, *, caller: str = "unknown") -> StopResult:
+    """Non-blocking stop (issue #140): accept now, terminate on a thread.
+
+    Same pre-checks as :func:`stop`, but a live process is terminated on
+    a background thread and this call returns immediately:
+
+    - Empty port / stale lockfile → ``action="already_empty"``,
+      synchronously — identical to :func:`stop`.
+    - Live process → ``action="stopping"``, ``success=True``,
+      immediately. Termination, lockfile removal, and the audit record
+      happen on the thread; completion is observable via status (the
+      port empties) and the audit log (``STOPPED`` with ``SUCCESS`` or
+      ``ERROR``). This mirrors ADR-014's in-flight semantics for
+      ``/cancel/{port}``: the endpoint acknowledges, it does not block
+      on the outcome.
+    - Repeated call while a stop is in flight → ``action="stopping"``
+      again, idempotently; no second termination is spawned.
+
+    The worker thread is daemonic so it can never wedge process exit;
+    the agent's lifespan reaper (issue #65) re-walks the lockfile
+    registry with the *blocking* :func:`stop` on shutdown, so a stop
+    interrupted mid-grace is re-driven rather than leaked.
+    """
+    early, existing = _reconcile_for_stop(port, caller=caller)
+    if early is not None:
+        return early
+    assert existing is not None  # narrowed by _reconcile_for_stop contract
+
+    with _inflight_lock:
+        pending = _inflight.get(port)
+        if pending is not None and pending.is_alive():
+            return StopResult(
+                success=True,
+                action="stopping",
+                port=port,
+                model=existing.model,
+                pid=existing.pid,
+                message=f"Stop already in progress for port {port}",
+            )
+
+        def _run() -> None:
+            try:
+                _terminate(port, existing, caller=caller)
+            except OSError as exc:
+                # Filesystem failure in lockfile/audit emission. psutil
+                # errors are already absorbed inside core.process. Log
+                # rather than die silently in the thread; the next
+                # status refresh reconciles whatever state remains.
+                logger.error(
+                    "Background stop for port %d failed: %s", port, exc
+                )
+
+        thread = threading.Thread(
+            target=_run, name=f"llauncher-stop-{port}", daemon=True
+        )
+        _inflight[port] = thread
+        thread.start()
+
+    return StopResult(
+        success=True,
+        action="stopping",
+        port=port,
+        model=existing.model,
+        pid=existing.pid,
+        message=f"Stopping {existing.model} on port {port}",
+    )
+
+
+def wait_for_stop(port: int, timeout: float | None = None) -> bool:
+    """Block until the in-flight background stop for ``port`` (if any) ends.
+
+    Returns ``True`` when no stop remains in flight after the wait,
+    ``False`` if a stop is still running when ``timeout`` expires.
+    Primarily a deterministic join point for tests and diagnostics —
+    production callers observe completion through status/audit instead.
+    """
+    with _inflight_lock:
+        thread = _inflight.get(port)
+    if thread is None:
+        return True
+    thread.join(timeout)
+    return not thread.is_alive()

--- a/llauncher/remote/node.py
+++ b/llauncher/remote/node.py
@@ -371,6 +371,18 @@ class RemoteNode:
     def stop_server(self, port: int) -> dict | None:
         """Stop a server on this node.
 
+        Issue #140 timeout contract: the agent's ``POST /stop/{port}``
+        acknowledges a live process with **202** and
+        ``action="stopping"`` and terminates it asynchronously, so this
+        call returns well inside ``self.timeout`` even when the
+        llama-server needs the full SIGTERM grace to unload. Callers
+        treat ``stopping`` as accepted-success and observe completion
+        through the next status refresh. The self-loop path keeps the
+        *synchronous* ``ops.stop`` on purpose: there is no transport
+        timeout in-process, the blocking call returns the definitive
+        outcome, and a short-lived caller (CLI) must not exit while a
+        background termination is still mid-grace.
+
         Args:
             port: Port of the server to stop.
 
@@ -389,7 +401,9 @@ class RemoteNode:
                     f"{self.base_url}/stop/{port}",
                     headers=self._get_headers(),
                 )
-                if response.status_code == 200:
+                # 200 (already_empty / legacy stopped) and 202
+                # (stopping, issue #140) are both success envelopes.
+                if response.status_code in (200, 202):
                     self.status = NodeStatus.ONLINE
                     self.last_seen = datetime.now()
                     return response.json()

--- a/llauncher/ui/utils.py
+++ b/llauncher/ui/utils.py
@@ -83,6 +83,11 @@ _INFO_ACTIONS: frozenset[str] = frozenset({
     "already_running",
     "already_empty",
     "not_found",
+    # Accepted-in-flight (issue #140): a remote agent acknowledged the
+    # stop with 202 and is terminating asynchronously. Informational —
+    # the tab's next status refresh shows the port emptied. Not SUCCESS:
+    # the ✅ icon would overclaim an outcome that hasn't landed yet.
+    "stopping",
 })
 
 _WARNING_ACTIONS: frozenset[str] = frozenset({

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -107,7 +107,7 @@ chmod 700 "$LLAUNCHER_DIR"
 # via the failing command-substitution — an empty TOKEN_VALUE then routes
 # to the informative else-branch below instead of a silent exit 1. This
 # is the failure mode when a pre-rename env file still uses the old
-# single-L LAUNCHER_AGENT_TOKEN key (see #138/#139).
+# single-L (LAUNCHER, not LLAUNCHER) token key (see #138/#139).
 TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]' || true)"
 if [ -n "$TOKEN_VALUE" ]; then
     # printf '%s' (no trailing newline) matches the byte-shape of

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -282,7 +282,7 @@ class TestStopServerEndpoint:
         from llauncher import operations as ops
 
         monkeypatch.setattr(
-            "llauncher.agent.routing.ops.stop",
+            "llauncher.agent.routing.ops.stop_in_background",
             lambda port, caller="agent": ops.StopResult(
                 success=True,
                 action="already_empty",
@@ -293,6 +293,62 @@ class TestStopServerEndpoint:
         response = client.post("/stop/99999")
         assert response.status_code == 200
         assert response.json()["action"] == "already_empty"
+
+    def test_stop_live_port_responds_while_termination_pending(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Issue #140 timing contract, end to end through the endpoint.
+
+        A live claim whose termination is *deliberately held open* must
+        not delay the HTTP response: the caller gets 202/``stopping``
+        while the (simulated slow, would-be ~8 s) shutdown is still in
+        flight. No real sleeps — the slow shutdown is an Event the test
+        releases after asserting the response already came back.
+        """
+        import os
+        import threading
+
+        from llauncher import operations as ops
+        from llauncher.core import lockfile as lf
+
+        run_dir = tmp_path / "run"
+        monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
+        monkeypatch.setattr(
+            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH",
+            tmp_path / "audit.jsonl",
+        )
+        lf.write_lockfile(8081, "slow-model", os.getpid(), run_dir=run_dir)
+
+        release = threading.Event()
+
+        def slow_terminate(port, **kwargs):
+            # Stands in for the SIGTERM grace; bounded so a regression
+            # cannot hang the suite.
+            release.wait(timeout=10)
+            return True
+
+        monkeypatch.setattr(
+            "llauncher.operations.proc.stop_server_by_port", slow_terminate
+        )
+
+        try:
+            response = client.post("/stop/8081")
+
+            # Response arrived while the termination is still blocked.
+            assert response.status_code == 202
+            data = response.json()
+            assert data["success"] is True
+            assert data["action"] == "stopping"
+            assert data["model"] == "slow-model"
+            # The durable claim is still present — termination pending.
+            assert lf.read_lockfile(8081, run_dir=run_dir) is not None
+        finally:
+            release.set()
+
+        # Once released, the background path completes and removes the
+        # lockfile — the success the caller polls /status for.
+        assert ops.wait_for_stop(8081, timeout=10) is True
+        assert lf.read_lockfile(8081, run_dir=run_dir) is None
 
 
 class TestLogsEndpoint:
@@ -1126,8 +1182,8 @@ class TestAgentRouting:
         assert response.status_code == 500
         assert response.json()["detail"]["action"] == "error"
 
-    def test_stop_server_success(self, client, monkeypatch):
-        """``stopped`` action → 200."""
+    def test_stop_server_stopping_returns_202(self, client, monkeypatch):
+        """``stopping`` action (issue #140 async-accept) → 202."""
         from llauncher import operations as ops
 
         captured: dict = {}
@@ -1136,19 +1192,22 @@ class TestAgentRouting:
             captured["args"] = (port, caller)
             return ops.StopResult(
                 success=True,
-                action="stopped",
+                action="stopping",
                 port=port,
                 model="test-model",
                 pid=1234,
-                message=f"Stopped test-model on port {port}",
+                message=f"Stopping test-model on port {port}",
             )
 
-        monkeypatch.setattr("llauncher.agent.routing.ops.stop", fake_stop)
+        monkeypatch.setattr(
+            "llauncher.agent.routing.ops.stop_in_background", fake_stop
+        )
 
         response = client.post("/stop/8081")
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
-        assert data["action"] == "stopped"
+        assert data["success"] is True
+        assert data["action"] == "stopping"
         assert data["port"] == 8081
         assert data["model"] == "test-model"
         assert captured["args"] == (8081, "agent")
@@ -1158,7 +1217,7 @@ class TestAgentRouting:
         from llauncher import operations as ops
 
         monkeypatch.setattr(
-            "llauncher.agent.routing.ops.stop",
+            "llauncher.agent.routing.ops.stop_in_background",
             lambda port, caller="agent": ops.StopResult(
                 success=True,
                 action="already_empty",
@@ -1171,12 +1230,18 @@ class TestAgentRouting:
         assert response.status_code == 200
         assert response.json()["action"] == "already_empty"
 
-    def test_stop_server_termination_failure_returns_500(self, client, monkeypatch):
-        """A live process that won't terminate → 500."""
+    def test_stop_server_error_action_returns_500(self, client, monkeypatch):
+        """Defensive mapping: an ``error`` envelope still maps to 500.
+
+        ``stop_in_background`` reports termination failure via the audit
+        log after the 202 (issue #140), so this path is not normally
+        reachable — but the status-code table must keep failing closed
+        if an error envelope ever surfaces synchronously again.
+        """
         from llauncher import operations as ops
 
         monkeypatch.setattr(
-            "llauncher.agent.routing.ops.stop",
+            "llauncher.agent.routing.ops.stop_in_background",
             lambda port, caller="agent": ops.StopResult(
                 success=False,
                 action="error",

--- a/tests/unit/test_agent_lifespan.py
+++ b/tests/unit/test_agent_lifespan.py
@@ -95,6 +95,54 @@ def test_lifespan_shutdown_reaps_each_lockfile(
     assert all(caller == "agent-shutdown" for _, caller in stop_calls)
 
 
+def test_lifespan_shutdown_coalesces_with_inflight_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A port whose in-flight background stop completed is skipped (PR #161).
+
+    The reaper joins any in-flight ``stop_in_background`` thread first
+    (bounded by the full grace budget) and only drives the blocking
+    ``ops.stop`` for ports with no in-flight stop — otherwise two
+    threads race SIGTERM/SIGKILL on the same process.
+    """
+    monkeypatch.setattr(
+        agent_server.lf,
+        "list_lockfiles",
+        lambda: [
+            _FakeLockfile(port=8081, model="mistral-7b"),
+            _FakeLockfile(port=8082, model="qwen-2.5-coder"),
+        ],
+    )
+    # Pin the grace settings so the joined timeout is assertable.
+    monkeypatch.setattr(
+        agent_server.settings, "LLAUNCHER_STOP_CHILD_GRACE_S", 0.25
+    )
+    monkeypatch.setattr(agent_server.settings, "LLAUNCHER_STOP_GRACE_S", 0.5)
+
+    join_calls: list[tuple[int, float]] = []
+
+    def _fake_join(port: int, timeout: float | None = None) -> bool:
+        join_calls.append((port, timeout))
+        return port == 8081  # 8081's in-flight stop completed; 8082 has none
+
+    monkeypatch.setattr(agent_server.ops, "join_inflight_stop", _fake_join)
+
+    stop_calls: list[int] = []
+
+    def _fake_stop(port: int, *, caller: str = "unknown") -> StopResult:
+        stop_calls.append(port)
+        return StopResult(success=True, action="stopped", port=port)
+
+    monkeypatch.setattr(agent_server.ops, "stop", _fake_stop)
+
+    _drive_lifespan(monkeypatch)
+
+    # Every port was offered the coalesce, bounded by the grace budget sum.
+    assert join_calls == [(8081, 0.75), (8082, 0.75)]
+    # Only the non-coalesced port fell through to the blocking stop.
+    assert stop_calls == [8082]
+
+
 def test_lifespan_shutdown_tolerates_per_port_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -509,6 +509,94 @@ def test_stop_in_background_termination_failure_audited(
     assert entries[0].result == AuditResult.ERROR
 
 
+def test_stop_in_background_reaps_inflight_registry_on_completion(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Completed background stops leave no registry entry (PR #161 review).
+
+    Without the reap, a long-lived agent accumulates one dead Thread
+    object per completed stop, unbounded. The entry must exist while the
+    stop is in flight (that's the dedupe key) and be gone once the
+    thread finishes.
+    """
+    import importlib
+    import os
+    import threading
+
+    # ``operations.stop`` the *attribute* is the verb function (the
+    # package re-exports it), so reach the module via importlib.
+    stop_mod = importlib.import_module("llauncher.operations.stop")
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+
+    release = threading.Event()
+
+    def slow_terminate(port, **kwargs):
+        release.wait(timeout=10)
+        return True
+
+    with patch("llauncher.operations.proc.stop_server_by_port", slow_terminate):
+        result = ops.stop_in_background(8081, caller="test")
+        assert result.action == "stopping"
+
+        # In flight: the registry entry is live (it's the dedupe key).
+        with stop_mod._inflight_lock:
+            assert 8081 in stop_mod._inflight
+
+        release.set()
+        # wait_for_stop joins the thread; the reap runs in the thread's
+        # ``finally`` *before* termination, so post-join it has landed.
+        assert ops.wait_for_stop(8081, timeout=10) is True
+
+    with stop_mod._inflight_lock:
+        assert 8081 not in stop_mod._inflight
+
+
+# ---------------------------------------------------------------------------
+# join_inflight_stop (PR #161 review: reaper coalesce)
+# ---------------------------------------------------------------------------
+
+
+def test_join_inflight_stop_returns_false_when_nothing_in_flight(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """No in-flight stop → ``False``: the caller must drive its own stop.
+
+    Contrast ``wait_for_stop``, which answers ``True`` here ("nothing
+    remains in flight"). The coalescing caller needs the distinction —
+    a bare ``True`` would make the reaper skip a port nobody stopped.
+    """
+    assert ops.join_inflight_stop(8081, timeout=0) is False
+
+
+def test_join_inflight_stop_running_then_completed(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Still-running stop → ``False`` (fall back); completed → ``True`` (skip)."""
+    import os
+    import threading
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+
+    release = threading.Event()
+
+    def slow_terminate(port, **kwargs):
+        release.wait(timeout=10)
+        return True
+
+    with patch("llauncher.operations.proc.stop_server_by_port", slow_terminate):
+        assert ops.stop_in_background(8081, caller="test").action == "stopping"
+
+        # Gate still held: the join times out → caller would fall back
+        # to the blocking stop.
+        assert ops.join_inflight_stop(8081, timeout=0) is False
+
+        release.set()
+        # Gate released: the in-flight stop completes within the budget
+        # → caller skips its own stop.
+        assert ops.join_inflight_stop(8081, timeout=10) is True
+
+
 # ---------------------------------------------------------------------------
 # Result serialization
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -365,6 +365,151 @@ def test_stop_when_termination_fails(run_dir: Path, audit_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# stop_in_background (issue #140)
+# ---------------------------------------------------------------------------
+#
+# Timing discipline: no real grace-period sleeps. The "slow shutdown" is a
+# threading.Event the test controls; every wait is bounded so a regression
+# fails fast instead of hanging the suite.
+
+
+def test_stop_in_background_returns_while_termination_pending(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Caller-side success on a slow-but-successful shutdown (issue #140).
+
+    The call must return ``stopping`` immediately while the (held-open)
+    termination is still in flight, then complete the durable effects —
+    lockfile removal + STOPPED/SUCCESS audit — once the grace resolves.
+    """
+    import os
+    import threading
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+
+    release = threading.Event()
+    calls: list[int] = []
+
+    def slow_terminate(port, **kwargs):
+        calls.append(port)
+        release.wait(timeout=10)  # simulated SIGTERM grace, bounded
+        return True
+
+    with patch("llauncher.operations.proc.stop_server_by_port", slow_terminate):
+        result = ops.stop_in_background(8081, caller="test")
+
+        # Returned before the termination resolved.
+        assert result.success is True
+        assert result.action == "stopping"
+        assert result.model == "mistral-7b"
+        assert result.pid == os.getpid()
+        # Pending: claim still on disk, no audit yet.
+        assert lf.read_lockfile(8081, run_dir=run_dir) is not None
+        assert al.read_entries(path=audit_path) == []
+
+        release.set()
+        assert ops.wait_for_stop(8081, timeout=10) is True
+
+    # Durable effects landed on the background thread.
+    assert calls == [8081]
+    assert lf.read_lockfile(8081, run_dir=run_dir) is None
+    entries = al.read_entries(path=audit_path)
+    assert len(entries) == 1
+    assert entries[0].action == AuditAction.STOPPED
+    assert entries[0].result == AuditResult.SUCCESS
+    assert entries[0].model == "mistral-7b"
+
+
+def test_stop_in_background_repeat_request_is_deduped(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """A second stop while one is in flight: ``stopping``, no second kill."""
+    import os
+    import threading
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+
+    release = threading.Event()
+    calls: list[int] = []
+
+    def slow_terminate(port, **kwargs):
+        calls.append(port)
+        release.wait(timeout=10)
+        return True
+
+    with patch("llauncher.operations.proc.stop_server_by_port", slow_terminate):
+        first = ops.stop_in_background(8081, caller="test")
+        second = ops.stop_in_background(8081, caller="test")
+
+        assert first.action == "stopping"
+        assert second.action == "stopping"
+        assert second.success is True
+        assert "in progress" in second.message
+
+        release.set()
+        assert ops.wait_for_stop(8081, timeout=10) is True
+
+    # Exactly one termination despite two accepted requests.
+    assert calls == [8081]
+
+
+def test_stop_in_background_empty_port_is_synchronous(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Empty port short-circuits synchronously — identical to ``stop``."""
+    result = ops.stop_in_background(8081, caller="test")
+
+    assert result.success is True
+    assert result.action == "already_empty"
+    assert ops.wait_for_stop(8081, timeout=0) is True  # nothing in flight
+    assert al.read_entries(path=audit_path) == []
+
+
+def test_stop_in_background_stale_lockfile_cleaned_synchronously(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Stale claim (dead pid) reconciles inline, no thread, no kill."""
+    lf.write_lockfile(8081, "ghost", 2**31 - 1, run_dir=run_dir)
+
+    with patch("llauncher.operations.proc.stop_server_by_port") as stop_proc:
+        result = ops.stop_in_background(8081, caller="test")
+
+    assert result.success is True
+    assert result.action == "already_empty"
+    assert result.model == "ghost"
+    stop_proc.assert_not_called()
+    assert lf.read_lockfile(8081, run_dir=run_dir) is None
+
+    entries = al.read_entries(path=audit_path)
+    assert len(entries) == 1
+    assert entries[0].action == AuditAction.OBSERVED_STOPPED
+
+
+def test_stop_in_background_termination_failure_audited(
+    run_dir: Path, audit_path: Path
+) -> None:
+    """Async failure is observable: STOPPED/ERROR audit, lockfile retained."""
+    import os
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+
+    with patch(
+        "llauncher.operations.proc.stop_server_by_port", return_value=False
+    ):
+        result = ops.stop_in_background(8081, caller="test")
+        # The 202-shaped acceptance happens before the failure is known.
+        assert result.action == "stopping"
+        assert ops.wait_for_stop(8081, timeout=10) is True
+
+    # Lockfile NOT removed on error — operator may need to investigate.
+    assert lf.read_lockfile(8081, run_dir=run_dir) is not None
+    entries = al.read_entries(path=audit_path)
+    assert len(entries) == 1
+    assert entries[0].action == AuditAction.STOPPED
+    assert entries[0].result == AuditResult.ERROR
+
+
+# ---------------------------------------------------------------------------
 # Result serialization
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -359,9 +359,9 @@ class TestStopServer:
             "llauncher.core.process.psutil.wait_procs",
             return_value=([], []),
         ) as mock_wait, patch(
-            "llauncher.core.process.settings.LAUNCHER_STOP_CHILD_GRACE_S", 0.25
+            "llauncher.core.process.settings.LLAUNCHER_STOP_CHILD_GRACE_S", 0.25
         ), patch(
-            "llauncher.core.process.settings.LAUNCHER_STOP_GRACE_S", 0.5
+            "llauncher.core.process.settings.LLAUNCHER_STOP_GRACE_S", 0.5
         ):
             result = stop_server_by_pid(12345)
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -275,7 +275,9 @@ class TestStopServer:
                 result = stop_server_by_port(8080)
 
                 assert result is True
-                mock_stop.assert_called_once_with(12345)
+                mock_stop.assert_called_once_with(
+                    12345, child_grace_s=None, grace_s=None
+                )
 
     def test_stop_by_port_not_found(self):
         """Stop server by port when not found."""
@@ -303,6 +305,101 @@ class TestStopServer:
         with patch("psutil.Process", side_effect=psutil.NoSuchProcess(12345, None)):
             result = stop_server_by_pid(12345)
             assert result is False
+
+    def test_stop_by_pid_kills_children_surviving_grace(self):
+        """Issue #140: a child that outlives its SIGTERM grace is SIGKILLed.
+
+        Previously only the main process escalated to ``kill()``; a child
+        ignoring SIGTERM leaked past the stop. ``wait_procs`` is faked so
+        no real grace period elapses.
+        """
+        mock_proc = MagicMock()
+        survivor = MagicMock()
+        deceased = MagicMock()
+        mock_proc.children.return_value = [survivor, deceased]
+
+        with patch("psutil.Process", return_value=mock_proc), patch(
+            "llauncher.core.process.psutil.wait_procs",
+            return_value=([deceased], [survivor]),
+        ) as mock_wait:
+            result = stop_server_by_pid(12345, child_grace_s=0.01, grace_s=0.01)
+
+        assert result is True
+        survivor.terminate.assert_called_once()
+        survivor.kill.assert_called_once()  # grace expired → no leak
+        deceased.kill.assert_not_called()  # exited within grace
+        mock_wait.assert_called_once_with([survivor, deceased], timeout=0.01)
+
+    def test_stop_by_pid_child_gone_before_kill_is_tolerated(self):
+        """A survivor that exits between wait and kill is success, not error."""
+        mock_proc = MagicMock()
+        survivor = MagicMock()
+        survivor.kill.side_effect = psutil.NoSuchProcess(54321, None)
+        mock_proc.children.return_value = [survivor]
+
+        with patch("psutil.Process", return_value=mock_proc), patch(
+            "llauncher.core.process.psutil.wait_procs",
+            return_value=([], [survivor]),
+        ):
+            result = stop_server_by_pid(12345, child_grace_s=0.01, grace_s=0.01)
+
+        assert result is True
+        mock_proc.terminate.assert_called_once()
+
+    def test_stop_by_pid_grace_defaults_read_from_settings_at_call_time(self):
+        """Grace periods come from settings when not passed (issue #140).
+
+        Read at call time — not captured at import — so env-configured
+        profiles and test patches both take effect.
+        """
+        mock_proc = MagicMock()
+        mock_proc.children.return_value = []
+
+        with patch("psutil.Process", return_value=mock_proc), patch(
+            "llauncher.core.process.psutil.wait_procs",
+            return_value=([], []),
+        ) as mock_wait, patch(
+            "llauncher.core.process.settings.LAUNCHER_STOP_CHILD_GRACE_S", 0.25
+        ), patch(
+            "llauncher.core.process.settings.LAUNCHER_STOP_GRACE_S", 0.5
+        ):
+            result = stop_server_by_pid(12345)
+
+        assert result is True
+        mock_wait.assert_called_once_with([], timeout=0.25)
+        mock_proc.wait.assert_called_once_with(timeout=0.5)
+
+    def test_stop_by_pid_explicit_grace_overrides_settings(self):
+        """Explicit keyword grace wins over the settings defaults."""
+        mock_proc = MagicMock()
+        mock_proc.children.return_value = []
+
+        with patch("psutil.Process", return_value=mock_proc), patch(
+            "llauncher.core.process.psutil.wait_procs",
+            return_value=([], []),
+        ) as mock_wait:
+            result = stop_server_by_pid(12345, child_grace_s=0.01, grace_s=0.02)
+
+        assert result is True
+        mock_wait.assert_called_once_with([], timeout=0.01)
+        mock_proc.wait.assert_called_once_with(timeout=0.02)
+
+    def test_stop_by_port_forwards_grace_to_stop_by_pid(self):
+        """``stop_server_by_port`` propagates the grace knobs (issue #140)."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+
+        with patch(
+            "llauncher.core.process.find_server_by_port", return_value=mock_proc
+        ), patch(
+            "llauncher.core.process.stop_server_by_pid", return_value=True
+        ) as mock_stop:
+            result = stop_server_by_port(8080, child_grace_s=0.01, grace_s=0.02)
+
+        assert result is True
+        mock_stop.assert_called_once_with(
+            12345, child_grace_s=0.01, grace_s=0.02
+        )
 
 
 class TestFindServer:

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -324,6 +324,39 @@ class TestRemoteNode:
         assert result["success"] is True
 
     @patch("httpx.Client")
+    def test_stop_server_accepts_202_stopping(self, mock_client_class):
+        """Issue #140: the async-accept envelope (202/``stopping``) is success.
+
+        The agent acknowledges a live stop before the SIGTERM grace runs;
+        the client must report acceptance, not a timeout-shaped failure.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.json = MagicMock(
+            return_value={
+                "success": True,
+                "action": "stopping",
+                "port": 8080,
+                "model": "test-model",
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post = MagicMock(return_value=mock_response)
+
+        mock_client_class.return_value = mock_client
+
+        node = RemoteNode("test-node", "192.168.1.100", port=8765)
+        result = node.stop_server(8080)
+
+        assert result is not None
+        assert result["success"] is True
+        assert result["action"] == "stopping"
+        assert node.status == NodeStatus.ONLINE
+
+    @patch("httpx.Client")
     def test_stop_server_not_found(self, mock_client_class):
         """Test stop_server returns 404 error for missing server."""
         mock_response = MagicMock()

--- a/tests/unit/test_render_op_result.py
+++ b/tests/unit/test_render_op_result.py
@@ -46,7 +46,10 @@ class TestClassifyActionInfo:
 
     @pytest.mark.parametrize(
         "action",
-        ["already_running", "already_empty", "not_found"],
+        # ``stopping`` is the issue-#140 async-accept envelope from a
+        # remote agent: acknowledged, completion pending — INFO, not
+        # SUCCESS (the outcome hasn't landed yet) and not ERROR.
+        ["already_running", "already_empty", "not_found", "stopping"],
     )
     def test_info_actions(self, action: str) -> None:
         assert classify_action(action) is OpResultSeverity.INFO


### PR DESCRIPTION
## Summary

Implements issue #140's preferred **Option A** (non-blocking stop in llauncher). `POST /stop/{port}` previously blocked through the full graceful-shutdown grace (3 s children + 5 s main, ~8 s worst case) while callers default to a 5 s HTTP timeout — so stops that *succeeded* were reported as timeout failures.

## Contract change

- **`POST /stop/{port}`** on a live claim now returns **202** with `action="stopping"` immediately; the SIGTERM → grace → SIGKILL sequence runs on a background thread in the agent. Completion is observable via `GET /status` (port empties) and the audit log (`STOPPED` `SUCCESS`/`ERROR`). Mirrors ADR-014's `/cancel/{port}` in-flight semantics: acknowledge now, don't block on the outcome.
- Empty/stale port stays synchronous **200** `already_empty` (idempotent, unchanged). Repeat stop while one is in flight → 202 `stopping` again, deduped (no second kill).
- Termination *failure* now lands in the audit log after the 202 instead of a 500 — inherent to async-accept; the port stays visibly occupied in status.

## Callers (consistency)

- **remote client** (`RemoteNode.stop_server`): accepts the 202 envelope as success; self-loop path deliberately keeps the blocking `ops.stop` (no transport timeout in-process; a short-lived caller must not exit mid-grace).
- **CLI / MCP server**: keep the synchronous verb for the same reason — they get the definitive `stopped` result with no timeout to violate.
- **UI**: `classify_action("stopping")` → INFO (accepted-pending, not ✅-done).
- **Agent lifespan reaper (#65)**: still uses blocking stop; re-drives any background stop interrupted by agent shutdown, so daemon worker threads cannot leak a half-stopped server.

## Also fixed in core.process (issue scope: "no hung-process leak when grace expires")

- Children that outlive their SIGTERM grace are now **SIGKILLed** like the main process — previously they leaked.
- Grace periods are settings-driven at call time (`LAUNCHER_STOP_CHILD_GRACE_S` / `LAUNCHER_STOP_GRACE_S`, defaults 3/5 s) with per-call overrides, so slow-GPU deployments can lengthen and test profiles can shorten without code changes.

## Tests

Timing-shaped without real sleeps: the slow shutdown is a held `threading.Event` released only after asserting the caller already has its 202/`stopping` response; all waits bounded. Covers: caller-side success on slow-but-successful shutdown (ops layer + end-to-end through the FastAPI endpoint), in-flight dedupe, synchronous already_empty/stale paths, async failure audited with lockfile retained, child kill-escalation at grace expiry, settings-vs-explicit grace resolution, remote-client 202 acceptance, UI severity.

`tests/` fully green (1064 passed, 11 skipped), coverage **94.97%** (gate 93).

## Note

First commit (`7191f78`) fixes a **pre-existing** suite failure on main: the #142 comment in `scripts/systemd/install.sh` re-stated the legacy `LAUNCHER_AGENT_*` token key verbatim, tripping `test_no_legacy_env_var_names_in_tracked_source` since `d42fbb7`. Reworded the comment rather than weakening the guard's allowlist.

Fixes #140