### PR TITLE
docs(arch): governance ARCHITECTURE.md — audited layering + mint invariant

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,271 @@
+# Architecture: llauncher
+
+This document defines the **layering-and-mint** invariant of `llauncher` and makes the
+boundary between layers enforceable. Its purpose is to distinguish a valid composition
+from a violation — not to describe what the code currently does, but to state what it
+must do and to name the gaps that remain.
+
+> Edit-time companion: `.claude/architecture.md` is the terse layer map kept open while
+> editing. This document is the governing version — invariant-first, with an audited
+> conformance ledger. Where the two disagree, this one is the target.
+
+---
+
+## The invariant (read this first)
+
+Seven rules. All seven apply simultaneously.
+
+1. **Dependencies point downward.** Each layer imports only from layers beneath it;
+   siblings never import siblings. The mechanism is a **perception** firewall — the
+   import graph. A module physically cannot name a symbol it does not import, so the
+   rule stops a cross-layer edge from being *authored*. It does **not** bound what a
+   running process can reach over other channels (HTTP, a shell, a `sys.path` insert) —
+   only what the source may import. *(→ `.claude/architecture.md`; ADR-008)*
+
+2. **`remote` and `agent` are network peers, not Python neighbors.** They share exactly
+   one thing: the HTTP wire contract. `remote` is a client; `agent` is a server. Neither
+   imports the other in Python — a shared helper is hoisted **down** into `core`, never
+   reached sideways. *(→ ADR-009)*
+
+3. **The orchestration facade is stateless.** `LauncherState` and `operations/` hold no
+   cross-call session state; every read rebuilds the live process table from the
+   filesystem and the OS per call. Identity of result depends on current ground truth,
+   not call history. *(→ ADR-008)*
+
+4. **`ModelConfig.name` is the mint (ONE-MINT).** It is the single authority for
+   local-model identity across the ecosystem. Every other string — port, adapter, log
+   filename, process title, wire alias — is an **envelope** derived from the name, never
+   a redefinition of it. An envelope defect is fixed in envelope space; the name does not
+   bend to absorb it. *(→ ecosystem ground-physics constitution: ONE-MINT /
+   IDENTITY⊥ENVELOPE; issues #146/#63)*
+
+5. **The wire emits the canonical name (EMIT-CANONICAL).** llama-server starts with
+   `--alias = ModelConfig.name` so `GET /v1/models` reports the minted identity
+   byte-for-byte — no transformation, no sanitization. The flag is launcher-owned: it is
+   on the `extra_args` deny-list so no config can override the minted identity.
+   *(→ ecosystem ground-physics constitution: EMIT-CANONICAL; issue #120)*
+
+6. **Parse at the door; no backcompat shims (PARSE-AT-THE-DOOR).** A persisted artifact
+   is parsed once into its validated shape, or the load fails loud. Never dual-parse two
+   shapes of the same artifact; never trust-and-degrade on an unrecognized one. When a
+   shape changes, migrate deterministically in place, once. *(→ ecosystem
+   ground-physics constitution: PARSE-AT-THE-DOOR; project `CLAUDE.md` local rule;
+   ADR-017)*
+
+7. **Ports are owned at the call site.** `start` / `stop` / `swap` and every port-keyed
+   endpoint take the port as an explicit caller-supplied argument; the orchestration
+   layer never allocates or derives it. `ModelConfig` carries no port. *(→ ADR-010;
+   ADR-011)*
+
+---
+
+## The layers
+
+Top (consumer) to bottom (substrate). The one rule across all of them: **dependencies
+point downward; siblings do not import siblings.**
+
+### Endpoints (the doors)
+
+**What lives here:** `agent/` (HTTP server), `mcp_server/` (stdio JSON-RPC), `ui/`
+(Streamlit), `cli.py`.
+
+**Rules:**
+- Endpoints **orchestrate** — they call orchestration verbs, they do not reimplement
+  them.
+- Siblings do not import siblings: `ui` does not import `mcp_server`, `cli` does not
+  import `agent`. A shared need is hoisted into `core`.
+- `agent/` is the only server-side door the network client (`remote`) may reach, and
+  only over HTTP.
+
+### Orchestration (stateless verbs + facade)
+
+**What lives here:** `operations/` (start · stop · swap · delete · orphan · preflight),
+`state.py` (`LauncherState` — ADR-008).
+
+**Rules:**
+- Holds no cross-call session state; rebuilds from ground truth per call (rule 3).
+- Does not know its callers — never imports an endpoint layer.
+- Ports arrive as explicit arguments (rule 7).
+
+### Core (mechanics)
+
+**What lives here:** `core/` — `config`, `process`, `settings`, `lockfile`,
+`audit_log`, `model_health`, `gpu`, `marker`.
+
+**Rules:**
+- Imports only `models/` and the `util/` substrate. Never imports upward (`state`,
+  `operations`, `agent`, `remote`, `ui`, `mcp_server`).
+- Owns the mint→envelope derivations: the `--alias` emission (`process.build_command`)
+  and log-filename sanitization (`process.log_stem_for`) derive from `ModelConfig.name`
+  (rules 4–5).
+
+### Models (the floor)
+
+**What lives here:** `models/` — Pydantic data types, including `ModelConfig`.
+
+**Rules:**
+- Dependency-free relative to llauncher's own layers — imports nothing from `core` or
+  above.
+- `ModelConfig.name` is the mint (rule 4); the type carries no port (rule 7).
+
+### remote (network client peer)
+
+**What lives here:** `remote/` — `NodeRegistry`, `RemoteNode`, `RemoteAggregator`.
+
+**Rules:**
+- Reaches other nodes **only** over HTTP to `agent/` endpoints. Imports nothing from
+  `agent` in Python (rule 2).
+- Used by `ui/` and `cli`; it is a client, structurally symmetric to `agent` across the
+  wire.
+
+---
+
+## What the invariant does NOT govern (out of scope)
+
+- **The managed `llama-server` processes themselves.** llauncher owns their
+  start/stop/swap/status lifecycle, but their internals — inference telemetry, slot
+  state, KV-cache pressure — are out of process and outside this invariant. Reading them
+  (e.g. monitoring-from-llama-server work) is a **new consumer of `core`**, not a
+  layering exception: it enters through `core` like any other mechanic and surfaces
+  through `agent/` + MCP like any other read. This is a scoping fact, not a license to
+  bypass.
+- **The `util/` substrate** (`llauncher/util/`, e.g. the TTL cache). It sits **beneath**
+  `core` and is used across layers. `core` importing `util` is a downward edge, not a
+  violation; `util` imports nothing internal upward.
+- **External tooling shelled out by `core`** — `nvidia-smi` (GPU metrics), the
+  `llama-server` binary. These are process dependencies, not Python layers; the
+  layering rule does not reach across the process boundary.
+
+---
+
+## Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ENDPOINTS (the doors)                                         │
+│   agent/ (HTTP)   mcp_server/ (stdio)   ui/ (Streamlit)  cli  │
+└───────┬──────────────────┬──────────────────┬───────────┬────┘
+        │                  │                  │           │
+        └──────────────────┴────────┬─────────┴───────────┘
+                                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│ ORCHESTRATION (stateless)                                     │
+│   operations/  (start·stop·swap·delete·orphan·preflight)      │
+│   state.py     (LauncherState facade — ADR-008)               │
+└─────────────────────────────┬───────────────────────────────┘
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│ CORE (mechanics)                                              │
+│   config · process · settings · lockfile · audit_log          │
+│   model_health · gpu · marker                                 │
+└─────────────────────────────┬───────────────────────────────┘
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│ MODELS (the floor)   — Pydantic types; ModelConfig (the mint) │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                  ┌───────────┴───────────┐
+                  │  util/  (substrate)    │  used across layers; imports nothing up
+                  └────────────────────────┘
+
+   remote/ ──── HTTP wire contract ────▶ agent/        (peers; no Python edge)
+   (NodeRegistry, RemoteNode, RemoteAggregator)         used by ui/ + cli
+
+   core/ ──shell──▶ nvidia-smi, llama-server binary     (out of process; out of scope)
+```
+
+Notes on the diagram:
+- Every endpoint arrow crosses down through orchestration; none reaches into `core` or
+  `models` sideways past it.
+- `remote` and `agent` touch only across the **HTTP wire contract** line — no Python
+  import edge runs between them.
+- `util/` sits beside-and-beneath the stack; a downward import into it is not a
+  violation.
+- The shelled-out external processes sit outside the boundary entirely.
+
+---
+
+## Why downward-only layering and a single mint
+
+**Downward-only layering** keeps each layer substitutable and testable in isolation. If
+`core` could import `operations` or an endpoint, the floor would depend on the building:
+a unit test of a `core` mechanic would drag in the orchestration facade and its
+filesystem assumptions, and a change to an endpoint could silently alter `core`
+behavior. The peer split between `remote` and `agent` is the same principle across the
+network boundary — a client that imported its server would couple the two into one
+deployable, defeating the symmetric hub-spoke topology (ADR-009) where any node is both.
+
+**A single mint** is what keeps model identity from fragmenting into per-consumer
+dialects. The ecosystem has many envelopes for the same model — a port, a log filename,
+a process title, a wire alias, a router key. If any of them were allowed to *be* the
+identity rather than *derive from* it, two envelopes could disagree and there would be no
+authority to adjudicate. `ModelConfig.name` is that authority; `EMIT-CANONICAL` is the
+keystone that pushes the authority onto the wire so downstream routers match against it
+rather than re-deriving their own string. This is why an envelope defect (e.g. a
+log-filename sanitization collision, #146/#63) is fixed in envelope space — bending the
+name to dodge the collision would make the mint serve the envelope instead of the
+reverse.
+
+---
+
+## Current conformance (honest)
+
+The invariant above is the target. The code is **audited** below; it conforms on five
+rules and is in violation on two.
+
+### Conforming (audited)
+
+| Rule | Evidence (`path:symbol`) | Note |
+|------|--------------------------|------|
+| 3 — stateless facade | `llauncher/state.py:LauncherState.refresh` | Rebuilds process table + config from disk per call; read-side MCP tools call `state.refresh()` per request (`mcp_server/tools/servers.py:server_status`, `:get_server_logs`). Only persistent fields are within-process orphan-dedup sets. |
+| 4 — ONE-MINT | `llauncher/models/config.py:ModelConfig.name` | Sole identity field; envelopes derive from it (`core/process.py:log_stem_for`, `:log_path_for`, the `--alias` emission). |
+| 5 — EMIT-CANONICAL | `llauncher/core/process.py:build_command` (`cmd.extend(["--alias", config.name])`) + `llauncher/models/config.py:DENIED_EXTRA_ARG_FLAGS` (`--alias` denied) | Canonical name emitted unconditionally; launcher-owned via deny-list. **See reconciliation note below.** |
+| 6 — PARSE-AT-THE-DOOR | `llauncher/core/config.py:ConfigStore.load` (single parse); `llauncher/remote/registry.py:_load_node_tokens` (type-filters, does not dual-parse a legacy bare-string shape); `llauncher/core/audit_log.py:read_entries` (single enum coercion, corrupt lines skipped) | No dual-parse / trust-and-degrade observed. |
+| 7 — port at call site | `llauncher/operations/start.py:start(model_name, port, …)`, `operations/stop.py:stop(port, …)`, `operations/swap.py:swap(model_name, port, …)`; MCP schemas require `port` (`mcp_server/tools/servers.py`) | Port is always caller-supplied; `ModelConfig` carries none. |
+
+### Violations
+
+| Violation | Why it breaks the invariant | Evidence (`path:symbol`) | Resolved by |
+|-----------|----------------------------|--------------------------|-------------|
+| **Models imports Core (upward edge).** `ModelConfig`'s blacklisted-ports default-factory sources its list from `core.settings`. | Breaks rule 1: `models/` is the floor and must be dependency-free relative to llauncher's own layers; importing `core` inverts the arrow. | `llauncher/models/config.py:17` — `from llauncher.core.settings import BLACKLISTED_PORTS` (consumed at `ChangeRules.blacklisted_ports`) | Invert the dependency: pass the blacklist in at construction/validation time, or hoist the constant to `models`/`util` so the edge points down. Tracked: #170. |
+| **`remote` imports `agent` (sideways/upward edge).** `remote/registry.py` imports `resolve_agent_token` from `agent.auth` to source the local node's token. | Breaks rule 2: client importing its server couples the two across the network-peer boundary they are supposed to share only over HTTP. | `llauncher/remote/registry.py:85` — `from llauncher.agent.auth import resolve_agent_token` | Hoist the token **read** path into `core`; keep token **materialization** in `agent.auth`. Known regression, also noted in `.claude/architecture.md`. Tracked: #171. |
+
+> **Reconciliation note (rule 5).** `EMIT-CANONICAL` conforms as of
+> `core/process.py:build_command`. However the project `CLAUDE.md` and the ecosystem
+> alignment roadmap (Phase 1) still describe it as *pending* / *the single
+> highest-leverage fix*. Those references are **stale**; the implementation landed (issue
+> #120). Reconciling them — closing #120 if open, advancing the roadmap phase, and
+> trimming the CLAUDE.md "until this lands" framing — is tracked as a separate doc task.
+> This conformance row is the audited ground truth.
+
+---
+
+## What "instant fail" looks like
+
+One row per invariant rule. Each violation paired with the contracted correct shape.
+
+| Violation | Valid form |
+|-----------|------------|
+| A `core/` module imports `from llauncher.operations import …` or `from llauncher.agent import …`. | `core/` depends only on `models/` and `util/`; whatever it needs from above is passed in by the caller. |
+| `models/config.py` imports a constant from `core.settings`. | The constant lives in `models`/`util` (downward), or is injected at construction — the floor imports nothing from above. |
+| `remote/registry.py` imports a function from `agent.auth`. | The shared read path is hoisted into `core`; `remote` reaches `agent` only over the HTTP wire contract. |
+| `LauncherState` caches a server list at construction and serves it on later calls. | Every read calls `refresh()` and rebuilds from the live process table + disk. |
+| A second module redefines model identity (e.g. keys a registry by sanitized log name instead of `ModelConfig.name`). | All identity flows from `ModelConfig.name`; the sanitized log name is an envelope derived from it, never an alternate authority. |
+| llama-server is started without `--alias`, so `/v1/models` reports the GGUF filename; or `--alias` is moved into `extra_args` where a config can override it. | `build_command` emits `--alias config.name` unconditionally; `--alias` stays on `DENIED_EXTRA_ARG_FLAGS`. |
+| A loader accepts both a legacy bare-string and a new dict shape of `node_tokens.json`, branching on which it sees. | The artifact is migrated to one shape at the door (or the load fails loud); exactly one shape is parsed thereafter. |
+| `operations.start` allocates a free port itself when the caller omits one. | `port` is a required argument; the caller (endpoint) chooses it per ADR-010. |
+
+---
+
+## Relation to the decision record
+
+| ADR / decision | What it fixes | File / status |
+|----------------|--------------|---------------|
+| ADR-008: LauncherState stateless facade | Rules 1, 3 — the downward layer arrow and the stateless orchestration facade | `docs/adrs/accepted/008-launcher-state-stateless-facade.md` — Accepted |
+| ADR-009: Symmetric hub-spoke topology | Rule 2 — `remote`/`agent` as network peers sharing only the HTTP wire | `docs/adrs/completed/009-symmetric-hub-spoke-topology.md` — Completed |
+| ADR-010: Port ownership at call site | Rule 7 — port is a call-site argument; `ModelConfig` carries none | `docs/adrs/completed/010-port-ownership-at-call-site.md` — Completed |
+| ADR-011: Swap semantics v2 | Rule 7 — the port-keyed `swap` and its preflight | `docs/adrs/completed/011-swap-semantics-v2.md` — Completed |
+| ADR-016: Canonical self-swap | Rules 4–5 — canonical identity preserved across an agent's self-swap | `docs/adrs/completed/016-canonical-self-swap.md` — Completed |
+| ADR-017: (node-token persistence) | Rule 6 — parse-at-the-door; the bare-string `node_tokens.json` dual-parse caught in review is the anchor violation | `docs/adrs/` — see CLAUDE.md local rule |
+| Issue #120: EMIT-CANONICAL `--alias` | Rule 5 — the wire reports the minted name | Implemented (`core/process.py`); roadmap reference stale, see reconciliation note |
+| Ecosystem ground-physics constitution | Rules 4, 5, 6 — ONE-MINT, IDENTITY⊥ENVELOPE, EMIT-CANONICAL, PARSE-AT-THE-DOOR | Out-of-tree (private); handles also restated in project `CLAUDE.md` |


### PR DESCRIPTION
## What

Adds `docs/ARCHITECTURE.md` — the governance-shaped architecture document for llauncher, instantiated from the ecosystem architecture-governance template (maintained out-of-tree). Promotes the edit-time layer map (`.claude/architecture.md`) and the identity invariants from `CLAUDE.md` into a single invariant-first doc with an **audited** conformance ledger.

## Invariant (7 rules)

Layering spine — (1) dependencies point downward, (2) `remote`/`agent` are network peers not Python neighbors, (3) stateless orchestration facade — plus the mint clauses — (4) `ModelConfig.name` is the mint (**ONE-MINT**), (5) **EMIT-CANONICAL**, (6) **PARSE-AT-THE-DOOR**, (7) port owned at the call site. Each rule joins to its ADR/decision record.

## Conformance (honest, audited — Branch B)

Five rules conform with `path:symbol` citations. Two live violations, now tracked:
- **#170** — `models/config.py:17` imports `BLACKLISTED_PORTS` from `core.settings` (models → core upward edge).
- **#171** — `remote/registry.py:85` imports `resolve_agent_token` from `agent.auth` (remote → agent regression).

## Notable finding

**EMIT-CANONICAL has landed.** `core/process.py:build_command` emits `--alias = ModelConfig.name` unconditionally, with `--alias` on `DENIED_EXTRA_ARG_FLAGS`. The project `CLAUDE.md` and the ecosystem alignment roadmap still describe it as the pending highest-leverage fix — **stale**. Reconciling those (and closing #120 if open) is a separate follow-up, intentionally not in this PR.

## Scope

Documentation only — no code behavior change. `auto:draft` artifact, operator-ratified before this PR was opened. The two violations are tracked for separate remediation, not fixed here.