### PR TITLE
fix(ui): migrate use_container_width=True to width='stretch' (Streamlit 1.56 deprecation)

### DIFF
--- a/llauncher/ui/app.py
+++ b/llauncher/ui/app.py
@@ -123,7 +123,7 @@ def main():
         st.header("Controls")
 
         # Refresh button
-        if st.button("🔄 Refresh All", use_container_width=True):
+        if st.button("🔄 Refresh All", width='stretch'):
             state.refresh()
             registry.refresh_all()
             st.toast("Refreshed all nodes", icon="🔄")

--- a/llauncher/ui/tabs/audit.py
+++ b/llauncher/ui/tabs/audit.py
@@ -184,4 +184,4 @@ def render_audit_tab(
     import pandas as pd
 
     df = pd.DataFrame(rows, columns=_DISPLAY_COLUMNS)
-    st.dataframe(df, use_container_width=True, hide_index=True)
+    st.dataframe(df, width='stretch', hide_index=True)

--- a/llauncher/ui/tabs/dashboard.py
+++ b/llauncher/ui/tabs/dashboard.py
@@ -142,7 +142,7 @@ def render_dashboard(
         # (Streamlit ships pandas, so this is belt-and-suspenders.)
         import pandas as pd
 
-        st.dataframe(pd.DataFrame(rows), hide_index=True, use_container_width=True)
+        st.dataframe(pd.DataFrame(rows), hide_index=True, width='stretch')
 
     # ── Configured-but-stopped models ───────────────────────────
     running_names = {s.config_name for s in servers}
@@ -165,4 +165,4 @@ def render_dashboard(
     ]
     import pandas as pd
 
-    st.dataframe(pd.DataFrame(rows), hide_index=True, use_container_width=True)
+    st.dataframe(pd.DataFrame(rows), hide_index=True, width='stretch')

--- a/llauncher/ui/tabs/forms.py
+++ b/llauncher/ui/tabs/forms.py
@@ -109,7 +109,7 @@ def render_add_model(state: LauncherState) -> None:
                 help="Additional command-line arguments (e.g., '--mcp-config /path/to/file.json')",
             )
 
-        submitted = st.form_submit_button("Add Model", use_container_width=True)
+        submitted = st.form_submit_button("Add Model", width='stretch')
 
         if submitted:
             _process_add_model(state, name, model_path, mmproj_path,
@@ -338,9 +338,9 @@ def render_edit_model(state: LauncherState, model_name: str | None = None) -> No
 
         col_submit, col_cancel = st.columns(2)
         with col_submit:
-            submitted = st.form_submit_button("Save Changes", use_container_width=True)
+            submitted = st.form_submit_button("Save Changes", width='stretch')
         with col_cancel:
-            cancel_clicked = st.form_submit_button("Cancel", use_container_width=True)
+            cancel_clicked = st.form_submit_button("Cancel", width='stretch')
 
         if cancel_clicked:
             del st.session_state[f"editing_{model_name}"]

--- a/llauncher/ui/tabs/model_card.py
+++ b/llauncher/ui/tabs/model_card.py
@@ -49,7 +49,7 @@ def render_model_card(
                 status_icon,
                 key=f"toggle_stop_{node_name}_{model_name}",
                 help=f"Stop {model_name}",
-                use_container_width=True,
+                width='stretch',
             ):
                 _handle_stop(state, aggregator, node_name, running_server.port)
         else:
@@ -93,7 +93,7 @@ def _render_start_button(
                 status_icon,
                 key=f"toggle_start_{node_name}_{model_name}",
                 help="Model config not found",
-                use_container_width=True,
+                width='stretch',
                 disabled=True,
             )
             return
@@ -111,7 +111,7 @@ def _render_start_button(
         status_icon,
         key=f"toggle_start_{node_name}_{model_name}",
         help=f"Start {model_name}",
-        use_container_width=True,
+        width='stretch',
         disabled=chosen_port is None,
     ):
         if chosen_port is None:
@@ -154,14 +154,14 @@ def _render_eviction_dialog(
         if st.button(
             "Cancel",
             key=f"evict_cancel_{node_name}_{port}_{model_name}",
-            use_container_width=True,
+            width='stretch',
         ):
             st.rerun()
     with col2:
         if st.button(
             "Confirm Eviction",
             key=f"evict_confirm_{node_name}_{port}_{model_name}",
-            use_container_width=True,
+            width='stretch',
             type="primary",
         ):
             # v2 ops migration (issue #57): route eviction through
@@ -264,11 +264,11 @@ def _render_model_details(
     # Edit button (only for stopped models on local)
     st.divider()
     if not running_server and node_name == "local":
-        if st.button("✏️ Edit", use_container_width=True, key=f"edit_{node_name}_{model_name}_enabled"):
+        if st.button("✏️ Edit", width='stretch', key=f"edit_{node_name}_{model_name}_enabled"):
             st.session_state[f"editing_{model_name}"] = True
             st.rerun()
     elif not running_server:
-        st.button("✏️ Edit", use_container_width=True, key=f"edit_{node_name}_{model_name}_disabled", disabled=True)
+        st.button("✏️ Edit", width='stretch', key=f"edit_{node_name}_{model_name}_disabled", disabled=True)
         st.caption("Remote model editing not yet supported")
 
 

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -43,7 +43,7 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
     # Refresh button
     col1, col2 = st.columns([1, 3])
     with col1:
-        if st.button("🔄 Refresh All", use_container_width=True, key="refresh_all_nodes"):
+        if st.button("🔄 Refresh All", width='stretch', key="refresh_all_nodes"):
             registry.refresh_all()
             st.toast("Refreshed all nodes", icon="🔄")
             st.rerun()
@@ -121,7 +121,7 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
                     )
                     if st.button(
                         "💾 Save token",
-                        use_container_width=True,
+                        width='stretch',
                         key=f"save_key_{node.name}",
                     ):
                         # overwrite=True with all existing fields preserved.
@@ -147,7 +147,7 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
             with action_col1:
                 if st.button(
                     "🔍 Test Connection",
-                    use_container_width=True,
+                    width='stretch',
                     key=f"test_{node.name}",
                 ):
                     result = node.ping()
@@ -170,7 +170,7 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
                 else:
                     if st.button(
                         "🗑️ Remove Node",
-                        use_container_width=True,
+                        width='stretch',
                         key=f"remove_{node.name}",
                     ):
                         success, message = registry.remove_node(node.name)
@@ -229,13 +229,13 @@ def render_add_node_form(registry: NodeRegistry) -> None:
         with test_col:
             test_clicked = st.form_submit_button(
                 "🔍 Test Connection",
-                use_container_width=True,
+                width='stretch',
                 type="secondary",
             )
         with submit_col:
             submit_clicked = st.form_submit_button(
                 "➕ Add Node",
-                use_container_width=True,
+                width='stretch',
                 type="primary",
             )
 


### PR DESCRIPTION
## What

Streamlit 1.56.0 deprecated the `use_container_width` keyword in favor of `width`, emitting a deprecation warning to the console **on every rerun**. This migrates all occurrences to the new API.

## Mechanical mapping

- `use_container_width=True` → `width='stretch'`
- `use_container_width=False` → `width='content'` (none present in this repo — all 20 occurrences were literal `=True`)

## Scope

Pure mechanical keyword swap — **UI-only, no logic change**. 20 occurrences across 6 modules:

- `llauncher/ui/app.py`
- `llauncher/ui/tabs/audit.py`
- `llauncher/ui/tabs/dashboard.py`
- `llauncher/ui/tabs/forms.py`
- `llauncher/ui/tabs/model_card.py`
- `llauncher/ui/tabs/nodes.py`

`git diff --stat`: 20 insertions / 20 deletions. A final `grep -rn use_container_width .` shows **zero** code occurrences remain (the only remaining hits are historical prose references in `docs/handoffs/**`, intentionally untouched). No test files referenced the keyword.

## Why now

Surfaced while diagnosing **#181** — the per-rerun console spam was masking eject diagnostics. Clearing it restores signal in the console.

## Tests

`python -m pytest -q`: **1088 passed, 11 skipped**. 4 pre-existing failures in `tests/integration/` are environmental and unrelated to this change (3 GPU tests fail on `nvidia-smi` "Driver/library version mismatch"; 1 live-swap test asserts against a resident model name). None touch UI/`width`.

Closes #122.