### PR TITLE
refactor(state): configurable LAUNCHER_STATE_DIR for shared multiuser state

### DIFF
--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -9,10 +9,11 @@ HTTP API authentication. The policy in precedence order:
    the token from standard input (one line, stripped). Lets operators
    pipe a token from a secret manager without leaving it in the
    environment.
-3. The token file at ``~/.llauncher/agent.token``, when present.
-   Read verbatim (stripped).
+3. The token file ``agent.token`` under ``LAUNCHER_STATE_DIR``
+   (default ``~/.llauncher``; see issue #196), when present. Read
+   verbatim (stripped).
 4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token,
-   write it to ``~/.llauncher/agent.token`` with mode 0600 (parent
+   write it to that ``agent.token`` path with mode 0600 (parent
    dir 0700), print it to stderr *once*, and return it.
 
 The auto-generation path is only safe to silently take when the
@@ -44,8 +45,17 @@ def is_loopback(host: str) -> bool:
 
 
 def default_token_path() -> Path:
-    """Return ``~/.llauncher/agent.token``."""
-    return Path.home() / ".llauncher" / "agent.token"
+    """Return the agent token path under ``LAUNCHER_STATE_DIR``.
+
+    Derived from the single durable-state base (issue #196). With
+    ``LAUNCHER_STATE_DIR`` unset this resolves to
+    ``~/.llauncher/agent.token`` exactly as before. Imported lazily so
+    importing this module stays filesystem-free and avoids any import
+    ordering concerns.
+    """
+    from llauncher.core.settings import LAUNCHER_STATE_DIR
+
+    return LAUNCHER_STATE_DIR / "agent.token"
 
 
 def _read_stdin_token() -> str:

--- a/llauncher/core/config.py
+++ b/llauncher/core/config.py
@@ -8,14 +8,17 @@ don't pass one are recorded as ``"unknown"``.
 """
 
 import json
-from pathlib import Path
 
 from llauncher.core import audit_log as al
 from llauncher.core.audit_log import AuditAction, AuditResult
+from llauncher.core.settings import LAUNCHER_STATE_DIR
 from llauncher.models.config import ModelConfig
 
 
-CONFIG_DIR = Path.home() / ".llauncher"
+# Derived from the single LAUNCHER_STATE_DIR base (issue #196). With
+# LAUNCHER_STATE_DIR unset, this resolves to ~/.llauncher exactly as
+# before.
+CONFIG_DIR = LAUNCHER_STATE_DIR
 CONFIG_PATH = CONFIG_DIR / "config.json"
 
 

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -64,19 +64,36 @@ AGENT_API_KEY: str | None = os.getenv("LLAUNCHER_AGENT_TOKEN")
 if AGENT_API_KEY == "":
     AGENT_API_KEY = None
 
+# Base directory for all durable launcher state (issue #196). Every
+# per-actor state path (config, run lockfiles, audit log, per-server
+# logs, node registry + token sidecars, agent token) derives from this
+# single base so a multiuser deployment can point every actor at a
+# shared, non-home-relative location via one env var. Each per-dir env
+# override below still wins when set explicitly; otherwise the path is
+# derived from this base. The legacy ``~/.llauncher`` default is the
+# base's default, so with ``LAUNCHER_STATE_DIR`` unset every resolved
+# path is byte-identical to before this var existed. Pure getenv + Path
+# — no filesystem probing at import (cf. issue #195).
+LAUNCHER_STATE_DIR = Path(os.getenv(
+    "LAUNCHER_STATE_DIR",
+    str(Path.home() / ".llauncher"),
+))
+
 # Lockfile directory for running servers (per ADR-008).
 # Configurable via env so container deployments can volume-mount it,
 # enabling in-container agents to read host-side llauncher state.
+# Precedence: explicit ``LAUNCHER_RUN_DIR`` > ``LAUNCHER_STATE_DIR``/run.
 LAUNCHER_RUN_DIR = Path(os.getenv(
     "LAUNCHER_RUN_DIR",
-    str(Path.home() / ".llauncher" / "run"),
+    str(LAUNCHER_STATE_DIR / "run"),
 ))
 
 # Audit log path (per ADR-008). JSON Lines, append-only.
 # Same volume-mount story as LAUNCHER_RUN_DIR.
+# Precedence: explicit ``LAUNCHER_AUDIT_PATH`` > ``LAUNCHER_STATE_DIR``/audit.jsonl.
 LAUNCHER_AUDIT_PATH = Path(os.getenv(
     "LAUNCHER_AUDIT_PATH",
-    str(Path.home() / ".llauncher" / "audit.jsonl"),
+    str(LAUNCHER_STATE_DIR / "audit.jsonl"),
 ))
 
 # Per-server log directory (ADR-013). Files inside are
@@ -86,7 +103,7 @@ LAUNCHER_AUDIT_PATH = Path(os.getenv(
 # same way as ``LAUNCHER_RUN_DIR`` and ``LAUNCHER_AUDIT_PATH``.
 LAUNCHER_LOG_DIR = Path(os.getenv(
     "LAUNCHER_LOG_DIR",
-    str(Path.home() / ".llauncher" / "logs"),
+    str(LAUNCHER_STATE_DIR / "logs"),
 ))
 
 # Size cap for a single live log file before rotation kicks in (ADR-013).

--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -3,12 +3,15 @@
 import json
 import logging
 import os
-from pathlib import Path
 from typing import Iterator
 
+from llauncher.core.settings import LAUNCHER_STATE_DIR
 from llauncher.remote.node import RemoteNode, NodeStatus
 
-NODES_FILE = Path.home() / ".llauncher" / "nodes.json"
+# Derived from the single LAUNCHER_STATE_DIR base (issue #196). With
+# LAUNCHER_STATE_DIR unset these resolve to ~/.llauncher/* exactly as
+# before.
+NODES_FILE = LAUNCHER_STATE_DIR / "nodes.json"
 # Sibling secrets file for remote-node API tokens (issue #132). Kept
 # separate from ``nodes.json`` so the C10 invariant — "credentials never
 # live in the registry file" — stays crisp. Different secret classes
@@ -16,14 +19,15 @@ NODES_FILE = Path.home() / ".llauncher" / "nodes.json"
 # own files: blast-radius per-concern, corruption degrades gracefully,
 # and the filename itself telegraphs "this is the credential, treat
 # accordingly". Do NOT ratchet tokens back into nodes.json.
-NODE_TOKENS_FILE = Path.home() / ".llauncher" / "node_tokens.json"
+NODE_TOKENS_FILE = LAUNCHER_STATE_DIR / "node_tokens.json"
 logger = logging.getLogger(__name__)
 
 
 class NodeRegistry:
     """Manages a collection of remote nodes.
 
-    Persists node configurations to ~/.llauncher/nodes.json.
+    Persists node configurations to ``nodes.json`` under
+    ``LAUNCHER_STATE_DIR`` (default ``~/.llauncher``; see issue #196).
     """
 
     def __init__(self):

--- a/tests/unit/test_state_dir.py
+++ b/tests/unit/test_state_dir.py
@@ -1,0 +1,172 @@
+"""Tests for the single LAUNCHER_STATE_DIR durable-state base (issue #196).
+
+The durable-state paths (config.json, nodes.json, node_tokens.json,
+agent.token, run/, audit.jsonl, logs/) all derive from one
+env-configurable base, ``LAUNCHER_STATE_DIR``, defined in
+``llauncher.core.settings``.
+
+Most of the paths under test are **module-level constants resolved at
+import time** (``settings.LAUNCHER_RUN_DIR``, ``config.CONFIG_DIR``,
+``registry.NODES_FILE``, ...). They cannot be re-resolved by merely
+setting an env var after import, so these tests use
+``importlib.reload`` under a patched environment to re-execute the
+module bodies. ``llauncher.agent.auth.default_token_path`` is the
+exception — it resolves the base lazily at call time, so it picks up a
+``monkeypatch.setattr`` on ``settings.LAUNCHER_STATE_DIR`` without a
+reload.
+
+A teardown fixture reloads the touched modules back to their default
+(unpatched) environment so reloads here do not leak module state into
+the rest of the suite.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from llauncher.agent import auth as auth_mod
+from llauncher.core import config as config_mod
+from llauncher.core import settings as settings_mod
+from llauncher.remote import registry as registry_mod
+
+
+def _reload_state_modules():
+    """Re-execute settings then the modules that derive paths from it.
+
+    Order matters: ``settings`` first (it owns ``LAUNCHER_STATE_DIR``),
+    then ``config`` and ``registry`` which bind their constants from the
+    freshly reloaded ``settings`` at their own import time.
+    """
+    importlib.reload(settings_mod)
+    importlib.reload(config_mod)
+    importlib.reload(registry_mod)
+
+
+@pytest.fixture(autouse=True)
+def _restore_state_modules():
+    """Reload the state modules back to the ambient env after each test."""
+    yield
+    _reload_state_modules()
+
+
+# --- (a) unset env -> legacy ~/.llauncher defaults ----------------------
+
+def test_defaults_under_home_llauncher_when_unset(monkeypatch, tmp_path):
+    """With no env overrides every path derives from ~/.llauncher."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    for var in (
+        "LAUNCHER_STATE_DIR",
+        "LAUNCHER_RUN_DIR",
+        "LAUNCHER_AUDIT_PATH",
+        "LAUNCHER_LOG_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    _reload_state_modules()
+
+    base = fake_home / ".llauncher"
+    assert settings_mod.LAUNCHER_STATE_DIR == base
+    assert settings_mod.LAUNCHER_RUN_DIR == base / "run"
+    assert settings_mod.LAUNCHER_AUDIT_PATH == base / "audit.jsonl"
+    assert settings_mod.LAUNCHER_LOG_DIR == base / "logs"
+    assert config_mod.CONFIG_DIR == base
+    assert config_mod.CONFIG_PATH == base / "config.json"
+    assert registry_mod.NODES_FILE == base / "nodes.json"
+    assert registry_mod.NODE_TOKENS_FILE == base / "node_tokens.json"
+    # auth resolves lazily at call time
+    monkeypatch.setattr(settings_mod, "LAUNCHER_STATE_DIR", base)
+    assert auth_mod.default_token_path() == base / "agent.token"
+
+
+# --- (b) LAUNCHER_STATE_DIR redirects every derived path ----------------
+
+def test_state_dir_redirects_all_paths(monkeypatch, tmp_path):
+    """Setting LAUNCHER_STATE_DIR points every actor at the shared base."""
+    base = tmp_path / "somewhere"
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(base))
+    for var in ("LAUNCHER_RUN_DIR", "LAUNCHER_AUDIT_PATH", "LAUNCHER_LOG_DIR"):
+        monkeypatch.delenv(var, raising=False)
+
+    _reload_state_modules()
+
+    assert settings_mod.LAUNCHER_STATE_DIR == base
+    assert settings_mod.LAUNCHER_RUN_DIR == base / "run"
+    assert settings_mod.LAUNCHER_AUDIT_PATH == base / "audit.jsonl"
+    assert settings_mod.LAUNCHER_LOG_DIR == base / "logs"
+    assert config_mod.CONFIG_DIR == base
+    assert config_mod.CONFIG_PATH == base / "config.json"
+    assert registry_mod.NODES_FILE == base / "nodes.json"
+    assert registry_mod.NODE_TOKENS_FILE == base / "node_tokens.json"
+    monkeypatch.setattr(settings_mod, "LAUNCHER_STATE_DIR", base)
+    assert auth_mod.default_token_path() == base / "agent.token"
+
+
+def test_state_dir_is_not_home_relative(monkeypatch, tmp_path):
+    """An absolute non-home base is honored verbatim (multiuser deploy)."""
+    base = Path("/var/lib/llauncher-shared")
+    # Make home obviously different so a regression to home-relative fails.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(base))
+
+    _reload_state_modules()
+
+    assert settings_mod.LAUNCHER_STATE_DIR == base
+    assert config_mod.CONFIG_PATH == base / "config.json"
+    assert registry_mod.NODES_FILE == base / "nodes.json"
+
+
+# --- (c) explicit per-dir override still wins ---------------------------
+
+# Each per-dir override var, the settings attribute it controls, and the
+# base-derived default the override must beat. Parameterized so every
+# override seam is exercised, not just LAUNCHER_RUN_DIR.
+_PER_DIR_OVERRIDES = (
+    ("LAUNCHER_RUN_DIR", "LAUNCHER_RUN_DIR", "run"),
+    ("LAUNCHER_AUDIT_PATH", "LAUNCHER_AUDIT_PATH", "audit.jsonl"),
+    ("LAUNCHER_LOG_DIR", "LAUNCHER_LOG_DIR", "logs"),
+)
+
+
+@pytest.mark.parametrize(
+    "override_var, settings_attr, base_suffix", _PER_DIR_OVERRIDES
+)
+def test_explicit_per_dir_override_wins_over_base(
+    monkeypatch, tmp_path, override_var, settings_attr, base_suffix
+):
+    """An explicit per-dir env var beats its LAUNCHER_STATE_DIR-derived default.
+
+    Covers each override seam (``LAUNCHER_RUN_DIR``,
+    ``LAUNCHER_AUDIT_PATH``, ``LAUNCHER_LOG_DIR``): the overridden var
+    takes the explicit value while every un-overridden sibling still
+    derives from the base.
+    """
+    base = tmp_path / "base"
+    override_value = tmp_path / "elsewhere" / base_suffix
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(base))
+    # Clear all per-dir vars first, then set only the one under test, so
+    # the siblings are guaranteed base-derived (not leaked from the env).
+    for var, _, _ in _PER_DIR_OVERRIDES:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(override_var, str(override_value))
+
+    _reload_state_modules()
+
+    # Explicit override wins for the var under test...
+    assert getattr(settings_mod, settings_attr) == override_value
+    # ...while the un-overridden siblings still derive from the base.
+    for var, attr, suffix in _PER_DIR_OVERRIDES:
+        if var == override_var:
+            continue
+        assert getattr(settings_mod, attr) == base / suffix
+
+
+def test_no_filesystem_touch_at_import(monkeypatch, tmp_path):
+    """Reloading settings must not create the state dir on disk."""
+    base = tmp_path / "never-created"
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(base))
+
+    _reload_state_modules()
+
+    assert not base.exists()


### PR DESCRIPTION
Closes #196.

## What
All durable-state paths now derive from a single env-configurable, non-home-relative base `LAUNCHER_STATE_DIR` (default `~/.llauncher`):
- `core/settings.py` — new base; `LAUNCHER_RUN_DIR`/`LAUNCHER_AUDIT_PATH`/`LAUNCHER_LOG_DIR` derive from it (explicit per-dir env still wins).
- `core/config.py` — `CONFIG_DIR` (model registry `config.json`).
- `remote/registry.py` — `NODES_FILE`, `NODE_TOKENS_FILE`.
- `agent/auth.py` — `agent.token` (resolved lazily at call time).

## Why
The paths were hardcoded `Path.home()`-relative, so the operator UI, the agent, and a second agent user each resolved a *different* `~/.llauncher` — the core blocker to sharing state across users. This is the prerequisite for the system-mode installer (#194): system mode will set `LAUNCHER_STATE_DIR=/var/lib/llauncher` so all actors share one group-readable tree.

## Safety
- Behavior-preserving: with the env unset, every resolved path is byte-identical to before.
- Import-safe: no filesystem probing added at import.
- Tests: new `tests/unit/test_state_dir.py` (defaults, redirection, per-dir override precedence across all three dir vars, import-time fs abstinence). Full suite **1098 passed, 0 failed**, coverage 94.81%.