### PR TITLE
fix(env): rename remaining single-L LAUNCHER_* env vars to LLAUNCHER_* (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,50 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
   Fresh `scripts/systemd/install.sh` and `scripts/windows/install.ps1`
   runs write the new names. Existing `agent.env` files are **not**
   auto-migrated.
+
+- **Remaining single-L env vars renamed (#151).** The rest of the
+  `LAUNCHER_*` surface — the `core/settings.py` path/log/cache family
+  plus the runner scripts' UI bind address — now carries the same
+  leading `L` as the #138 agent family:
+
+  | Old                       | New                        |
+  | ------------------------- | -------------------------- |
+  | `LAUNCHER_RUN_DIR`        | `LLAUNCHER_RUN_DIR`        |
+  | `LAUNCHER_AUDIT_PATH`     | `LLAUNCHER_AUDIT_PATH`     |
+  | `LAUNCHER_LOG_DIR`        | `LLAUNCHER_LOG_DIR`        |
+  | `LAUNCHER_LOG_MAX_BYTES`  | `LLAUNCHER_LOG_MAX_BYTES`  |
+  | `LAUNCHER_LOG_KEEP`       | `LLAUNCHER_LOG_KEEP`       |
+  | `LAUNCHER_FOOTER_CACHE_S` | `LLAUNCHER_FOOTER_CACHE_S` |
+  | `LAUNCHER_UI_HOST`        | `LLAUNCHER_UI_HOST`        |
+
+  As with #138, there is **no runtime fallback shim** (pre-v1): a
+  legacy single-L name set in the environment is silently ignored and
+  the documented default applies. All of these vars default sensibly
+  (`~/.llauncher/...` paths, loopback UI bind), so only deployments
+  that explicitly override them — e.g. volume-mounted container state
+  per ADR-008 — need to act.
+
+  **Operator migration** — these vars live wherever *you* export them
+  (shell profile, container env, a repo-local `.env`, or `agent.env`
+  for the systemd/NSSM service). The one-liners below cover the two
+  managed files; fix shell exports by hand:
+
+  - **Linux / systemd:**
+
+    ```sh
+    sed -i 's/^LAUNCHER_/LLAUNCHER_/' "${XDG_CONFIG_HOME:-$HOME/.config}/llauncher/agent.env"
+    [ -f .env ] && sed -i 's/^LAUNCHER_/LLAUNCHER_/' .env   # from the repo root, if you keep one
+    sudo systemctl restart llauncher-agent
+    ```
+
+  - **Windows / NSSM:**
+
+    ```powershell
+    (Get-Content $env:USERPROFILE\.llauncher\agent.env) `
+      -replace '^LAUNCHER_', 'LLAUNCHER_' `
+      | Set-Content $env:USERPROFILE\.llauncher\agent.env
+    nssm restart llauncher-agent
+    ```
+
+  (The `^LAUNCHER_` anchor also covers any stragglers from the #138
+  agent family in the same file.)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Config CRUD plus the per-model verb buttons. Add / edit / delete configurations 
 Peer registry for multi-node setups. Add / list / remove remote agent nodes, test connectivity, and observe status. The sidebar `node_selector` (`ui/components/node_selector.py`) chooses which node the Models tab acts against.
 
 #### Audit Tab
-Tails the local audit log at `LAUNCHER_AUDIT_PATH` (`~/.llauncher/audit.jsonl` by default). Read-only view of commanded vs. observed events. Remote-node audit access is deferred per #64.
+Tails the local audit log at `LLAUNCHER_AUDIT_PATH` (`~/.llauncher/audit.jsonl` by default). Read-only view of commanded vs. observed events. Remote-node audit access is deferred per #64.
 
 ### CLI
 
@@ -304,7 +304,7 @@ llauncher/
 │   │   ├── marker.py           # In-flight swap/start marker (ADR-011/014)
 │   │   ├── model_health.py     # Cache probe (ADR-005)
 │   │   ├── process.py          # Subprocess management
-│   │   └── settings.py         # LAUNCHER_* env-var family
+│   │   └── settings.py         # LLAUNCHER_* env-var family
 │   ├── models/
 │   │   └── config.py           # Pydantic ModelConfig (no default_port; ADR-010)
 │   ├── remote/                 # Multi-node hub-spoke (ADR-009)
@@ -493,7 +493,7 @@ The sidebar **Node Selector** (`ui/components/node_selector.py`) picks the targe
 - **Dashboard Tab**: read-only running view across the selected node.
 - **Models Tab**: config CRUD + per-model Start / Stop / Swap, acting on the selected node.
 - **Nodes Tab**: registered-nodes list with Test Connection and Remove controls.
-- **Audit Tab**: tails the local `LAUNCHER_AUDIT_PATH`. Remote-node audit access is deferred per #64.
+- **Audit Tab**: tails the local `LLAUNCHER_AUDIT_PATH`. Remote-node audit access is deferred per #64.
 
 ### Troubleshooting
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -802,16 +802,16 @@ def ensure_model_running(model_name: str, port: int):
 
 ## Environment Variables
 
-The v2 `LAUNCHER_*` env-var family (per ADR-008 / ADR-013):
+The v2 `LLAUNCHER_*` env-var family (per ADR-008 / ADR-013):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LAUNCHER_RUN_DIR` | `~/.llauncher/run` | Per-port lockfile and in-flight marker directory |
-| `LAUNCHER_AUDIT_PATH` | `~/.llauncher/audit.jsonl` | JSON Lines audit log (commanded vs. observed) |
-| `LAUNCHER_LOG_DIR` | `~/.llauncher/logs` | Per-server log directory (append mode, ADR-013) |
-| `LAUNCHER_LOG_MAX_BYTES` | `52428800` (50 MiB) | Per-log rotation threshold |
-| `LAUNCHER_LOG_KEEP` | `3` | Retained rotated log files per server |
-| `LAUNCHER_FOOTER_CACHE_S` | `1.0` | `/footer-context/{port}` TTL (seconds; `<= 0` disables) |
+| `LLAUNCHER_RUN_DIR` | `~/.llauncher/run` | Per-port lockfile and in-flight marker directory |
+| `LLAUNCHER_AUDIT_PATH` | `~/.llauncher/audit.jsonl` | JSON Lines audit log (commanded vs. observed) |
+| `LLAUNCHER_LOG_DIR` | `~/.llauncher/logs` | Per-server log directory (append mode, ADR-013) |
+| `LLAUNCHER_LOG_MAX_BYTES` | `52428800` (50 MiB) | Per-log rotation threshold |
+| `LLAUNCHER_LOG_KEEP` | `3` | Retained rotated log files per server |
+| `LLAUNCHER_FOOTER_CACHE_S` | `1.0` | `/footer-context/{port}` TTL (seconds; `<= 0` disables) |
 | `LLAUNCHER_AGENT_HOST` | `127.0.0.1` | HTTP Agent bind host. Non-loopback requires a token. |
 | `LLAUNCHER_AGENT_PORT` | `8765` | HTTP Agent listen port |
 | `LLAUNCHER_AGENT_NODE_NAME` | hostname | Friendly node identifier |

--- a/docs/_audit_module_design.md
+++ b/docs/_audit_module_design.md
@@ -99,7 +99,7 @@
 | File | Gap | Design Doc |
 |------|-----|------------|
 | `core/process.py` | Log files opened in `"w"` mode (truncate) instead of `"a"` (append) | M5 Item 2: "Logs survive restarts" |
-| `core/lockfile.py` | No env-var sentinel (`LAUNCHER_OWNED_PID`) yet - still argv-based | ADR-012 Amendment Notes for ADR-008 |
+| `core/lockfile.py` | No env-var sentinel (`LLAUNCHER_OWNED_PID`) yet - still argv-based | ADR-012 Amendment Notes for ADR-008 |
 
 #### Roadmap Alignment Notes
 

--- a/docs/adrs/accepted/008-launcher-state-stateless-facade.md
+++ b/docs/adrs/accepted/008-launcher-state-stateless-facade.md
@@ -86,8 +86,8 @@ Persisted as JSON Lines at a configurable path (default `~/.llauncher/audit.json
 
 Both the lockfile dir and the audit log path are configurable via env:
 
-- `LAUNCHER_RUN_DIR` (default `~/.llauncher/run`)
-- `LAUNCHER_AUDIT_PATH` (default `~/.llauncher/audit.jsonl`)
+- `LLAUNCHER_RUN_DIR` (default `~/.llauncher/run`)
+- `LLAUNCHER_AUDIT_PATH` (default `~/.llauncher/audit.jsonl`)
 
 so that container deployments can mount them as volumes, enabling in-container agents to introspect the state of llauncher running on the host.
 

--- a/docs/adrs/accepted/013-logs-lifecycle.md
+++ b/docs/adrs/accepted/013-logs-lifecycle.md
@@ -2,17 +2,17 @@
 
 **Status:** Accepted
 **Date:** 2026-05-08
-**Relationship to other ADRs:** ADR-008 (configurable on-disk paths) extends here with `LAUNCHER_LOG_DIR`. ADR-005 (model health) is unaffected. The log-name sanitization collision risk flagged in `docs/m5-design.md` is filed separately ([#63](https://github.com/shanevcantwell/llauncher/issues/63)) and **out of scope** for this ADR.
+**Relationship to other ADRs:** ADR-008 (configurable on-disk paths) extends here with `LLAUNCHER_LOG_DIR`. ADR-005 (model health) is unaffected. The log-name sanitization collision risk flagged in `docs/m5-design.md` is filed separately ([#63](https://github.com/shanevcantwell/llauncher/issues/63)) and **out of scope** for this ADR.
 
 **Supersedes:** No prior ADR — the previous behaviors (log files opened in `"w"` mode; `_tail_file` slurping the whole file via `f.readlines()`) were undocumented defaults rather than ratified decisions. Replacing them here for the record so a future reader does not assume those choices were intentional.
 
 ## Context
 
-Each `llama-server` child process writes its stdout+stderr to `${LAUNCHER_LOG_DIR}/{name}-{port}.log`. Three problems with the pre-ADR behavior surfaced as M4 work approached:
+Each `llama-server` child process writes its stdout+stderr to `${LLAUNCHER_LOG_DIR}/{name}-{port}.log`. Three problems with the pre-ADR behavior surfaced as M4 work approached:
 
 1. **Truncation on every start.** `start_server` opened the log in `"w"` mode, destroying the previous run's output the moment the user hit "restart" — which is exactly when the previous run's tail was the most useful debugging artifact. The orientation spike (`docs/reviews/2026-05-02-v2-orientation-spike.md` §5) called this out as a Tier 2 deferred item.
 2. **Unbounded growth.** With no rotation, a long-running server's log grew to the disk's limit. The single-user / single-host scope of this project doesn't make this an outage risk in practice, but it does make `_tail_file` — which used `f.readlines()` — slurp the entire file into memory on every call.
-3. **No env override for the log directory.** `LAUNCHER_RUN_DIR` and `LAUNCHER_AUDIT_PATH` (ADR-008) are env-configurable for volume-mounted container deployments; logs are not. An in-container agent that wants to surface host-side logs has no way to point at the host's log directory.
+3. **No env override for the log directory.** `LLAUNCHER_RUN_DIR` and `LLAUNCHER_AUDIT_PATH` (ADR-008) are env-configurable for volume-mounted container deployments; logs are not. An in-container agent that wants to surface host-side logs has no way to point at the host's log directory.
 
 This ADR addresses all three together because they share the same touch point (`core/process.py::start_server` and `_tail_file`) and have no useful intermediate state.
 
@@ -47,7 +47,7 @@ Called from `start_server` *before* the open, the helper checks the live log's s
 
 Rotation is **deliberately** at process-start time, not on every write. We don't own the file descriptor at write time (the child does); a `logging.Handler`-style rotation would have to either fork-and-exec a helper or interrupt the child. Process-start rotation has neither problem and is sufficient for the cadence this project sees (a server is rarely restarted more often than once per minute).
 
-Defaults: `LAUNCHER_LOG_MAX_BYTES = 50 * 1024 * 1024` (50 MiB), `LAUNCHER_LOG_KEEP = 3`. `max_bytes <= 0` disables rotation.
+Defaults: `LLAUNCHER_LOG_MAX_BYTES = 50 * 1024 * 1024` (50 MiB), `LLAUNCHER_LOG_KEEP = 3`. `max_bytes <= 0` disables rotation.
 
 ### 3. Bounded tail in `_tail_file`
 
@@ -57,13 +57,13 @@ For the common 100-line tail of a multi-MB log, this changes the read budget fro
 
 ### 4. Configurable log directory
 
-A new env var `LAUNCHER_LOG_DIR` joins the ADR-008 family:
+A new env var `LLAUNCHER_LOG_DIR` joins the ADR-008 family:
 
 | Env var | Default | Used for |
 |---------|---------|----------|
-| `LAUNCHER_RUN_DIR` | `~/.llauncher/run` | Lockfiles |
-| `LAUNCHER_AUDIT_PATH` | `~/.llauncher/audit.jsonl` | Audit log |
-| `LAUNCHER_LOG_DIR` | `~/.llauncher/logs` | Per-server logs (this ADR) |
+| `LLAUNCHER_RUN_DIR` | `~/.llauncher/run` | Lockfiles |
+| `LLAUNCHER_AUDIT_PATH` | `~/.llauncher/audit.jsonl` | Audit log |
+| `LLAUNCHER_LOG_DIR` | `~/.llauncher/logs` | Per-server logs (this ADR) |
 
 `core/process.py` continues to expose a module-level `LOG_DIR` initialized from the setting, both for backward-compat with existing `patch("llauncher.core.process.LOG_DIR")` test calls and as a single canonical reference inside the module.
 
@@ -78,7 +78,7 @@ A new env var `LAUNCHER_LOG_DIR` joins the ADR-008 family:
 
 ### Negative
 
-- Append mode means the log file grows across runs until the size cap fires. With small per-run output and a low `LAUNCHER_LOG_MAX_BYTES`, rotation can fire on what feels like a "fresh" file. Mitigated by the 50 MiB default — cadence-of-rotation is likely "weeks" for typical use.
+- Append mode means the log file grows across runs until the size cap fires. With small per-run output and a low `LLAUNCHER_LOG_MAX_BYTES`, rotation can fire on what feels like a "fresh" file. Mitigated by the 50 MiB default — cadence-of-rotation is likely "weeks" for typical use.
 - The `_tail_file` heuristic (160 bytes/line × 2) can produce fewer lines than requested if individual log lines are dramatically longer than that. Acceptable: returning a slightly-short tail is better than slurping a multi-GiB file. Callers that need exact line counts can read the rotated archives directly.
 - Rotation is process-start-only: a server that runs for months without restart accumulates one giant live file regardless of `max_bytes`. This is a known acceptable limitation given the project's restart cadence (per ADR-009 hub-spoke topology, restarts are common via swap).
 

--- a/docs/adrs/accepted/015-orphan-policy.md
+++ b/docs/adrs/accepted/015-orphan-policy.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-llauncher claims each model it launches by writing a per-port JSON lockfile in `LAUNCHER_RUN_DIR`. The agent shutdown path (#65) and the reconciliation guarantees of ADR-008 both treat the lockfile registry as the source of truth: anything in it is *managed* and must be reaped on graceful shutdown; anything not in it is invisible.
+llauncher claims each model it launches by writing a per-port JSON lockfile in `LLAUNCHER_RUN_DIR`. The agent shutdown path (#65) and the reconciliation guarantees of ADR-008 both treat the lockfile registry as the source of truth: anything in it is *managed* and must be reaped on graceful shutdown; anything not in it is invisible.
 
 That invisibility is wrong for two recurring operator scenarios:
 

--- a/docs/adrs/completed/011-swap-semantics-v2.md
+++ b/docs/adrs/completed/011-swap-semantics-v2.md
@@ -41,7 +41,7 @@ All four reach the same tool-layer `swap` function, which calls into the statele
 
 If any check fails: `success=false, port_state=unchanged, action=rejected_preflight`. Old model untouched.
 
-**Phase 2 — Take the in-flight marker.** Atomically create `{LAUNCHER_RUN_DIR}/{port}.swap` (open with `O_EXCL`). If creation fails because the file exists, return `rejected_in_progress` immediately. The marker contains caller, timestamp, llauncher pid, and from/to model names — enough for stale-marker reconciliation later.
+**Phase 2 — Take the in-flight marker.** Atomically create `{LLAUNCHER_RUN_DIR}/{port}.swap` (open with `O_EXCL`). If creation fails because the file exists, return `rejected_in_progress` immediately. The marker contains caller, timestamp, llauncher pid, and from/to model names — enough for stale-marker reconciliation later.
 
 **Phase 3 — Stop the old model.** SIGTERM, brief grace period, escalate to SIGKILL if needed. Remove the old lockfile. Audit-log `stopped` (commanded). If stop fails (process refuses to die): release the marker, return `success=false, port_state=unchanged, action=rejected_stop_failed`. Old model is still running; nothing else has changed.
 
@@ -91,7 +91,7 @@ When an LLM agent on model A emits a tool call to swap port P (which A occupies)
 
 ### In-Flight Marker
 
-Per-port marker file at `{LAUNCHER_RUN_DIR}/{port}.swap`, written atomically at the start of Phase 2 and removed at the end of any terminal phase (success, rollback, or failure).
+Per-port marker file at `{LLAUNCHER_RUN_DIR}/{port}.swap`, written atomically at the start of Phase 2 and removed at the end of any terminal phase (success, rollback, or failure).
 
 Contents:
 

--- a/docs/adrs/completed/012-footer-context-endpoint.md
+++ b/docs/adrs/completed/012-footer-context-endpoint.md
@@ -47,7 +47,7 @@ A tiny in-process cache keyed by `port`, with per-entry expiry:
 def get_footer_context(port: int) -> FooterContext | None: ...
 ```
 
-- **TTL:** `LAUNCHER_FOOTER_CACHE_S` seconds (default `1.0`). Set to `0` to disable the cache (every request hits disk).
+- **TTL:** `LLAUNCHER_FOOTER_CACHE_S` seconds (default `1.0`). Set to `0` to disable the cache (every request hits disk).
 - **Cache value:** the fully-resolved tuple `(model, ctx_size, parallel, port, expires_at_monotonic)`.
 - **Cache miss:** read lockfile, then `ConfigStore.get_model(lockfile.model)`. Both calls are cheap and synchronous; no process scan, no GPU probe.
 - **Cache eviction:** lazy. Expired entries are recomputed on the next request for that port. There is no background sweep; the cache size is bounded by the number of ports the agent host has served, which is small (≤ tens for the project's hobby scope).
@@ -88,7 +88,7 @@ If a future deployment surfaces N-port-per-node footers as a real cost, file a s
 
 ### Negative
 
-- The footer can show up to `LAUNCHER_FOOTER_CACHE_S` of staleness after a swap. At the default 1 s this is invisible to a human; at higher values (set deliberately to reduce probe traffic) it becomes the user's choice.
+- The footer can show up to `LLAUNCHER_FOOTER_CACHE_S` of staleness after a swap. At the default 1 s this is invisible to a human; at higher values (set deliberately to reduce probe traffic) it becomes the user's choice.
 - A footer reading from a lockfile whose owning process has died will show ghost data until the next operation on that port reconciles the lockfile. We accept this; the inference channel will fail on the same port and the user will know.
 - Pinning the response shape adds a small change-management cost: future maintainers must amend this ADR rather than expanding the response ad-hoc. This is the intended cost.
 
@@ -103,7 +103,7 @@ Touch points (see `git log --grep "closes #53"` for the landing commit):
 
 - `llauncher/agent/footer_cache.py` — new. `FooterContext` dataclass, `get_footer_context(port)` entry point, module-level dict + lock.
 - `llauncher/agent/routing.py` — new `GET /footer-context/{port}` handler.
-- `llauncher/core/settings.py` — new `LAUNCHER_FOOTER_CACHE_S` env var (float, default 1.0).
+- `llauncher/core/settings.py` — new `LLAUNCHER_FOOTER_CACHE_S` env var (float, default 1.0).
 - `tests/unit/test_footer_cache.py` — new. Cache hit/miss/expiry, missing-lockfile, missing-config, lock contention.
 - `tests/unit/test_agent.py` — new `TestFooterContextEndpoint` class. Happy path, port-empty 404, missing-config-graceful-null, auth-required-when-configured.
 - `pi-footer-extension/footer-budget.ts` — separate slice. Switch URL with a 404→`/status` fallback for one release cycle, then drop the fallback.

--- a/docs/generated/TEST_SUITE_SUMMARY.md
+++ b/docs/generated/TEST_SUITE_SUMMARY.md
@@ -1935,11 +1935,11 @@ ad-hoc markers used in the suite without declaration.
 #### `tests/regression/test_logs_lifecycle_regression.py` (5 tests)
 
 - **`test_launcher_log_dir_env_honored_on_settings_import`**
-  - *``LAUNCHER_LOG_DIR`` env var is read by ``settings`` at import time.*
+  - *``LLAUNCHER_LOG_DIR`` env var is read by ``settings`` at import time.*
 - **`test_launcher_log_max_bytes_env_honored_on_settings_import`**
-  - *``LAUNCHER_LOG_MAX_BYTES`` env var is parsed as int at import time.*
+  - *``LLAUNCHER_LOG_MAX_BYTES`` env var is parsed as int at import time.*
 - **`test_launcher_log_keep_env_honored_on_settings_import`**
-  - *``LAUNCHER_LOG_KEEP`` env var is parsed as int at import time.*
+  - *``LLAUNCHER_LOG_KEEP`` env var is parsed as int at import time.*
 - **`test_banner_flushed_before_subprocess_spawn`**
   - *``log.flush()`` MUST be called before ``Popen`` inherits the fd.*
 - **`test_rotation_runs_before_banner_write`**

--- a/docs/m5-design.md
+++ b/docs/m5-design.md
@@ -33,7 +33,7 @@ The footer cares about three fields: `ctx_size`, `parallel`, and the active `mod
 
 ### Decision Sketch
 
-Add `GET /footer-context/{port}` returning a minimal `{model, ctx_size, parallel, port}` JSON object. Cache the payload for `LAUNCHER_FOOTER_CACHE_S` seconds (default 1s) per port — at footer redraw cadence (multiple per second) this collapses N redraws into one process-table scan.
+Add `GET /footer-context/{port}` returning a minimal `{model, ctx_size, parallel, port}` JSON object. Cache the payload for `LLAUNCHER_FOOTER_CACHE_S` seconds (default 1s) per port — at footer redraw cadence (multiple per second) this collapses N redraws into one process-table scan.
 
 The legacy `/status` stays for the dashboard and other introspection consumers; this is purely a footer-optimized side endpoint.
 
@@ -56,15 +56,15 @@ Logs are at `~/.llauncher/logs/{name}-{port}.log`, opened in `"w"` mode — **tr
 ### Decision Sketch
 
 - Open new logs in `"a"` mode (append) plus a startup banner line (`=== started at <iso> pid=<n> ===`).
-- Roll on size: when a log file exceeds `LAUNCHER_LOG_MAX_BYTES` (default 50MB), rotate to `{name}-{port}.log.1`. Keep at most `LAUNCHER_LOG_KEEP` rotated files (default 3).
+- Roll on size: when a log file exceeds `LLAUNCHER_LOG_MAX_BYTES` (default 50MB), rotate to `{name}-{port}.log.1`. Keep at most `LLAUNCHER_LOG_KEEP` rotated files (default 3).
 - `stream_logs` switches to a bounded tail: seek `min(size, lines * AVG_LINE_BYTES * 2)` from the end, then read forward.
-- Add `LAUNCHER_LOG_DIR` env override (paired with the existing `LAUNCHER_RUN_DIR` and `LAUNCHER_AUDIT_PATH` per ADR-008).
+- Add `LLAUNCHER_LOG_DIR` env override (paired with the existing `LLAUNCHER_RUN_DIR` and `LLAUNCHER_AUDIT_PATH` per ADR-008).
 
 ### Touch Points
 
 - `llauncher/core/process.py` — open mode + banner; bounded tail in `stream_logs`.
 - `llauncher/core/log_rotation.py` — **new**, size-rotate-on-write helper.
-- `llauncher/core/settings.py` — `LAUNCHER_LOG_DIR`, `LAUNCHER_LOG_MAX_BYTES`, `LAUNCHER_LOG_KEEP`.
+- `llauncher/core/settings.py` — `LLAUNCHER_LOG_DIR`, `LLAUNCHER_LOG_MAX_BYTES`, `LLAUNCHER_LOG_KEEP`.
 
 ### Slice Scope
 

--- a/docs/m6-design.md
+++ b/docs/m6-design.md
@@ -87,7 +87,7 @@ This is the breaking-shape change. Update the UI form (see slice 21) and the MCP
 - `validate_model_path`: vLLM accepts HuggingFace IDs or local snapshots. Validation: if path looks like a local dir, check `config.json` + `tokenizer*` files; if it looks like an HF ID (`org/model`), defer (no offline validation).
 - `estimate_vram_mb`: vLLM has its own VRAM math (KV-cache budget × `gpu_memory_utilization`). Probably pull from a published heuristic or vLLM's own estimator.
 - `readiness_endpoint`: vLLM's `/health` differs from llama-server's `/health`; abstract via the adapter.
-- `sentinel_kwargs`: env-var sentinel (per ADR-008 amendment) with `LAUNCHER_OWNED_MODEL=<name>` and `LAUNCHER_OWNED_PID=<self_pid>`. Used by `find_all_llama_servers`'s generalized successor.
+- `sentinel_kwargs`: env-var sentinel (per ADR-008 amendment) with `LLAUNCHER_OWNED_MODEL=<name>` and `LLAUNCHER_OWNED_PID=<self_pid>`. Used by `find_all_llama_servers`'s generalized successor.
 
 ### Slice 21 — UI + MCP surface
 
@@ -99,7 +99,7 @@ This is the breaking-shape change. Update the UI form (see slice 21) and the MCP
 ### Slice 22 — Process discovery + sentinel
 
 - Rename `find_all_llama_servers` → `find_all_owned_processes` (or similar).
-- The function now reads `/proc/<pid>/environ` for `LAUNCHER_OWNED_*` instead of grepping argv. Cross-platform caveat: on Windows there's no `/proc`; we wrap behind a `read_process_env(pid)` abstraction.
+- The function now reads `/proc/<pid>/environ` for `LLAUNCHER_OWNED_*` instead of grepping argv. Cross-platform caveat: on Windows there's no `/proc`; we wrap behind a `read_process_env(pid)` abstraction.
 - Lockfile remains the authoritative claim per ADR-008; the sentinel is for cross-validation and orphan detection (M5 item 4).
 
 ### Slice 23 — Amend ADRs 005, 006, 008

--- a/llauncher/agent/footer_cache.py
+++ b/llauncher/agent/footer_cache.py
@@ -12,7 +12,7 @@ The cache is deliberately small and obvious:
 * Keyed by ``port``. No cross-port aggregation, no sweep thread.
 * Lazy eviction — expired entries are recomputed on the next request
   for that port.
-* TTL is read from ``settings.LAUNCHER_FOOTER_CACHE_S`` at call time so
+* TTL is read from ``settings.LLAUNCHER_FOOTER_CACHE_S`` at call time so
   tests can override via monkeypatch. ``<= 0`` disables caching.
 * No invalidation hook from ``operations.start``/``swap``/``stop``: a
   bounded staleness window is acceptable per ADR-012, and wiring
@@ -94,7 +94,7 @@ def get_footer_context(port: int) -> FooterContext | None:
 
     Returns ``None`` if the port has no lockfile.
     """
-    ttl = settings.LAUNCHER_FOOTER_CACHE_S
+    ttl = settings.LLAUNCHER_FOOTER_CACHE_S
     if ttl <= 0:
         return _read_through(port)
 

--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -262,7 +262,7 @@ def list_orphans_cmd(
     """List unmanaged llama-server processes on the local node.
 
     An orphan is a live ``llama-server`` whose ``(port, pid)`` does not
-    match a live lockfile in ``LAUNCHER_RUN_DIR``. Per ADR-015 this
+    match a live lockfile in ``LLAUNCHER_RUN_DIR``. Per ADR-015 this
     revision is read-only; no ``adopt`` verb is exposed.
     """
     from llauncher import operations as ops

--- a/llauncher/core/audit_log.py
+++ b/llauncher/core/audit_log.py
@@ -12,7 +12,7 @@ The log is plain JSON Lines, append-only, never truncated by llauncher.
 Rotation and retention are out-of-scope for ADR-008 and tracked separately
 (Tier 2).
 
-Path is configurable via the ``LAUNCHER_AUDIT_PATH`` env var so container
+Path is configurable via the ``LLAUNCHER_AUDIT_PATH`` env var so container
 deployments can mount a host directory and let in-container agents read
 the log produced on the host.
 """
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
-from llauncher.core.settings import LAUNCHER_AUDIT_PATH
+from llauncher.core.settings import LLAUNCHER_AUDIT_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class AuditEntry:
 
 
 def _resolve_path(path: Path | None) -> Path:
-    return path if path is not None else LAUNCHER_AUDIT_PATH
+    return path if path is not None else LLAUNCHER_AUDIT_PATH
 
 
 def append_entry(entry: AuditEntry, *, path: Path | None = None) -> None:

--- a/llauncher/core/lockfile.py
+++ b/llauncher/core/lockfile.py
@@ -2,7 +2,7 @@
 
 Per ADR-008 (LauncherState as Stateless Facade). Each lockfile is the
 authoritative claim that llauncher launched a specific model on a specific
-port. Stored at ``{LAUNCHER_RUN_DIR}/{port}.lock`` as JSON.
+port. Stored at ``{LLAUNCHER_RUN_DIR}/{port}.lock`` as JSON.
 
 The lockfile is paired with an argv (or env-var, future) sentinel for
 process identity validation; see :func:`reconcile_lockfile`.
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import psutil
 
-from llauncher.core.settings import LAUNCHER_RUN_DIR
+from llauncher.core.settings import LLAUNCHER_RUN_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class ReconcileResult:
 
 
 def _resolve_run_dir(run_dir: Path | None) -> Path:
-    return run_dir if run_dir is not None else LAUNCHER_RUN_DIR
+    return run_dir if run_dir is not None else LLAUNCHER_RUN_DIR
 
 
 def lockfile_path(port: int, run_dir: Path | None = None) -> Path:

--- a/llauncher/core/marker.py
+++ b/llauncher/core/marker.py
@@ -1,7 +1,7 @@
 """Per-port in-flight swap marker.
 
 Per ADR-011 (Swap Semantics v2). The marker is a sentinel file at
-``{LAUNCHER_RUN_DIR}/{port}.swap`` created atomically (``O_EXCL``) at the
+``{LLAUNCHER_RUN_DIR}/{port}.swap`` created atomically (``O_EXCL``) at the
 start of Phase 2 of a swap and removed when the swap reaches any terminal
 phase (success, rollback, or failure).
 
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from llauncher.core.lockfile import is_pid_alive
-from llauncher.core.settings import LAUNCHER_RUN_DIR
+from llauncher.core.settings import LLAUNCHER_RUN_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class MarkerReconcileResult:
 
 
 def _resolve_run_dir(run_dir: Path | None) -> Path:
-    return run_dir if run_dir is not None else LAUNCHER_RUN_DIR
+    return run_dir if run_dir is not None else LLAUNCHER_RUN_DIR
 
 
 def marker_path(port: int, run_dir: Path | None = None) -> Path:

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -24,13 +24,13 @@ DEFAULT_SERVER_BINARY = LLAMA_SERVER_PATH
 # ``LOG_DIR`` from this module, and tests use
 # ``patch("llauncher.core.process.LOG_DIR", ...)``. ADR-013 made the
 # directory env-configurable; new code should read
-# ``settings.LAUNCHER_LOG_DIR`` directly.
+# ``settings.LLAUNCHER_LOG_DIR`` directly.
 #
 # IMPORTANT: this alias is captured at *import* time. Patching
-# ``os.environ["LAUNCHER_LOG_DIR"]`` after import does NOT update this
+# ``os.environ["LLAUNCHER_LOG_DIR"]`` after import does NOT update this
 # symbol — the supported test seam is ``patch(..."LOG_DIR", ...)`` on
 # this module. Don't expect env mutations to propagate here.
-LOG_DIR = settings.LAUNCHER_LOG_DIR
+LOG_DIR = settings.LLAUNCHER_LOG_DIR
 
 # Heuristic for the bounded tail in :func:`_tail_file`: assume each line
 # averages ~160 bytes (timestamp + message; llama-server logs trend
@@ -294,8 +294,8 @@ def start_server(
     # absorbing yet another run on top of however much it already has.
     log_rotation.rotate_if_needed(
         log_file,
-        max_bytes=settings.LAUNCHER_LOG_MAX_BYTES,
-        keep=settings.LAUNCHER_LOG_KEEP,
+        max_bytes=settings.LLAUNCHER_LOG_MAX_BYTES,
+        keep=settings.LLAUNCHER_LOG_KEEP,
     )
 
     # Append-mode (ADR-013) preserves the previous run's logs across

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -67,15 +67,15 @@ if AGENT_API_KEY == "":
 # Lockfile directory for running servers (per ADR-008).
 # Configurable via env so container deployments can volume-mount it,
 # enabling in-container agents to read host-side llauncher state.
-LAUNCHER_RUN_DIR = Path(os.getenv(
-    "LAUNCHER_RUN_DIR",
+LLAUNCHER_RUN_DIR = Path(os.getenv(
+    "LLAUNCHER_RUN_DIR",
     str(Path.home() / ".llauncher" / "run"),
 ))
 
 # Audit log path (per ADR-008). JSON Lines, append-only.
-# Same volume-mount story as LAUNCHER_RUN_DIR.
-LAUNCHER_AUDIT_PATH = Path(os.getenv(
-    "LAUNCHER_AUDIT_PATH",
+# Same volume-mount story as LLAUNCHER_RUN_DIR.
+LLAUNCHER_AUDIT_PATH = Path(os.getenv(
+    "LLAUNCHER_AUDIT_PATH",
     str(Path.home() / ".llauncher" / "audit.jsonl"),
 ))
 
@@ -83,23 +83,23 @@ LAUNCHER_AUDIT_PATH = Path(os.getenv(
 # ``{stem}-{port}.log`` plus rotated siblings ``{stem}-{port}.log.{N}``,
 # where ``stem`` is minted by ``core.process.log_stem_for`` (#63/#146).
 # Configurable via env so container deployments can volume-mount it the
-# same way as ``LAUNCHER_RUN_DIR`` and ``LAUNCHER_AUDIT_PATH``.
-LAUNCHER_LOG_DIR = Path(os.getenv(
-    "LAUNCHER_LOG_DIR",
+# same way as ``LLAUNCHER_RUN_DIR`` and ``LLAUNCHER_AUDIT_PATH``.
+LLAUNCHER_LOG_DIR = Path(os.getenv(
+    "LLAUNCHER_LOG_DIR",
     str(Path.home() / ".llauncher" / "logs"),
 ))
 
 # Size cap for a single live log file before rotation kicks in (ADR-013).
 # Default 50 MiB; ``<= 0`` disables rotation entirely.
-LAUNCHER_LOG_MAX_BYTES = int(os.getenv(
-    "LAUNCHER_LOG_MAX_BYTES",
+LLAUNCHER_LOG_MAX_BYTES = int(os.getenv(
+    "LLAUNCHER_LOG_MAX_BYTES",
     str(50 * 1024 * 1024),
 ))
 
 # How many rotated log files to retain alongside the live file
 # (ADR-013). With the default 3, the on-disk set is
 # ``foo-8081.log`` plus ``foo-8081.log.{1,2,3}``.
-LAUNCHER_LOG_KEEP = int(os.getenv("LAUNCHER_LOG_KEEP", "3"))
+LLAUNCHER_LOG_KEEP = int(os.getenv("LLAUNCHER_LOG_KEEP", "3"))
 
 # Graceful-shutdown grace periods for terminating a llama-server
 # (issue #140). ``core.process.stop_server_by_pid`` sends SIGTERM and
@@ -118,4 +118,4 @@ LLAUNCHER_STOP_GRACE_S = float(os.getenv("LLAUNCHER_STOP_GRACE_S", "5.0"))
 # (ADR-012). Default 1.0 absorbs footer poll cadence (multiple
 # redraws per second collapse into one lockfile + ConfigStore read).
 # ``<= 0`` disables caching — every request hits disk.
-LAUNCHER_FOOTER_CACHE_S = float(os.getenv("LAUNCHER_FOOTER_CACHE_S", "1.0"))
+LLAUNCHER_FOOTER_CACHE_S = float(os.getenv("LLAUNCHER_FOOTER_CACHE_S", "1.0"))

--- a/llauncher/operations/orphan.py
+++ b/llauncher/operations/orphan.py
@@ -4,7 +4,7 @@ An *orphan* is a live ``llama-server`` process that llauncher did not
 launch (or whose claim it has since lost). Concretely, a process found
 by :func:`llauncher.core.process.find_all_llama_servers_annotated` whose
 ``(port, pid)`` does not match a live, parseable lockfile in
-``LAUNCHER_RUN_DIR``.
+``LLAUNCHER_RUN_DIR``.
 
 ADR-015 deliberately scopes M1 of this work to **annotation and listing
 only** — there is no ``adopt`` verb in this module. A future revision

--- a/llauncher/ui/app.py
+++ b/llauncher/ui/app.py
@@ -83,7 +83,7 @@ def show_agent_down_banner() -> None:
         "```\n\n"
         f"Then refresh this page. The agent listens on port "
         f"``{agent_port}`` (override via ``LLAUNCHER_AGENT_PORT``) and "
-        f"reads/writes state under ``{settings.LAUNCHER_RUN_DIR.parent}``.",
+        f"reads/writes state under ``{settings.LLAUNCHER_RUN_DIR.parent}``.",
         icon="🛑",
     )
     with st.expander("Why doesn't the UI start the agent for me?"):

--- a/llauncher/ui/launch.py
+++ b/llauncher/ui/launch.py
@@ -26,9 +26,8 @@ from pathlib import Path
 # (Tailscale / SSH tunnel / authenticating reverse proxy).
 DEFAULT_UI_HOST = "127.0.0.1"
 
-# NB: deliberately the two-L spelling. scripts/run.sh still reads the
-# legacy single-L LAUNCHER_UI_HOST; that drift is tracked for rename so
-# both converge on LLAUNCHER_UI_HOST.
+# Two-L spelling per the project name; scripts/run.sh and run.bat read
+# the same name (#151), so all UI entrances agree.
 UI_HOST_ENV = "LLAUNCHER_UI_HOST"
 
 

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -78,10 +78,10 @@ goto :help
     echo [INFO] Starting Streamlit UI...
     REM Bind to loopback by default. The dashboard has no built-in auth;
     REM see README "Streamlit UI" + docs/plans/security-hardening-plan.md
-    REM section 2.8 (C12). Override with LAUNCHER_UI_HOST only behind a
+    REM section 2.8 (C12). Override with LLAUNCHER_UI_HOST only behind a
     REM gateway (Tailscale / SSH tunnel / reverse proxy with auth).
-    if "%LAUNCHER_UI_HOST%"=="" set "LAUNCHER_UI_HOST=127.0.0.1"
-    "%PYTHON_EXECUTABLE%" -m streamlit run "%PROJECT_DIR%\llauncher\ui\app.py" --server.address %LAUNCHER_UI_HOST%
+    if "%LLAUNCHER_UI_HOST%"=="" set "LLAUNCHER_UI_HOST=127.0.0.1"
+    "%PYTHON_EXECUTABLE%" -m streamlit run "%PROJECT_DIR%\llauncher\ui\app.py" --server.address %LLAUNCHER_UI_HOST%
     goto :end
 
 :agent
@@ -120,6 +120,11 @@ goto :help
     echo   LLAUNCHER_AGENT_HOST     Host to bind to (default: 0.0.0.0)
     echo   LLAUNCHER_AGENT_PORT     Port to listen on (default: 8765)
     echo   LLAUNCHER_AGENT_NODE_NAME Friendly name for this node
+    echo.
+    echo Environment variables for ui:
+    echo   LLAUNCHER_UI_HOST        UI bind address (default: 127.0.0.1;
+    echo                            expose beyond loopback only behind an
+    echo                            authenticating gateway)
     echo.
     echo First time setup:
     echo   run.bat install

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -54,10 +54,10 @@ case "${1:-}" in
         print_info "Starting Streamlit UI..."
         # Bind to loopback by default. The dashboard has no built-in auth;
         # see README "Streamlit UI" + docs/plans/security-hardening-plan.md
-        # §2.8 (C12). Override with LAUNCHER_UI_HOST only behind a gateway
+        # §2.8 (C12). Override with LLAUNCHER_UI_HOST only behind a gateway
         # (Tailscale / SSH tunnel / reverse proxy with auth).
         streamlit run "$PROJECT_DIR/llauncher/ui/app.py" \
-            --server.address "${LAUNCHER_UI_HOST:-127.0.0.1}"
+            --server.address "${LLAUNCHER_UI_HOST:-127.0.0.1}"
         ;;
     agent)
         print_info "Starting remote management agent..."
@@ -89,6 +89,11 @@ case "${1:-}" in
         echo "  LLAUNCHER_AGENT_HOST     Host to bind to (default: 0.0.0.0)"
         echo "  LLAUNCHER_AGENT_PORT     Port to listen on (default: 8765)"
         echo "  LLAUNCHER_AGENT_NODE_NAME Friendly name for this node"
+        echo ""
+        echo "Environment variables for ui:"
+        echo "  LLAUNCHER_UI_HOST        UI bind address (default: 127.0.0.1;"
+        echo "                           expose beyond loopback only behind an"
+        echo "                           authenticating gateway)"
         echo ""
         echo "First time setup:"
         echo "  $0 install"

--- a/scripts/systemd/llauncher-agent.service.in
+++ b/scripts/systemd/llauncher-agent.service.in
@@ -5,7 +5,7 @@
 ; ~/.config/systemd/user/llauncher-agent.service.
 ;
 ; Rationale for user-mode instead of system-mode:
-;   - State already lives under $HOME (see LAUNCHER_RUN_DIR in
+;   - State already lives under $HOME (see LLAUNCHER_RUN_DIR in
 ;     llauncher/core/settings.py); a system unit would either fight
 ;     that or force a /var/lib/llauncher migration.
 ;   - ADR-009 treats the local agent as a peer started deliberately

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,15 +90,15 @@ def tmp_config_dir(tmp_path):
 def mock_config_store(tmp_config_dir):
     """Mock ConfigStore with temporary paths.
 
-    Also redirects ``LAUNCHER_AUDIT_PATH`` so the CRUD audit entries
+    Also redirects ``LLAUNCHER_AUDIT_PATH`` so the CRUD audit entries
     added per issue #60 are written into ``tmp_path`` instead of the
     developer's real ``~/.llauncher/audit.jsonl``.
     """
     audit_target = tmp_config_dir / "audit.jsonl"
     with patch('llauncher.core.config.CONFIG_DIR', tmp_config_dir) as mock_dir, \
          patch('llauncher.core.config.CONFIG_PATH', tmp_config_dir / 'config.json') as mock_path, \
-         patch('llauncher.core.audit_log.LAUNCHER_AUDIT_PATH', audit_target), \
-         patch('llauncher.core.settings.LAUNCHER_AUDIT_PATH', audit_target):
+         patch('llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH', audit_target), \
+         patch('llauncher.core.settings.LLAUNCHER_AUDIT_PATH', audit_target):
         yield mock_dir, mock_path
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -78,15 +78,15 @@ def mcp_env(tmp_path: Path, stub_binary: Path, monkeypatch: pytest.MonkeyPatch):
 
     # Settings module constants are captured at import time. Patch every
     # alias that downstream modules captured.
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.marker.LLAUNCHER_RUN_DIR", run_dir)
 
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_LOG_DIR", log_dir)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_LOG_DIR", log_dir)
     monkeypatch.setattr("llauncher.core.process.LOG_DIR", log_dir)
 
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", audit_path)
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_AUDIT_PATH", audit_path)
+    monkeypatch.setattr("llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path)
 
     monkeypatch.setattr("llauncher.core.config.CONFIG_DIR", config_dir)
     monkeypatch.setattr("llauncher.core.config.CONFIG_PATH", config_path)
@@ -229,13 +229,13 @@ def real_binary_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     log_dir.mkdir()
     config_dir.mkdir()
 
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_LOG_DIR", log_dir)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.marker.LLAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_LOG_DIR", log_dir)
     monkeypatch.setattr("llauncher.core.process.LOG_DIR", log_dir)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", audit_path)
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_AUDIT_PATH", audit_path)
+    monkeypatch.setattr("llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path)
     monkeypatch.setattr("llauncher.core.config.CONFIG_DIR", config_dir)
     monkeypatch.setattr("llauncher.core.config.CONFIG_PATH", config_dir / "config.json")
     monkeypatch.setattr("llauncher.core.settings.LLAMA_SERVER_PATH", real_bin)

--- a/tests/integration/test_adr_cross_cutting.py
+++ b/tests/integration/test_adr_cross_cutting.py
@@ -22,7 +22,7 @@ class TestAuthAndHealthCombined:
             f.write('''import os
 
 LLAMA_SERVER_PATH = os.getenv("LLAMA_SERVER_BIN", "/usr/bin/llama-server")
-DEFAULT_PORT = int(os.getenv("LAUNCHER_DEFAULT_PORT", "8081"))
+DEFAULT_PORT = int(os.getenv("LLAUNCHER_DEFAULT_PORT", "8081"))
 AGENT_API_KEY = os.getenv("LLAUNCHER_AGENT_TOKEN", None)
 if AGENT_API_KEY == "":
     AGENT_API_KEY = None

--- a/tests/regression/test_cancel_regression.py
+++ b/tests/regression/test_cancel_regression.py
@@ -54,17 +54,17 @@ from llauncher.models.config import ModelConfig
 @pytest.fixture
 def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     target = tmp_path / "run"
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", target)
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.marker.LLAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_RUN_DIR", target)
     return target
 
 
 @pytest.fixture
 def audit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     target = tmp_path / "audit.jsonl"
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_AUDIT_PATH", target)
     return target
 
 

--- a/tests/regression/test_logs_lifecycle_regression.py
+++ b/tests/regression/test_logs_lifecycle_regression.py
@@ -4,7 +4,7 @@ These pin down the specific behaviors the feature introduced — and which
 would silently break if someone refactored the rotation/banner ordering
 or stopped reading the configured log directory at process boot:
 
-* ``LAUNCHER_LOG_DIR`` environment variable is honored when the settings
+* ``LLAUNCHER_LOG_DIR`` environment variable is honored when the settings
   module is (re)imported. Historical bug shape: a hard-coded ``LOG_DIR``
   ignored the env, so volume-mounted container deployments wrote inside
   the container instead of onto the host mount.
@@ -47,61 +47,61 @@ def minimal_config() -> ModelConfig:
 
 
 # ---------------------------------------------------------------------------
-# LAUNCHER_LOG_DIR env honored
+# LLAUNCHER_LOG_DIR env honored
 # ---------------------------------------------------------------------------
 
 
 def test_launcher_log_dir_env_honored_on_settings_import(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``LAUNCHER_LOG_DIR`` env var is read by ``settings`` at import time.
+    """``LLAUNCHER_LOG_DIR`` env var is read by ``settings`` at import time.
 
     Regression: a hard-coded default would silently override an
     operator-supplied env on a container with a volume mount.
     """
     custom = tmp_path / "container-mounted-logs"
-    monkeypatch.setenv("LAUNCHER_LOG_DIR", str(custom))
+    monkeypatch.setenv("LLAUNCHER_LOG_DIR", str(custom))
 
     import llauncher.core.settings as settings_mod
 
     reloaded = importlib.reload(settings_mod)
     try:
-        assert reloaded.LAUNCHER_LOG_DIR == custom
+        assert reloaded.LLAUNCHER_LOG_DIR == custom
     finally:
         # Restore the un-monkey-patched module state for subsequent tests.
-        monkeypatch.delenv("LAUNCHER_LOG_DIR", raising=False)
+        monkeypatch.delenv("LLAUNCHER_LOG_DIR", raising=False)
         importlib.reload(settings_mod)
 
 
 def test_launcher_log_max_bytes_env_honored_on_settings_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``LAUNCHER_LOG_MAX_BYTES`` env var is parsed as int at import time."""
-    monkeypatch.setenv("LAUNCHER_LOG_MAX_BYTES", "12345")
+    """``LLAUNCHER_LOG_MAX_BYTES`` env var is parsed as int at import time."""
+    monkeypatch.setenv("LLAUNCHER_LOG_MAX_BYTES", "12345")
 
     import llauncher.core.settings as settings_mod
 
     reloaded = importlib.reload(settings_mod)
     try:
-        assert reloaded.LAUNCHER_LOG_MAX_BYTES == 12345
+        assert reloaded.LLAUNCHER_LOG_MAX_BYTES == 12345
     finally:
-        monkeypatch.delenv("LAUNCHER_LOG_MAX_BYTES", raising=False)
+        monkeypatch.delenv("LLAUNCHER_LOG_MAX_BYTES", raising=False)
         importlib.reload(settings_mod)
 
 
 def test_launcher_log_keep_env_honored_on_settings_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``LAUNCHER_LOG_KEEP`` env var is parsed as int at import time."""
-    monkeypatch.setenv("LAUNCHER_LOG_KEEP", "7")
+    """``LLAUNCHER_LOG_KEEP`` env var is parsed as int at import time."""
+    monkeypatch.setenv("LLAUNCHER_LOG_KEEP", "7")
 
     import llauncher.core.settings as settings_mod
 
     reloaded = importlib.reload(settings_mod)
     try:
-        assert reloaded.LAUNCHER_LOG_KEEP == 7
+        assert reloaded.LLAUNCHER_LOG_KEEP == 7
     finally:
-        monkeypatch.delenv("LAUNCHER_LOG_KEEP", raising=False)
+        monkeypatch.delenv("LLAUNCHER_LOG_KEEP", raising=False)
         importlib.reload(settings_mod)
 
 
@@ -205,8 +205,8 @@ def test_rotation_runs_before_banner_write(
 
     with patch("llauncher.core.process.DEFAULT_SERVER_BINARY", mock_bin), \
          patch("llauncher.core.process.LOG_DIR", log_dir), \
-         patch("llauncher.core.process.settings.LAUNCHER_LOG_MAX_BYTES", 100), \
-         patch("llauncher.core.process.settings.LAUNCHER_LOG_KEEP", 3), \
+         patch("llauncher.core.process.settings.LLAUNCHER_LOG_MAX_BYTES", 100), \
+         patch("llauncher.core.process.settings.LLAUNCHER_LOG_KEEP", 3), \
          patch("llauncher.core.process.log_rotation.rotate_if_needed",
                side_effect=tracking_rotate), \
          patch("builtins.open", side_effect=tracking_open), \

--- a/tests/regression/test_orphan_regression.py
+++ b/tests/regression/test_orphan_regression.py
@@ -65,16 +65,16 @@ from llauncher.operations.orphan import OrphanInfo
 def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     target = tmp_path / "run"
     target.mkdir()
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_RUN_DIR", target)
     return target
 
 
 @pytest.fixture
 def audit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     target = tmp_path / "audit.jsonl"
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_AUDIT_PATH", target)
     return target
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -312,9 +312,9 @@ class TestStopServerEndpoint:
         from llauncher.core import lockfile as lf
 
         run_dir = tmp_path / "run"
-        monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
+        monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir)
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH",
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH",
             tmp_path / "audit.jsonl",
         )
         lf.write_lockfile(8081, "slow-model", os.getpid(), run_dir=run_dir)
@@ -384,7 +384,7 @@ class TestAuditEndpoint:
         """Empty/missing audit log returns 200 with an empty list."""
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         response = client.get("/audit")
@@ -397,7 +397,7 @@ class TestAuditEndpoint:
 
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         audit_log.record(
@@ -436,7 +436,7 @@ class TestAuditEndpoint:
 
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         audit_log.record(
@@ -458,7 +458,7 @@ class TestAuditEndpoint:
 
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         audit_log.record(
@@ -480,7 +480,7 @@ class TestAuditEndpoint:
 
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         for i in range(5):

--- a/tests/unit/test_env_var_naming_regression.py
+++ b/tests/unit/test_env_var_naming_regression.py
@@ -1,17 +1,19 @@
-"""Regression guards for the LLAUNCHER_AGENT_* env-var naming (issue #138).
+"""Regression guards for the LLAUNCHER_* env-var naming (issues #138/#151).
 
 Background
 ----------
 Issue #138 renamed every ``LAUNCHER_AGENT_*`` env var to
-``LLAUNCHER_AGENT_*`` (matching the project name ``llauncher``). The
-original typo was introduced by an LLM (qwen3.5 / qwen3.6 family) that
-silently drops the leading token when generating identifiers from the
-project name. Any future code-generating model ingesting this codebase
-is at risk of reintroducing the typo — and a green test suite would
-not catch it, because the new (correct) name still works fine in
-isolation.
+``LLAUNCHER_AGENT_*`` (matching the project name ``llauncher``); issue
+#151 finished the job for the rest of the single-L surface — the
+``core/settings.py`` path/log/cache family and the runner scripts' UI
+bind address. The original typo was introduced by an LLM (qwen3.5 /
+qwen3.6 family) that silently drops the leading token when generating
+identifiers from the project name. Any future code-generating model
+ingesting this codebase is at risk of reintroducing the typo — and a
+green test suite would not catch it, because the new (correct) name
+still works fine in isolation.
 
-This module is the regression net. It has three jobs:
+This module is the regression net. It has five jobs:
 
 Category A — pin the precedence in :func:`resolve_agent_token`:
     the new name is honored, the old name is *not* honored as a
@@ -22,9 +24,20 @@ Category B — pin the precedence for the other agent env reads
     clean seams :class:`AgentConfig.from_env` and
     :func:`llauncher.agent.routing.get_node_name`.
 
-Category C — repo-grep guard: fail if the legacy ``LAUNCHER_AGENT_*``
-    names reappear in tracked source outside an allowlist of
-    historical paths (changelog, handoffs, plans, reviews).
+Category C — repo-grep guard: fail if any legacy single-L
+    ``LAUNCHER_*`` name reappears in tracked source outside an
+    allowlist of historical paths (changelog, handoffs, plans,
+    reviews).
+
+Category D — pin the ``core/settings.py`` family (#151): each
+    ``LLAUNCHER_{RUN_DIR,AUDIT_PATH,LOG_DIR,LOG_MAX_BYTES,LOG_KEEP,
+    FOOTER_CACHE_S}`` is honored at settings (re)import, and the
+    legacy single-L spelling is silently ignored — the documented
+    default applies (same no-fallback posture as #138).
+
+Category E — pin the UI bind address (#151): ``LLAUNCHER_UI_HOST``
+    is the only env read; the legacy single-L spelling falls through
+    to the loopback default.
 
 ALLOWED_PATH_PREFIXES rationale
 -------------------------------
@@ -44,6 +57,7 @@ The allowlist is the set of paths where matches are *expected*:
 
 from __future__ import annotations
 
+import importlib
 import io
 import subprocess
 from pathlib import Path
@@ -216,9 +230,15 @@ def test_routing_get_node_name_ignores_old_name(monkeypatch):
 
 
 # Built from a split string so this source line does not itself match
-# the legacy pattern under ``\bLAUNCHER_AGENT_``. Belt-and-suspenders:
+# the legacy pattern under ``\bLAUNCHER_``. Belt-and-suspenders:
 # this file is also in ``ALLOWED_PATH_PREFIXES`` below.
-_LEGACY_PREFIX = "LAUNCHER" + "_AGENT_"
+#
+# #151 broadened this from the agent family (``LAUNCHER_AGENT_``) to
+# the whole single-L namespace: any ``LAUNCHER_<UPPERCASE>`` token now
+# trips the guard, including names that do not exist yet — a future
+# feature minting a fresh env var under the typo prefix fails here
+# before it ships.
+_LEGACY_PREFIX = "LAUNCHER" + "_"
 
 # Paths whose contents are historical records or explicitly document
 # the migration. Matches here are expected and allowed. See the module
@@ -256,10 +276,12 @@ def test_no_legacy_env_var_names_in_tracked_source():
     """
     repo_root = _repo_root()
 
-    # Word-boundary regex: matches LAUNCHER_AGENT_ only when not
+    # Word-boundary regex: matches LAUNCHER_<UPPER> only when not
     # preceded by a word character. That excludes the correct
-    # LLAUNCHER_AGENT_ form (where the preceding char is an L).
-    pattern = r"\b" + _LEGACY_PREFIX
+    # LLAUNCHER_* form (where the preceding char is an L). The
+    # trailing [A-Z] keeps prose like "launcher_" case-sensitive
+    # noise out without loosening the guard.
+    pattern = r"\b" + _LEGACY_PREFIX + "[A-Z]"
 
     result = subprocess.run(
         ["git", "grep", "-nE", "--", pattern],
@@ -291,6 +313,119 @@ def test_no_legacy_env_var_names_in_tracked_source():
         joined = "\n  ".join(offenders)
         pytest.fail(
             "Legacy env var name reappeared in tracked source "
-            "(see issue #138 — the rename to LLAUNCHER_AGENT_* must "
+            "(see issues #138/#151 — the rename to LLAUNCHER_* must "
             "not be undone). Offending occurrences:\n  " + joined
         )
+
+
+# ─────────── Category D: core/settings.py family (#151) ────────────
+
+
+# (new env name, raw env value, settings attribute, expected, default)
+# ``expected`` is what the attribute must read back as when the NEW
+# name is set to ``raw``; ``default`` is what it must fall back to
+# when only the LEGACY single-L name is set.
+_SETTINGS_FAMILY = [
+    pytest.param(
+        "LLAUNCHER_RUN_DIR", "/mnt/state/run",
+        "LLAUNCHER_RUN_DIR", Path("/mnt/state/run"),
+        Path.home() / ".llauncher" / "run",
+        id="run-dir",
+    ),
+    pytest.param(
+        "LLAUNCHER_AUDIT_PATH", "/mnt/state/audit.jsonl",
+        "LLAUNCHER_AUDIT_PATH", Path("/mnt/state/audit.jsonl"),
+        Path.home() / ".llauncher" / "audit.jsonl",
+        id="audit-path",
+    ),
+    pytest.param(
+        "LLAUNCHER_LOG_DIR", "/mnt/state/logs",
+        "LLAUNCHER_LOG_DIR", Path("/mnt/state/logs"),
+        Path.home() / ".llauncher" / "logs",
+        id="log-dir",
+    ),
+    pytest.param(
+        "LLAUNCHER_LOG_MAX_BYTES", "12345",
+        "LLAUNCHER_LOG_MAX_BYTES", 12345,
+        50 * 1024 * 1024,
+        id="log-max-bytes",
+    ),
+    pytest.param(
+        "LLAUNCHER_LOG_KEEP", "7",
+        "LLAUNCHER_LOG_KEEP", 7,
+        3,
+        id="log-keep",
+    ),
+    pytest.param(
+        "LLAUNCHER_FOOTER_CACHE_S", "2.5",
+        "LLAUNCHER_FOOTER_CACHE_S", 2.5,
+        1.0,
+        id="footer-cache-s",
+    ),
+]
+
+
+def _reload_settings():
+    import llauncher.core.settings as settings_mod
+
+    return settings_mod, importlib.reload(settings_mod)
+
+
+@pytest.mark.parametrize(
+    "env_name, raw, attr, expected, default", _SETTINGS_FAMILY
+)
+def test_settings_family_uses_new_env_var_name(
+    monkeypatch, env_name, raw, attr, expected, default
+):
+    """Each ``LLAUNCHER_*`` settings var is honored at (re)import."""
+    legacy_name = env_name.removeprefix("L")
+    monkeypatch.setenv(env_name, raw)
+    monkeypatch.delenv(legacy_name, raising=False)
+
+    settings_mod, reloaded = _reload_settings()
+    try:
+        assert getattr(reloaded, attr) == expected
+    finally:
+        # Restore the un-monkey-patched module state for later tests.
+        monkeypatch.delenv(env_name, raising=False)
+        importlib.reload(settings_mod)
+
+
+@pytest.mark.parametrize(
+    "env_name, raw, attr, expected, default", _SETTINGS_FAMILY
+)
+def test_settings_family_ignores_legacy_env_var_name(
+    monkeypatch, env_name, raw, attr, expected, default
+):
+    """A legacy single-L spelling MUST be silently ignored (#151).
+
+    Same no-fallback posture as #138: with only the typo set, the
+    documented default applies — any other value means a dual-read
+    crept back in.
+    """
+    legacy_name = env_name.removeprefix("L")
+    monkeypatch.setenv(legacy_name, raw)
+    monkeypatch.delenv(env_name, raising=False)
+
+    settings_mod, reloaded = _reload_settings()
+    try:
+        assert getattr(reloaded, attr) == default
+    finally:
+        monkeypatch.delenv(legacy_name, raising=False)
+        importlib.reload(settings_mod)
+
+
+# ─────────── Category E: UI bind address (#151) ────────────────────
+
+
+def test_resolve_ui_host_ignores_legacy_name():
+    """Legacy single-L UI-host spelling falls through to loopback.
+
+    The new-name happy path is pinned by
+    ``tests/unit/test_ui_launch.py``; this guard covers the
+    legacy-ignored half only.
+    """
+    from llauncher.ui.launch import resolve_ui_host
+
+    legacy_name = "L" "AUNCHER_UI_HOST"
+    assert resolve_ui_host({legacy_name: "0.0.0.0"}) == "127.0.0.1"

--- a/tests/unit/test_footer_cache.py
+++ b/tests/unit/test_footer_cache.py
@@ -122,7 +122,7 @@ class TestReadThrough:
 
 class TestCaching:
     def test_second_hit_within_ttl_does_not_touch_disk(self, monkeypatch, patch_disk):
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 5.0)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 5.0)
         lf, cfg = patch_disk(
             lockfile=_FakeLockfile(port=8081, model="qwen"),
             config=_FakeModelConfig(),
@@ -134,7 +134,7 @@ class TestCaching:
         assert cfg.calls == 1
 
     def test_hit_after_ttl_expiry_rereads(self, monkeypatch, patch_disk):
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 0.05)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 0.05)
         lf, _ = patch_disk(
             lockfile=_FakeLockfile(port=8081, model="qwen"),
             config=_FakeModelConfig(),
@@ -145,7 +145,7 @@ class TestCaching:
         assert lf.calls == 2
 
     def test_ttl_zero_disables_cache(self, monkeypatch, patch_disk):
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 0.0)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 0.0)
         lf, _ = patch_disk(
             lockfile=_FakeLockfile(port=8081, model="qwen"),
             config=_FakeModelConfig(),
@@ -156,7 +156,7 @@ class TestCaching:
 
     def test_absence_is_not_cached(self, monkeypatch, patch_disk):
         """A subsequent appearance of a lockfile must not be hidden by a cached None."""
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 5.0)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 5.0)
 
         # First two calls: no lockfile. Switch the return mid-test by
         # mutating the counter's return_value.
@@ -175,7 +175,7 @@ class TestCaching:
         assert ctx.model == "qwen"
 
     def test_per_port_isolation(self, monkeypatch, patch_disk):
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 5.0)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 5.0)
 
         def by_port(port: int, **_):
             return _FakeLockfile(port=port, model=f"m{port}")
@@ -194,7 +194,7 @@ class TestCaching:
         assert lf.calls == 2
 
     def test_clear_cache_forces_reread(self, monkeypatch, patch_disk):
-        monkeypatch.setattr(footer_cache.settings, "LAUNCHER_FOOTER_CACHE_S", 5.0)
+        monkeypatch.setattr(footer_cache.settings, "LLAUNCHER_FOOTER_CACHE_S", 5.0)
         lf, _ = patch_disk(
             lockfile=_FakeLockfile(port=8081, model="qwen"),
             config=_FakeModelConfig(),

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -28,14 +28,14 @@ def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect lockfile writes to a tmp dir and inject the path into reads.
 
     Also redirects marker reads/writes (the marker module's module-level
-    ``LAUNCHER_RUN_DIR`` constant is bound at import time). ADR-014 added
+    ``LLAUNCHER_RUN_DIR`` constant is bound at import time). ADR-014 added
     a marker take/release to ``operations.start`` so this is needed for
     every test that exercises ``start``.
     """
     target = tmp_path / "run"
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", target)
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.lockfile.LLAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.marker.LLAUNCHER_RUN_DIR", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_RUN_DIR", target)
     return target
 
 
@@ -43,8 +43,8 @@ def run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def audit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect audit-log writes to a tmp file."""
     target = tmp_path / "audit.jsonl"
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", target)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", target)
+    monkeypatch.setattr("llauncher.core.settings.LLAUNCHER_AUDIT_PATH", target)
     return target
 
 
@@ -642,7 +642,7 @@ def test_stop_result_to_dict_envelope() -> None:
 @pytest.fixture
 def marker_run_dir(run_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect marker reads/writes to the same tmp run dir as lockfiles."""
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.marker.LLAUNCHER_RUN_DIR", run_dir)
     return run_dir
 
 

--- a/tests/unit/test_orphan.py
+++ b/tests/unit/test_orphan.py
@@ -115,10 +115,10 @@ class TestListOrphans:
         lf.write_lockfile(8081, "model-a", 2001, run_dir=run_dir)
 
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
         monkeypatch.setattr(
-            "llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.settings.LLAUNCHER_RUN_DIR", run_dir
         )
 
         fake = _fake_proc(2001)
@@ -136,7 +136,7 @@ class TestListOrphans:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
 
         fake = _fake_proc(2002)
@@ -154,7 +154,7 @@ class TestListOrphans:
         run_dir.mkdir()
         lf.write_lockfile(8083, "model-b", 9999, run_dir=run_dir)
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
 
         fake = _fake_proc(2003)
@@ -174,7 +174,7 @@ class TestListOrphans:
         run_dir.mkdir()
         lf.write_lockfile(8084, "model-c", 4000, run_dir=run_dir)
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
 
         fake = _fake_proc(2004)
@@ -192,7 +192,7 @@ class TestListOrphans:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
 
         fake = _fake_proc(2005)
@@ -210,7 +210,7 @@ class TestListOrphans:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         monkeypatch.setattr(
-            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir
+            "llauncher.core.lockfile.LLAUNCHER_RUN_DIR", run_dir
         )
 
         procs = [

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -1066,8 +1066,8 @@ class TestStartServerLogsLifecycle:
 
         with patch("llauncher.core.process.DEFAULT_SERVER_BINARY", mock_bin), \
              patch("llauncher.core.process.LOG_DIR", log_dir), \
-             patch("llauncher.core.process.settings.LAUNCHER_LOG_MAX_BYTES", 100), \
-             patch("llauncher.core.process.settings.LAUNCHER_LOG_KEEP", 3), \
+             patch("llauncher.core.process.settings.LLAUNCHER_LOG_MAX_BYTES", 100), \
+             patch("llauncher.core.process.settings.LLAUNCHER_LOG_KEEP", 3), \
              patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value = MagicMock()
             start_server(minimal_config, port=8081)

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -484,7 +484,7 @@ class TestRemoteNodeReadAudit:
         # Redirect audit-log writes to a tmp file.
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         audit_log.record(
@@ -516,7 +516,7 @@ class TestRemoteNodeReadAudit:
 
         audit_path = tmp_path / "audit.jsonl"
         monkeypatch.setattr(
-            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+            "llauncher.core.audit_log.LLAUNCHER_AUDIT_PATH", audit_path
         )
 
         audit_log.record(


### PR DESCRIPTION
Fixes #151. Finishes the #138 rename for the rest of the single-L `LAUNCHER_*` surface, following the same hard-rename / no-fallback decision.

## What renamed

| Old | New |
| --- | --- |
| `LAUNCHER_RUN_DIR` | `LLAUNCHER_RUN_DIR` |
| `LAUNCHER_AUDIT_PATH` | `LLAUNCHER_AUDIT_PATH` |
| `LAUNCHER_LOG_DIR` | `LLAUNCHER_LOG_DIR` |
| `LAUNCHER_LOG_MAX_BYTES` | `LLAUNCHER_LOG_MAX_BYTES` |
| `LAUNCHER_LOG_KEEP` | `LLAUNCHER_LOG_KEEP` |
| `LAUNCHER_FOOTER_CACHE_S` | `LLAUNCHER_FOOTER_CACHE_S` |
| `LAUNCHER_UI_HOST` | `LLAUNCHER_UI_HOST` |

Both forms renamed per the issue: the operator-facing `os.getenv` strings **and** the module-level constants imported across `core/` (marker, lockfile, audit_log, process), `agent/footer_cache.py`, `operations/orphan.py`, `ui/app.py`, plus every test monkeypatch/fixture target.

- `scripts/run.sh` / `scripts/run.bat` now read `LLAUNCHER_UI_HOST`, in agreement with `llauncher/ui/launch.py`, and the var is surfaced in the usage/help text (previously undocumented).
- Docs: README, `docs/MCP.md` env table, ADR-008/011/012/013/015, m5/m6 design docs, systemd unit comment. Historical handoffs/reviews/plans untouched per the issue; `docs/m6-design.md`'s not-yet-implemented sentinel family is now spelled `LLAUNCHER_OWNED_*` so a future implementation mints the correct prefix.
- CHANGELOG: new Unreleased breaking-change entry (table + sed/PowerShell migration one-liners) alongside the #138 entry.

## Legacy-name behavior

**Silently ignored** (falls through to the documented default), exactly matching the #138/#139 posture — no alias fallback (no-backcompat-shims rule), no startup fail-loud, consistent with the existing `LAUNCHER_AGENT_*` guard tests.

## Regression net

`tests/unit/test_env_var_naming_regression.py`:

- **Category C guard broadened**: `test_no_legacy_env_var_names_in_tracked_source` now greps for `\bLAUNCHER_[A-Z]` (the whole single-L namespace, not just `_AGENT_`), so any renamed family — or a *future* env var minted under the typo prefix — trips it. Verified to fail on a planted offender and pass on the clean tree.
- **New Category D**: each settings-family var is honored at settings (re)import under the new name; the legacy spelling is ignored and the default applies (parametrized over all six).
- **New Category E**: legacy UI-host spelling falls through to loopback (new-name path already pinned by `tests/unit/test_ui_launch.py`).

## Gates

- `python -m pytest tests/ -q`: **1105 passed, 11 skipped**
- Coverage: **95.02%** against the 93% floor (`--cov-fail-under=93` satisfied)
- Acceptance grep: `git grep -E '\bLAUNCHER_[A-Z_]+'` matches only the historical allowlist (handoffs/reviews/plans, `docs/_audit_adrs.md`, `docs/v2-handoff.md`, CHANGELOG, the guard test itself)