### PR TITLE
fix(models): make path-validation skip flag context-local, not class state

### DIFF
--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -7,14 +7,50 @@ is implemented in M1, vLLM follows in M6.
 """
 
 import shlex
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import Iterator, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from llauncher.core.settings import BLACKLISTED_PORTS as _ENV_BLACKLISTED_PORTS
+
+
+# Context-local skip flag for the ``model_path`` existence validator
+# (issue #88). A ``ContextVar`` instead of a class attribute for two
+# reasons:
+#
+# * Pydantic v2 turned the original underscore-prefixed class annotation
+#   into a ``ModelPrivateAttr`` descriptor — truthy at the class level —
+#   which silently no-op'd the validator on a fresh process (#88a).
+# * The replacement ``ClassVar`` toggle in ``from_dict_unvalidated`` was
+#   shared mutable state: one thread's ``finally``-reset could re-enable
+#   validation while another thread was mid-``model_validate`` (#88b).
+#
+# A ``ContextVar`` is local to the calling thread / async task, so the
+# race is structurally impossible: no construction can observe another
+# caller's skip window.
+_SKIP_PATH_VALIDATION: ContextVar[bool] = ContextVar(
+    "llauncher_skip_path_validation", default=False
+)
+
+
+@contextmanager
+def _path_validation_disabled() -> Iterator[None]:
+    """Disable ``ModelConfig.model_path`` existence checks in this context.
+
+    Scoped to the current thread / async task via ``ContextVar``; concurrent
+    callers outside the ``with`` block still validate normally. The token
+    reset in ``finally`` restores the *prior* value, so nesting is safe.
+    """
+    token = _SKIP_PATH_VALIDATION.set(True)
+    try:
+        yield
+    finally:
+        _SKIP_PATH_VALIDATION.reset(token)
 
 
 # Deny-list of llama-server flags llauncher manages at its own boundary
@@ -99,14 +135,6 @@ class ModelConfig(BaseModel):
     mlock: bool = False
     extra_args: str = ""
 
-    # ClassVar (not Pydantic field): underscore-prefixed annotations are
-    # treated as PrivateAttr descriptors by Pydantic v2, which made
-    # ``getattr(cls, "_skip_path_validation", False)`` truthy at the class
-    # level and silently no-op'd the validator on a fresh process. ClassVar
-    # makes this a plain Python class variable so the validator runs as
-    # intended on first construction (see issue #88).
-    _skip_path_validation: ClassVar[bool] = False
-
     @field_validator("extra_args", mode="before")
     @classmethod
     def extra_args_no_managed_flags(cls, v):
@@ -153,8 +181,14 @@ class ModelConfig(BaseModel):
     @field_validator("model_path", mode="before")
     @classmethod
     def model_exists(cls, v: str, info) -> str:
-        """Validate that the model path exists (supports shard patterns)."""
-        if getattr(cls, "_skip_path_validation", False):
+        """Validate that the model path exists (supports shard patterns).
+
+        Skipped inside a :func:`_path_validation_disabled` context (used by
+        :meth:`from_dict_unvalidated` for persisted configs whose files may
+        legitimately be absent on this host). The flag is context-local —
+        see the ``_SKIP_PATH_VALIDATION`` rationale (issue #88).
+        """
+        if _SKIP_PATH_VALIDATION.get():
             return v
 
         path = Path(v)
@@ -187,11 +221,8 @@ class ModelConfig(BaseModel):
         # Migrate extra_args from list[str] to str (legacy v1 shape).
         if "extra_args" in data and isinstance(data["extra_args"], list):
             data["extra_args"] = " ".join(data["extra_args"])
-        cls._skip_path_validation = True
-        try:
+        with _path_validation_disabled():
             return cls.model_validate(data)
-        finally:
-            cls._skip_path_validation = False
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""

--- a/tests/unit/test_models_config_extended.py
+++ b/tests/unit/test_models_config_extended.py
@@ -6,6 +6,9 @@ path validators.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -16,6 +19,7 @@ from llauncher.models.config import (
     ChangeRules,
     AuditEntry,
     RunningServer,
+    _path_validation_disabled,
 )
 
 
@@ -26,10 +30,11 @@ from llauncher.models.config import (
 class TestModelConfigPathValidation:
     """Path-existence validator on ``ModelConfig.model_path``.
 
-    Issue #88(a) resolved the prior order-dependency: ``_skip_path_validation``
-    is now a ``ClassVar[bool]`` rather than a Pydantic field, so the validator
-    runs on first construction without requiring a prior call to
-    ``from_dict_unvalidated`` to prime the class attribute.
+    Issue #88 resolved the prior order-dependency: the skip flag is a
+    context-local ``ContextVar`` (entered via ``_path_validation_disabled``)
+    rather than a Pydantic private attr or mutable class attribute, so the
+    validator runs on first construction in a fresh process and concurrent
+    callers cannot observe each other's skip window.
     """
 
     def test_missing_path_raises(self, tmp_path: Path) -> None:
@@ -51,6 +56,80 @@ class TestModelConfigPathValidation:
         missing = tmp_path / "does-not-exist.gguf"  # no ``-of-`` shard marker
         with pytest.raises(ValueError, match="does not exist"):
             ModelConfig(name="m", model_path=str(missing))
+
+    def test_fresh_process_validates_missing_path(self, tmp_path: Path) -> None:
+        """Regression for issue #88(a): on a *fresh* interpreter — no prior
+        ``from_dict_unvalidated`` call in the process — constructing with a
+        missing ``model_path`` must raise.
+
+        Run in a subprocess because the bug was order-dependent: the old
+        PrivateAttr descriptor was truthy at the class level, so the very
+        first construction in a process silently skipped validation. In-suite
+        tests cannot prove the fresh-process behavior.
+        """
+        missing = tmp_path / "no-such-fresh.gguf"
+        script = (
+            "from llauncher.models.config import ModelConfig\n"
+            "try:\n"
+            f"    ModelConfig(name='m', model_path={str(missing)!r})\n"
+            "except ValueError as e:\n"
+            "    assert 'does not exist' in str(e), str(e)\n"
+            "else:\n"
+            "    raise SystemExit('validator silently skipped on fresh process')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_skip_window_is_isolated_across_threads(self, tmp_path: Path) -> None:
+        """Issue #88(b): the skip flag is context-local, so another thread's
+        open skip window must not disable validation here.
+
+        Behavioral (not a stress test): the ``ContextVar`` mechanism makes
+        the old class-attribute race structurally impossible, so it suffices
+        to hold a skip window open in one thread and assert the main thread
+        still validates.
+        """
+        window_open = threading.Event()
+        release = threading.Event()
+        skipped_cfg: list[ModelConfig] = []
+
+        def hold_skip_window() -> None:
+            with _path_validation_disabled():
+                # Inside the window this thread may construct with a
+                # nonexistent path...
+                skipped_cfg.append(
+                    ModelConfig(name="m", model_path="/fake/elsewhere.gguf")
+                )
+                window_open.set()
+                release.wait(timeout=10)
+
+        t = threading.Thread(target=hold_skip_window)
+        t.start()
+        try:
+            assert window_open.wait(timeout=10)
+            # ...while the main thread, concurrently, still validates.
+            missing = tmp_path / "missing-while-window-open.gguf"
+            with pytest.raises(ValueError, match="does not exist"):
+                ModelConfig(name="m", model_path=str(missing))
+        finally:
+            release.set()
+            t.join(timeout=10)
+        assert skipped_cfg and skipped_cfg[0].model_path == "/fake/elsewhere.gguf"
+
+    def test_skip_window_restored_after_exception(self) -> None:
+        """The skip flag resets even when validation fails inside the window
+        (e.g. ``from_dict_unvalidated`` on data failing a *different*
+        validator), so later constructions validate normally."""
+        with pytest.raises(ValueError, match="llauncher-managed flag"):
+            ModelConfig.from_dict_unvalidated({
+                "name": "m",
+                "model_path": "/fake/path.gguf",
+                "extra_args": "--api-key sneaky",
+            })
+        with pytest.raises(ValueError, match="does not exist"):
+            ModelConfig(name="m", model_path="/fake/still-validated.gguf")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ModelConfig._skip_path_validation` was a mutable class attribute toggled by `from_dict_unvalidated`. Issue #88 identified two defects:

- **88(a)** — the original underscore annotation became a truthy Pydantic v2 `PrivateAttr` descriptor, silently no-op'ing the `model_path` existence validator on a fresh process (already mitigated on main via `ClassVar`).
- **88(b)** — the remaining class-level toggle was shared mutable state: one thread's `finally`-reset could re-enable validation while another thread was mid-`model_validate`.

This PR lands the issue's prescribed option 2: the flag is now a module-level `ContextVar` entered via a `_path_validation_disabled()` context manager. Context-locality makes the race **structurally impossible** — no construction can observe another caller's skip window — and token-based reset makes nesting and exception paths safe.

No caller-facing API change: `from_dict_unvalidated` keeps its signature, and nothing outside `models/config.py` touched the flag (only production caller is `core/config.py`, unchanged). Imports added are stdlib-only, so `models/` remains the dependency-free floor per `.claude/architecture.md`.

## Tests

- `test_fresh_process_validates_missing_path` — subprocess-based regression for 88(a); the in-suite test could not prove first-construction-in-process behavior.
- `test_skip_window_is_isolated_across_threads` — behavioral test for 88(b): a skip window held open in one thread does not disable validation in the main thread. Behavioral rather than stress-shaped because the mechanism removes the shared state entirely.
- `test_skip_window_restored_after_exception` — flag resets when a different validator fails inside the window.

## Gates

- `python -m pytest tests/ -q`: 1095 passed, 11 skipped
- `--cov-fail-under=93`: 95.06% total

Fixes #88