### PR TITLE
docs(provisioning): Phase 0 operability docs for manual token-copy flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+### Documentation
+
+- **UI auth restored end-to-end after the security-hardening cohort
+  (#131, #132, #134).** Phase 0 of the cross-node auth provisioning
+  roadmap (#137): the manual token-copy pairing flow is now documented
+  — README "Adding a remote node" walkthrough with per-platform token
+  paths, platform-specific Add Node form help text, and an info banner
+  pointing at the planned trusted-host successor (ADR-017 draft, #135).
+  Docs are explicit that the static token is a trusted-LAN convenience,
+  not strong auth.
+
 ### Breaking changes
 
 - **Agent env-var family renamed (#138).** The four service-facing agent

--- a/README.md
+++ b/README.md
@@ -447,15 +447,71 @@ The dashboard will automatically:
 
 #### 4. Add Remote Nodes
 
-In the dashboard:
-1. Go to the **Nodes** tab
-2. Click **➕ Add New Node**
-3. Enter:
+Follow the walkthrough in [Adding a remote node](#adding-a-remote-node)
+below — it includes the manual token-copy step that pairing currently
+requires.
+
+### Adding a remote node
+
+Pairing the dashboard with a remote agent currently requires copying the
+remote agent's API token by hand. This is the documented current path
+(Phase 0 of the provisioning roadmap, #137); trusted-host session-token
+issuance (ADR-017, draft at `docs/adrs/draft/017-session-token-issuance.md`,
+issue #135) is the planned successor in v0.4.0 and will eliminate the
+copy step. These docs describe what ships today.
+
+**Where the token lives on the remote box:**
+
+- **Linux**: `~/.llauncher/agent.token` — mirrored from
+  `~/.config/llauncher/agent.env` (`$XDG_CONFIG_HOME/llauncher/agent.env`
+  if set) by `scripts/systemd/install.sh`.
+- **Windows**: `%USERPROFILE%\.llauncher\agent.token` — mirrored from
+  `%USERPROFILE%\.llauncher\agent.env` by `scripts/windows/install.ps1`.
+
+If you start the agent by hand instead of via an installer, the token is
+whatever you set in `LLAUNCHER_AGENT_TOKEN` (required for any
+non-loopback bind — the agent refuses to start without it).
+
+**Step by step:**
+
+1. SSH (Linux) or RDP/PowerShell-remote (Windows) to the remote box and
+   print the token:
+
+   ```bash
+   # Linux
+   cat ~/.llauncher/agent.token
+   ```
+
+   ```powershell
+   # Windows
+   Get-Content $env:USERPROFILE\.llauncher\agent.token
+   ```
+
+2. Copy the printed value.
+3. On the dashboard machine, go to the **Nodes** tab and open
+   **➕ Add New Node**.
+4. Enter:
    - **Node Name**: Friendly name (e.g., `linux-box`, `windows-server`)
    - **Host**: IP address or hostname (e.g., `192.168.1.100`)
    - **Port**: Agent port (default: `8765`)
-4. Click **🔍 Test Connection** to verify
-5. Click **➕ Add Node** to register
+   - **API Key**: paste the token from step 2
+5. Click **🔍 Test Connection** to verify
+6. Click **➕ Add Node** to register
+
+**Rotating a token later:** update it on *both* sides — change
+`LLAUNCHER_AGENT_TOKEN` in the remote's `agent.env`, re-run the installer
+(or re-mirror the token file) and restart the agent, then paste the new
+value into the node's **🔑 Edit API key** expander on the Nodes tab.
+
+**Threat-model honesty (trusted LAN only):** the static token is a shared
+secret sent as an `X-Api-Key` header over plain HTTP — no TLS, no mutual
+authentication. Anyone who can sniff the LAN segment can read it, and
+anyone who has it can do anything the agent can do. It gates accidental
+access on a network where every host is already trusted; it is **not**
+strong auth. Only expose agents on networks you trust end-to-end
+(Tailscale or another WireGuard-class overlay is the recommended way to
+get cross-host trust). TLS/mTLS for hostile networks is tracked
+separately (#86).
 
 ### Network Configuration
 

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -187,6 +187,16 @@ def render_add_node_form(registry: NodeRegistry) -> None:
     Args:
         registry: NodeRegistry instance.
     """
+    # Phase 0 provisioning banner (#134): the manual token-copy flow is
+    # the *current* path; trusted-host session-token issuance (ADR-017
+    # draft, #135) is the planned successor in v0.4.0.
+    st.info(
+        "Adding a remote node currently requires copying the remote "
+        "agent's API token by hand — see README § \"Adding a remote "
+        "node\". Trusted-host session-token issuance (ADR-017, #135) "
+        "will eliminate this step in v0.4.0."
+    )
+
     with st.form("add_node_form", clear_on_submit=True):
         node_name = st.text_input(
             "Node Name",
@@ -218,8 +228,10 @@ def render_add_node_form(registry: NodeRegistry) -> None:
             "API Key",
             type="password",
             help=(
-                "Token from the remote agent's LLAUNCHER_AGENT_TOKEN / "
-                "agent.token. Required for non-loopback agents (per ADR-003). "
+                "On the remote box, run `cat ~/.llauncher/agent.token` "
+                "(Linux) or `Get-Content $env:USERPROFILE\\.llauncher"
+                "\\agent.token` (Windows) and paste the value here. "
+                "Required for non-loopback agents (per ADR-003). "
                 "Leave blank for unauthenticated loopback agents."
             ),
         )

--- a/tests/unit/test_nodes_tab.py
+++ b/tests/unit/test_nodes_tab.py
@@ -1,0 +1,59 @@
+"""Smoke tests for the Nodes tab Add Node form copy (#134, Phase 0).
+
+These pin the operability strings shipped by the Phase 0 provisioning
+docs (issue #134 / roadmap #137): the manual-token-copy info banner and
+the platform-specific API Key help text. They use the same mock-``st``
+pattern as ``test_models_tab.py`` — a real rendered-output smoke is
+deferred to the Streamlit AppTest harness (#69).
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestAddNodeFormProvisioningCopy:
+    """Phase 0 (#134) banner + help-text strings on the Add Node form."""
+
+    def _patch_st(self, mock_st):
+        """Wire up the Streamlit mocks the form needs."""
+
+        def mock_columns(n):
+            count = len(n) if isinstance(n, list) else n
+            return [MagicMock() for _ in range(count)]
+
+        mock_st.columns.side_effect = mock_columns
+        # Neither Test Connection nor Add Node is clicked.
+        mock_st.form_submit_button.return_value = False
+        return mock_st
+
+    def _render(self, mock_st):
+        from llauncher.ui.tabs.nodes import render_add_node_form
+
+        self._patch_st(mock_st)
+        render_add_node_form(MagicMock())
+
+    def test_manual_token_copy_banner_renders(self):
+        """An info banner surfaces the manual flow and its successor."""
+        with patch("llauncher.ui.tabs.nodes.st") as mock_st:
+            self._render(mock_st)
+
+        mock_st.info.assert_called_once()
+        banner = mock_st.info.call_args.args[0]
+        assert "API token by hand" in banner
+        assert "Adding a remote node" in banner  # README section pointer
+        assert "#135" in banner  # session-token issuance successor
+
+    def test_api_key_help_names_both_platform_commands(self):
+        """First-contact help tells you what the field wants, per platform."""
+        with patch("llauncher.ui.tabs.nodes.st") as mock_st:
+            self._render(mock_st)
+
+        api_key_calls = [
+            call
+            for call in mock_st.text_input.call_args_list
+            if call.args and call.args[0] == "API Key"
+        ]
+        assert len(api_key_calls) == 1
+        help_text = api_key_calls[0].kwargs["help"]
+        assert "cat ~/.llauncher/agent.token" in help_text
+        assert "Get-Content $env:USERPROFILE\\.llauncher\\agent.token" in help_text
+        assert "ADR-003" in help_text


### PR DESCRIPTION
Phase 0 of the cross-node auth provisioning roadmap (#137), target v0.3.1. Docs only, plus UI copy strings — no design change. Fixes #134.

## What ships

1. **README — "Adding a remote node" walkthrough** (new section under Multi-Node Management; Deployment step 4 now points at it):
   - Per-platform token locations: Linux `~/.llauncher/agent.token` (mirrored from `~/.config/llauncher/agent.env` by `scripts/systemd/install.sh`); Windows `%USERPROFILE%\.llauncher\agent.token` (mirrored from `%USERPROFILE%\.llauncher\agent.env` by `scripts/windows/install.ps1`). Paths verified against both installers.
   - Step-by-step: SSH/RDP → `cat` / `Get-Content` the token file → paste into the Add Node form → Test Connection → Add Node.
   - Token-rotation note (both sides must change; UI side via the per-node 🔑 Edit API key expander).
   - **Threat-model honesty box**: the static token is a shared secret over plain HTTP — no TLS, no mutual auth; it gates accidental access on a trusted LAN and is *not* strong auth. Trusted-host session-token issuance (ADR-017 draft, `docs/adrs/draft/017-session-token-issuance.md`, #135) is named as the planned v0.4.0 successor; mTLS for hostile networks deferred to #86. These docs describe what ships today.

2. **Add Node form help text** (`llauncher/ui/tabs/nodes.py`): generic "Token from the remote agent's LLAUNCHER_AGENT_TOKEN / agent.token" replaced with platform-specific `cat ~/.llauncher/agent.token` / `Get-Content $env:USERPROFILE\.llauncher\agent.token` guidance. ADR-003 loopback-exemption sentence retained.

3. **Info banner** (`st.info`) above the Add Node form surfacing the manual nature of the flow and its #135 successor.

4. **CHANGELOG**: v0.3.1 release-notes line — "UI auth restored end-to-end after the security-hardening cohort (#131, #132, #134)."

## Scope call

Issue item 4 (optional `llauncher-agent print-token` CLI affordance) is **deferred to Phase 1** — this PR is constrained to docs + UI strings per the dispatch contract.

## Tests

`tests/unit/test_nodes_tab.py` — two mock-`st` smoke tests pinning the banner string and the API Key help text, following the `test_models_tab.py` pattern. A real rendered-output smoke remains deferred to the Streamlit AppTest harness (#69); `ui/tabs` stays outside the coverage floor scope per `pytest.ini`.

## Gates

- `python -m pytest tests/ -q`: **1094 passed, 11 skipped**
- `python -m pytest tests/ --cov-fail-under=93`: **95.02% ≥ 93%**

Fixes #134