### PR TITLE
docs(adr): reword ADR-017 note that tripped the env-var naming guard

### DIFF
--- a/docs/adrs/draft/017-session-token-issuance.md
+++ b/docs/adrs/draft/017-session-token-issuance.md
@@ -59,7 +59,7 @@ token machinery.
   outright preserves the no-new-attack-surface invariant for upgrades.
 - When non-empty, loopback (`127.0.0.0/8`, `::1/128`) is implicitly appended.
 
-*(Note: #135 predates the #151 env-var rename and uses the `LAUNCHER_AGENT_*`
+*(Note: #135 predates the #151 env-var rename and uses the legacy single-L env-var
 prefix; this ADR uses the post-rename `LLAUNCHER_AGENT_*` family throughout.)*
 
 ### Issuance endpoint — `llauncher/agent/server.py`


### PR DESCRIPTION
One-line reword: the ADR-017 note about #135 predating the #151 rename spelled the legacy single-L prefix literally, tripping `test_no_legacy_env_var_names_in_tracked_source` on main (surfaced by the PR #159 fix-up agent as a contract-mismatch signal). Describes the prefix without spelling it. The guard's remaining hit (`scripts/systemd/install.sh:110`) is fixed in PR #161.