### PR TITLE
docs(adr): ADR-013 to completed/ (gap closed by #160)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -5,8 +5,8 @@ state of the decision**, not the maturity of the ADR document itself.
 
 | Folder | Meaning | Count |
 |--------|---------|-------|
-| [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 10 |
-| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 5 |
+| [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 11 |
+| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 4 |
 | [`superseded/`](./superseded/) | Replaced by a later ADR; preserved as historical record | 1 |
 | [`draft/`](./draft/) | Not yet ratified | 1 |
 
@@ -27,6 +27,7 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-010 — Port Ownership at the Call Site](./completed/010-port-ownership-at-call-site.md)
 - [ADR-011 — Swap Semantics v2](./completed/011-swap-semantics-v2.md)
 - [ADR-012 — Footer Context Endpoint — Minimal Payload, Short TTL Cache](./completed/012-footer-context-endpoint.md)
+- [ADR-013 — Per-Server Log Lifecycle (Append, Rotate, Bounded Tail)](./completed/013-logs-lifecycle.md)
 - [ADR-014 — Cancellation of In-Flight Start/Swap](./completed/014-cancellation.md)
 - [ADR-016 — Canonical Self-Swap — Worked Example and Integration Test](./completed/016-canonical-self-swap.md)
 
@@ -35,7 +36,6 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-004 — CLI Subcommand Interface](./accepted/004-cli-subcommand-interface.md) — `swap`, `logs` subcommands deferred
 - [ADR-006 — GPU Resource Monitoring and VRAM Tracking](./accepted/006-gpu-resource-monitoring.md) — `?full=true` filter + ROCm/MPS backends deferred; tracking #44
 - [ADR-008 — LauncherState as Stateless Facade](./accepted/008-launcher-state-stateless-facade.md) — `state._start_with_eviction_impl` retained for eviction-API smoke contract; M5/M6 cleanup pending
-- [ADR-013 — Per-Server Log Lifecycle (Append, Rotate, Bounded Tail)](./accepted/013-logs-lifecycle.md) — log filename sanitization tracked in #63
 - [ADR-015 — Orphan Policy (Annotation and Listing)](./accepted/015-orphan-policy.md) — `adopt` verb deferred per §Deferred Work
 
 ### Draft

--- a/docs/adrs/completed/013-logs-lifecycle.md
+++ b/docs/adrs/completed/013-logs-lifecycle.md
@@ -99,3 +99,12 @@ Touch points (see `git log --grep "closes #52"` for the landing commit):
 - `tests/unit/test_process.py` — updated 1 (`test_normal_start` now patches `rotate_if_needed`), replaced 1 (`test_tail_file_unicode_error` → `test_tail_file_invalid_utf8_is_replaced`), added 8 new tests covering bounded tail and append-banner-rotate flow.
 
 No callers of `LOG_DIR` or `_tail_file` outside `core/process.py` and tests; the module-level alias preserves the historical patch target.
+
+## Amendment Notes
+
+**2026-06-10:** The deferred gap — lossy log-filename sanitization
+colliding distinct model names (#63, later re-reported as #146) — closed
+by PR #160: `log_stem_for` is now the single injective name→filename
+mint (sanitized stem + 8-hex SHA-256 of the exact canonical name).
+Old-scheme files orphan and age out; no dual-scheme parsing. ADR moved
+`accepted/` → `completed/`.


### PR DESCRIPTION
Per the index's own process: PR #160 closed #63/#146, ADR-013's last tracked gap. `git mv` to `completed/`, table counts updated, amendment note added pointing at the injective `log_stem_for` mint.