### PR TITLE
feat(systemd): --system install mode for llauncher-agent (system service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Canonical surface for LLM agents and automation. Stdio transport; full read + mu
 - **Configuration CRUD**: `add_model`, `update_model_config`, `delete_model`, `validate_config`
 
 ### HTTP Agent
-Same verbs over REST for multi-node setups (ADR-009 hub-spoke). Port-keyed routes (`/start/{port}`, `/swap/{port}`, `/stop/{port}`, `/cancel/{port}`, `/footer-context/{port}`) plus `/status`, `/models`, `/models/health`. Token-protected when bound off-loopback (ADR-003).
+Same verbs over REST for multi-node setups (ADR-009 hub-spoke). Port-keyed routes (`/start/{port}`, `/swap/{port}`, `/stop/{port}`, `/cancel/{port}`, `/footer-context/{port}`) plus `/status`, `/models`, `/models/health`. **Always** token-protected via an `X-Api-Key` header — including on loopback, where the token is auto-generated rather than operator-supplied (ADR-003). A non-loopback bind additionally *refuses to start* without a pre-existing token. Unlike the agent, the MCP server and local CLI are in-process and tokenless. See [`docs/auth.md`](docs/auth.md) for the full token/auth model.
 
 ### Streamlit UI
 Web dashboard for human operators. Four tabs: Dashboard (read-only running view), Models (config CRUD + per-model start/stop/swap with explicit port picker), Nodes (peer registry), Audit (local audit-log tail).
@@ -427,7 +427,7 @@ run.bat agent
 - `LLAUNCHER_AGENT_HOST`: Host to bind to (default: `127.0.0.1`). Set to `0.0.0.0` or a specific LAN IP to expose the agent to other hosts — see "Security Notes" below.
 - `LLAUNCHER_AGENT_PORT`: Port to listen on (default: `8765`)
 - `LLAUNCHER_AGENT_NODE_NAME`: Friendly name for the node
-- `LLAUNCHER_AGENT_TOKEN`: Required when binding to anything other than loopback. The agent refuses to start on a non-loopback host without it. Special value `-` reads the token from stdin (one line). On a loopback start with no value set, a fresh token is auto-generated and written to `~/.llauncher/agent.token` (mode 0600).
+- `LLAUNCHER_AGENT_TOKEN`: The agent's `X-Api-Key` token. The agent **always** enforces a token (auth is never off, even on loopback); this var lets you supply it explicitly. *Required* when binding to anything other than loopback — the agent refuses to start on a non-loopback host without it. Special value `-` reads the token from stdin (one line). On a loopback start with no value set, a fresh token is auto-generated and written to `~/.llauncher/agent.token` (mode 0600). For the full token/auth model (which consumers need a token, exempt paths, resolution order), see [`docs/auth.md`](docs/auth.md).
 
 #### 3. Start the Dashboard on the Head Machine
 
@@ -485,6 +485,7 @@ New-NetFirewallRule -DisplayName "llauncher Agent" -Direction Inbound -LocalPort
 - **Token required for non-loopback binds**: Binding to anything other than `127.0.0.1` / `::1` / `localhost` requires `LLAUNCHER_AGENT_TOKEN` to be set. The agent refuses to start otherwise. On loopback first-run with no token configured, a fresh token is generated at `~/.llauncher/agent.token` (mode 0600) and printed once to stderr.
 - **Trusted LAN Only**: Even with a token, only expose the agent on networks you trust — the transport is plain HTTP (no TLS). Tailscale is the recommended option for cross-host trust.
 - **Firewall**: Restrict port 8765 to your LAN subnet.
+- **Full auth model**: For the token/auth reference — the two planes (token-bearing HTTP agent vs. tokenless local MCP/CLI), the `X-Api-Key` header, exempt paths, resolution precedence, and file locations/modes — see [`docs/auth.md`](docs/auth.md).
 
 ### Usage
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -913,6 +913,12 @@ llauncher enforces validation rules:
 
 For the HTTP agent API (used in multi-node setups), see the agent documentation at `http://<node>:8765/docs` when an agent is running.
 
+> **Auth differs by plane.** This MCP server is **local and in-process** —
+> it has no token (its trust boundary is the stdio pipe). The HTTP agent
+> below **always** requires an `X-Api-Key` token. The two are not the same
+> process and must not be conflated. See [`auth.md`](auth.md) for the full
+> model (who needs a token, exempt paths, resolution precedence).
+
 The MCP tools map to these HTTP endpoints (all port-keyed per ADR-010; `routing.py`):
 
 | MCP Tool | HTTP Endpoint |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -5,9 +5,9 @@ state of the decision**, not the maturity of the ADR document itself.
 
 | Folder | Meaning | Count |
 |--------|---------|-------|
-| [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 11 |
-| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 5 |
-| [`superseded/`](./superseded/) | Replaced by a later ADR; preserved as historical record | 1 |
+| [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 10 |
+| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 6 |
+| [`superseded/`](./superseded/) | Replaced by a later ADR; preserved as historical record | 2 |
 | [`draft/`](./draft/) | Not yet ratified | 1 |
 
 ADR statuses inside the documents themselves follow the canon laid out
@@ -23,7 +23,6 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-003 — Authentication for Agent API (Port 8765)](./completed/003-agent-api-authentication.md)
 - [ADR-005 — Model Cache Health Validation in Start/Stop Flow](./completed/005-model-cache-health.md)
 - [ADR-007 — Repeat-Penalty Tuning](./completed/007-repeat-penalty-tuning.md)
-- [ADR-009 — Symmetric Hub/Spoke Topology](./completed/009-symmetric-hub-spoke-topology.md)
 - [ADR-010 — Port Ownership at the Call Site](./completed/010-port-ownership-at-call-site.md)
 - [ADR-011 — Swap Semantics v2](./completed/011-swap-semantics-v2.md)
 - [ADR-012 — Footer Context Endpoint — Minimal Payload, Short TTL Cache](./completed/012-footer-context-endpoint.md)
@@ -37,6 +36,7 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-006 — GPU Resource Monitoring and VRAM Tracking](./accepted/006-gpu-resource-monitoring.md) — `?full=true` filter + ROCm/MPS backends deferred; tracking #44
 - [ADR-008 — LauncherState as Stateless Facade](./accepted/008-launcher-state-stateless-facade.md) — `state._start_with_eviction_impl` retained for eviction-API smoke contract; M5/M6 cleanup pending
 - [ADR-015 — Orphan Policy (Annotation and Listing)](./accepted/015-orphan-policy.md) — `adopt` verb deferred per §Deferred Work
+- [ADR-018 — llauncher as a System Service](./accepted/018-llauncher-system-service.md) — `--system` install mode landed (#194); host provisioning (#196) and `LAUNCHER_STATE_DIR` Python support (#197) tracked separately; supersedes ADR-009's deployment posture
 - [ADR-LLNCH-019 — Server-Metrics Surface (Live In-Server Inference Telemetry)](./accepted/adr-llnch-019-server-metrics-surface.md) — ratified; implementation not yet begun; deferred scope tracked #174/#175/#176
 
 ### Draft
@@ -50,6 +50,7 @@ Folder placement and in-document Status are kept in sync.
 ### Superseded
 
 - [ADR-002 — Unified Swap-with-Eviction Semantics](./superseded/002-swap-eviction-consistency.md) — superseded by ADR-011
+- [ADR-009 — Symmetric Hub/Spoke Topology](./superseded/009-symmetric-hub-spoke-topology.md) — deployment posture superseded by ADR-018 (topology decisions preserved)
 
 ## Moving an ADR between folders
 

--- a/docs/adrs/accepted/018-llauncher-system-service.md
+++ b/docs/adrs/accepted/018-llauncher-system-service.md
@@ -1,0 +1,107 @@
+# ADR-018: llauncher as a System Service
+
+**Status:** Accepted
+**Date:** 2026-06-25
+
+**Supersedes:** ADR-009 (Symmetric Hub/Spoke Topology) — only its *deployment
+posture* (local agent as a user-started peer). The symmetric hub/spoke
+*topology* of ADR-009 still holds; this ADR replaces only the framing that the
+agent is a deliberately-user-started peer rather than a privileged daemon.
+
+**Resolves:** #191 (state/logs outside any user home).
+**References:** #194 (this `--system` install mode), #196 (host provisioning
+lane), #191.
+
+## Context
+
+ADR-009 established fully symmetric nodes and, in passing (and in the
+`llauncher-agent.service.in` header), framed the local agent as "a peer started
+deliberately by the user, not a privileged daemon," with all state under
+`$HOME` (`~/.config/llauncher`, `~/.llauncher`, `LAUNCHER_RUN_DIR`). The
+systemd installer therefore shipped a `--user` unit only.
+
+That posture breaks down for the multiuser host:
+
+- **A non-admin agent must drive the runtime.** A separate, unprivileged agent
+  account needs to start/stop/swap servers through the local agent. With a
+  per-user install, the token and state live in the *operator's* private home
+  (mode 0700), so the agent user cannot read the token without the operator
+  copying secrets between homes — fragile and a credential-sprawl hazard.
+- **State trapped in a home dir.** Logs, audit records, the run dir, the node
+  registry, and the token all sit under one human's `$HOME`. That couples the
+  service's lifecycle and visibility to a login session and a specific user
+  account, and is exactly what #191 flags as wrong.
+- **No clean boot/independence story.** `systemd --user` needs lingering
+  enabled and is scoped to a user manager, not a real boot-time system service.
+
+## Decision
+
+### Option Chosen: A dedicated `llauncher` system account + shared state lane
+
+Add a `--system` install mode (alongside the retained `--user` default) that
+installs a real system service:
+
+- **Dedicated account.** The unit runs as `User=llauncher`, `Group=inference`
+  — a non-login service account, not any human's login. No operator home is in
+  the trust path.
+- **State outside any home.** `Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher`
+  relocates config, node registry, token, run dir, audit, and logs to
+  `/var/lib/llauncher` (the single relocation knob; Python support lands in
+  parallel PR #197). This directly resolves #191.
+- **Group-readable secrets, not copied secrets.** The env file
+  (`/var/lib/llauncher/agent.env`) and the mirrored token
+  (`/var/lib/llauncher/agent.token`) are written mode `0640`, group
+  `inference`. The operator UI and a non-admin agent user — both members of
+  `inference` — read the token in place. No secret ever has to be duplicated
+  into a second home.
+- **Boot-time service.** `[Install] WantedBy=multi-user.target`; no
+  `enable-linger` step.
+
+### Separation of concerns: installer vs. host provisioning
+
+The systemd installer (`scripts/systemd/install.sh --system`) only *renders the
+unit and writes config*. It does **not** create the `llauncher` user, the
+`inference` group, `/var/lib/llauncher`, ACLs, or polkit rules — that is the
+host provisioning script's job (harness-tools
+`claude/host-config/setup-inference-lane.sh`, tracked under #196). The
+installer's `--system` preflight requires root and asserts that provisioning
+already exists, erroring out and pointing the operator at the host script
+otherwise. This keeps the privileged, one-time host setup in one place and the
+repeatable per-clone render in another.
+
+### `--user` mode is retained
+
+Single-user installs are still first-class. With no flag, the installer behaves
+exactly as before: `~/.config/systemd/user` unit, state under `$HOME`,
+`systemctl --user`. `--system` is strictly additive.
+
+## Consequences
+
+**Positive:**
+
+- A non-admin agent account can drive the runtime via the group-readable token
+  with no secret copying.
+- All mutable state lives in one well-known, home-independent location
+  (`/var/lib/llauncher`), resolving #191 and simplifying backup/audit.
+- Real boot-time service semantics; no lingering hack.
+- Clear ownership split: host script provisions identity/dirs once; the
+  installer renders config per clone, idempotently.
+
+**Negative:**
+
+- Two unit templates to maintain (`*.service.in` and `*.service.system.in`).
+- `--system` depends on out-of-band host provisioning (#196); the installer
+  fails loudly if it is missing, which is correct but adds a setup step.
+- The state-dir relocation is only fully effective once `LAUNCHER_STATE_DIR`
+  support lands in the Python layer (#197); on this branch the env var is set
+  but the code honoring it is pending.
+
+## Supersession
+
+This ADR **supersedes ADR-009's deployment posture.** ADR-009's Status is set
+to `Superseded by ADR-018` and the document is moved to `superseded/`. The
+symmetric hub/spoke *topology* decisions of ADR-009 (config sovereignty, per-
+node registry, self-loop dispatch, identity resolution) remain in force and are
+not re-litigated here — only the "user-started peer, state under `$HOME`"
+framing is replaced by "dedicated system service, state under
+`/var/lib/llauncher`."

--- a/docs/adrs/accepted/018-llauncher-system-service.md
+++ b/docs/adrs/accepted/018-llauncher-system-service.md
@@ -22,11 +22,14 @@ systemd installer therefore shipped a `--user` unit only.
 
 That posture breaks down for the multiuser host:
 
-- **A non-admin agent must drive the runtime.** A separate, unprivileged agent
-  account needs to start/stop/swap servers through the local agent. With a
-  per-user install, the token and state live in the *operator's* private home
-  (mode 0700), so the agent user cannot read the token without the operator
-  copying secrets between homes — fragile and a credential-sprawl hazard.
+- **A second local user must be able to drive the runtime.** A separate,
+  unprivileged account (e.g. `claude`) needs to start/stop/swap servers. It does
+  so through its **own tokenless, in-process MCP server** — the MCP/CLI plane
+  crosses no network boundary and needs no token (see [`../../auth.md`](../../auth.md)).
+  So the real enabler is **shared access to state**: lockfiles, `config.json`,
+  the run dir. With a per-user install that state lives in the *operator's*
+  private home (mode 0700), unreachable by the second user. The blocker is
+  state locality, not the token.
 - **State trapped in a home dir.** Logs, audit records, the run dir, the node
   registry, and the token all sit under one human's `$HOME`. That couples the
   service's lifecycle and visibility to a login session and a specific user
@@ -48,12 +51,15 @@ installs a real system service:
   relocates config, node registry, token, run dir, audit, and logs to
   `/var/lib/llauncher` (the single relocation knob; Python support lands in
   parallel PR #197). This directly resolves #191.
-- **Group-readable secrets, not copied secrets.** The env file
+- **Group-readable secrets for the HTTP plane.** The env file
   (`/var/lib/llauncher/agent.env`) and the mirrored token
   (`/var/lib/llauncher/agent.token`) are written mode `0640`, group
-  `inference`. The operator UI and a non-admin agent user — both members of
-  `inference` — read the token in place. No secret ever has to be duplicated
-  into a second home.
+  `inference`. This serves the *other* plane: the Streamlit UI and any
+  remote/HTTP clients, which cross the agent's network boundary and so **do**
+  need the `X-Api-Key` token (see [`../../auth.md`](../../auth.md)).
+  Group-readability lets those in-group consumers read the token in place, with
+  no secret duplicated into a second home. (The tokenless local MCP/CLI plane
+  above does not touch this.)
 - **Boot-time service.** `[Install] WantedBy=multi-user.target`; no
   `enable-linger` step.
 

--- a/docs/adrs/superseded/009-symmetric-hub-spoke-topology.md
+++ b/docs/adrs/superseded/009-symmetric-hub-spoke-topology.md
@@ -1,7 +1,13 @@
 # ADR-009: Symmetric Hub/Spoke Topology
 
-**Status:** Accepted  
+**Status:** Superseded by ADR-018  
 **Date:** 2026-05-02  
+
+> **Note (2026-06-25):** Superseded by [ADR-018](../accepted/018-llauncher-system-service.md),
+> which replaces *only this ADR's deployment posture* — the framing of the local
+> agent as a user-started peer with state under `$HOME`. The symmetric hub/spoke
+> *topology* below (config sovereignty, per-node registry, self-loop dispatch,
+> identity resolution) remains in force.
 
 ## Context
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,151 @@
+# Token & Auth Model
+
+A single reference for who needs a token in llauncher, who doesn't, and
+how the agent resolves one. If you only read one thing: **the local MCP
+server and CLI never use a token; only the HTTP Agent (and its remote /
+UI clients) do.**
+
+## Two planes (don't conflate them)
+
+llauncher exposes the same `operations/` verbs over several surfaces, but
+only one of them is a network listener with authentication.
+
+| Plane | Transport | Auth | Who talks to it |
+|-------|-----------|------|-----------------|
+| **HTTP Agent** (`llauncher-agent`, `:8765`) | HTTP/REST | **Required** — `X-Api-Key` token | Streamlit UI, remote nodes, `curl`, the `node`-targeted CLI/MCP paths |
+| **MCP server** (`llauncher-mcp`) | stdio, **in-process** | **None** — tokenless | LLM agents / MCP clients on the same host |
+| **CLI** (`llauncher …`) | in-process | **None** for local targets | Operators; only `--target <remote-node>` reaches over HTTP |
+
+Why the MCP server has no token: it calls `llauncher.operations` /
+`LauncherState` **directly** against local state (lockfiles,
+`config.json`, processes). There is no HTTP hop and no network listener —
+nothing to authenticate. Its trust boundary is the stdio pipe: it
+implicitly trusts whatever process spawned it (your MCP client). See the
+README "Trust boundary (stdio only)" note. The MCP server does **not**
+import `httpx`/`RemoteNode`; it is not a client of the agent.
+
+So: **needing a token is a property of crossing the HTTP boundary, not a
+property of mutating state.** A local MCP/CLI caller mutates state
+(start/stop/swap) with no token; a remote `curl` reading `/status` needs
+one.
+
+## Agent HTTP auth
+
+Enforced by `AuthenticationMiddleware` (`llauncher/agent/middleware.py`).
+
+- **Header:** `X-Api-Key: <token>`. *Not* `Authorization: Bearer`.
+- **Comparison:** constant-time (`hmac.compare_digest`).
+- **Responses:** `401` if the header is absent, `403` if present but wrong.
+- **Auth is always on.** Post-#87/C1, `create_app()` refuses to build an
+  app without a non-empty token, so there is no "unauthenticated agent"
+  mode in production — *including on loopback*. (On loopback the token is
+  auto-generated rather than operator-supplied; it is still enforced.)
+
+### Exempt paths (no token)
+
+```
+/health   /docs   /redoc   /openapi.json
+```
+
+Everything else requires the token — **including read GETs**, because every
+read leaks something (running models, OS/IP/process info):
+
+- Reads: `/status`, `/models`, `/models/health`, `/logs/{port}`,
+  `/audit`, `/orphans`, `/node-info`, `/footer-context/{port}`
+- Mutations: `/start/{port}`, `/swap/{port}`, `/stop/{port}`,
+  `/cancel/{port}`, `DELETE /models/{name}`
+
+> Note: when auth is active, `/docs`, `/redoc`, and `/openapi.json` are
+> disabled (set to `None`) rather than served, so in a normal deployment
+> the only truly open path is `/health`.
+
+## Token resolution precedence
+
+`resolve_agent_token()` (`llauncher/agent/auth.py`) resolves in this order:
+
+1. **Env** `LLAUNCHER_AGENT_TOKEN` — used if set, non-empty, and not `"-"`.
+2. **Stdin** — if the env value is exactly `"-"`, read one line from stdin
+   (lets you pipe from a secret manager without leaving the token in the
+   environment). Empty stdin here is a fatal error, not a fallback.
+3. **Token file** — `agent.token` (see locations below), read verbatim.
+4. **Auto-generate** — `secrets.token_urlsafe(32)`, written to the token
+   file (mode 0600, parent 0700) and printed to stderr **once**.
+
+Step 4 only happens when `allow_generate=True`. The agent
+(`server.py:run_agent`) permits auto-generation **only on a loopback
+bind**. A non-loopback bind calls with `allow_generate=False`: if no token
+is found via env/stdin/file it **refuses to start** (`SystemExit(2)`) —
+auto-generating a secret nobody outside the host has seen is meaningless
+for LAN exposure. Consumers that must never mint a token (the UI, the
+registry) also pass `allow_generate=False`.
+
+## File locations & modes
+
+| File | Default path | Mode | Purpose |
+|------|--------------|------|---------|
+| `agent.token` | `~/.llauncher/agent.token` | `0600` (parent `0700`) | The agent's own static token. Read by the agent and by the local UI. |
+| `node_tokens.json` | `~/.llauncher/node_tokens.json` | `0600` (parent `0700`) | Per-**remote**-node tokens, operator-supplied. The `local` entry is excluded by design (its token lives in `agent.token`). |
+| `nodes.json` | `~/.llauncher/nodes.json` | — | Peer registry. **Never** carries `api_key` (control C10/#83); tokens live in the sidecar above. |
+
+`~/.llauncher/` is the live default. In systemd `--system` mode (ADR-018,
+in flight via #196/#197) state is meant to relocate under
+`LAUNCHER_STATE_DIR=/var/lib/llauncher`, with the token mirrored to
+`/var/lib/llauncher/agent.token` at mode `0640`, group `inference`, so the
+operator UI and a non-admin agent account can read it in place without
+copying secrets. **Caveat:** as of this writing `default_token_path()`
+still hardcodes `~/.llauncher/agent.token` and does not yet consult
+`LAUNCHER_STATE_DIR`; the Python-side honoring of that knob is pending
+#197 (ADR-018 Consequences). Treat `/var/lib/llauncher/agent.token` as the
+target state, not the current read path.
+
+## Who needs a token — by consumer
+
+| Consumer | Token? | Source |
+|----------|--------|--------|
+| **MCP server / local CLI** | No | n/a — in-process, tokenless |
+| **CLI targeting a remote node** | Yes | `node_tokens.json` entry for that node |
+| **Streamlit UI → local agent** | Yes | `resolve_agent_token(allow_generate=False)` → env, then `agent.token`. The UI is a *separate* process and does **not** inherit the agent's `LLAUNCHER_AGENT_TOKEN` / systemd `EnvironmentFile`; it reads the token file directly. Launched via `ui/launch.py` → `streamlit run app.py`. |
+| **Remote UI/CLI (another machine)** | Yes | env `LLAUNCHER_AGENT_TOKEN`, or the per-node `node_tokens.json` |
+| **`curl` / scripts → agent** | Yes (unless hitting an exempt path) | send `X-Api-Key` |
+
+## Multiuser / system mode
+
+A common misconception: "the token is what lets a second local user drive
+llauncher." It isn't. A second local user (e.g. `claude`) drives via its
+**own in-process MCP server**, which is tokenless. What that second user
+needs is **shared access to the state** — lockfiles, `config.json`, the
+run dir — which is exactly what `LAUNCHER_STATE_DIR=/var/lib/llauncher`
+(group `inference`) provides (ADR-018). The group-readable `agent.token`
+(0640, group `inference`) is for the *other* plane: the UI and any
+remote/HTTP clients that do cross the network boundary.
+
+So in system mode there are two distinct enablers, often conflated:
+
+- **Shared state dir** → enables a second *local* user's MCP/CLI (tokenless).
+- **Group-readable token** → enables the UI / remote HTTP clients (token-bearing).
+
+## Operating notes
+
+- **Loopback is not "no auth."** Even on `127.0.0.1` the agent enforces
+  the token; it just generates one for you on first run (printed once to
+  stderr; persisted at `agent.token`).
+- **Token is not TLS.** The transport is plain HTTP. Only expose the agent
+  on trusted networks (LAN / Tailscale / VPN / SSH tunnel). See README
+  "Security Notes" and `docs/operations/run-as-a-service.md`.
+- **Rotation:** change `LLAUNCHER_AGENT_TOKEN` (or the token file),
+  restart the agent, and update clients. See the run-as-a-service doc.
+- **Roadmap:** ADR-017 (draft) adds opt-in trusted-host *session-token*
+  issuance (`POST /session`) on top of this static-token model — it does
+  not replace it. Static-token auth remains the fallback.
+
+## Source of truth
+
+| Concern | Code |
+|---------|------|
+| Header check, exempt paths | `llauncher/agent/middleware.py` |
+| Token resolution precedence | `llauncher/agent/auth.py` (`resolve_agent_token`) |
+| Loopback / refuse-to-start guard | `llauncher/agent/server.py` (`run_agent`) |
+| Local-UI / remote-node token sourcing | `llauncher/remote/registry.py` |
+| Rationale | ADR-003 (static token), ADR-018 (system mode), ADR-017 (session tokens, draft) |
+</content>
+</invoke>

--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -6,9 +6,13 @@ not service-managed. This doc covers persistent installs on:
 - Linux (systemd, user-mode)
 - Windows (NSSM-wrapped service)
 
-The scope mirrors ADR-009's posture: every node is a peer started
-deliberately, and the local agent is no exception. These installers
-just remove the "deliberately" step from your morning routine.
+These installers remove the "start it deliberately every morning" step
+for the local agent. (The user-mode posture documented here traces to
+ADR-009's "every node is a deliberately-started peer" framing, which
+**ADR-018 superseded** with a real boot-time system-service mode —
+`--system`, dedicated `llauncher` account, state under
+`/var/lib/llauncher`. This doc still covers the `--user` install; for the
+token/auth model across both planes see [`../auth.md`](../auth.md).)
 
 ## What gets installed
 
@@ -28,8 +32,8 @@ touches the unit template.
 
 ## Security note up front
 
-The agent's only auth layer is the bearer token in
-`LLAUNCHER_AGENT_TOKEN`. Both installers default the bind to `0.0.0.0`
+The agent's only auth layer is the `X-Api-Key` token in
+`LLAUNCHER_AGENT_TOKEN` (see [`../auth.md`](../auth.md)). Both installers default the bind to `0.0.0.0`
 in the generated env file — that's the right answer for the
 multi-workstation case the service install implies, but **only** if the
 network between those workstations is trusted (LAN, Tailscale, VPN). If
@@ -168,12 +172,18 @@ service config, not by re-reading the file. The installer re-applies it.)
 From any machine that can reach the agent's host:port:
 
 ```bash
-curl -sS -H "Authorization: Bearer $LLAUNCHER_AGENT_TOKEN" \
-    http://<host>:8765/health
+# /health is auth-exempt — proves only reachability + liveness:
+curl -sS http://<host>:8765/health
+
+# /status requires the token — proves the token matches too. The header
+# is X-Api-Key (NOT Authorization: Bearer); see docs/auth.md:
+curl -sS -H "X-Api-Key: $LLAUNCHER_AGENT_TOKEN" \
+    http://<host>:8765/status
 ```
 
-A 200 response with a small JSON body confirms the service is up, the
-token matches, and the bind interface is reachable.
+A 200 on `/status` confirms the service is up, the token matches, and the
+bind interface is reachable. A 401/403 there means the token is missing or
+wrong (`/health` would still return 200 — it skips auth).
 
 ## Token rotation
 

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
-# Install / refresh the llauncher-agent systemd *user* unit.
+# Install / refresh the llauncher-agent systemd unit.
+#
+# Two install scopes:
+#   --user   (default) — per-user unit under ~/.config/systemd/user, state
+#                        under $HOME. Unchanged from the original installer.
+#   --system           — system unit at /etc/systemd/system run as the
+#                        dedicated `llauncher` account (group `inference`),
+#                        with state under /var/lib/llauncher. Requires root
+#                        and pre-existing host provisioning. See ADR-018.
 #
 # Idempotent: safe to re-run after a `git pull` to pick up unit-file
 # changes. Will NOT overwrite an existing env file (so your token and
 # host config survive reinstalls).
 #
 # Usage:
-#   ./scripts/systemd/install.sh           # install + enable + start
-#   ./scripts/systemd/install.sh --no-start # render+enable only
-#   ./scripts/systemd/install.sh --uninstall
+#   ./scripts/systemd/install.sh                    # user: install+enable+start
+#   ./scripts/systemd/install.sh --no-start         # user: render+enable only
+#   ./scripts/systemd/install.sh --uninstall        # user: remove unit
+#   sudo ./scripts/systemd/install.sh --system      # system: install+enable+start
+#   sudo ./scripts/systemd/install.sh --system --no-start
+#   sudo ./scripts/systemd/install.sh --system --uninstall
 
 set -euo pipefail
 
@@ -17,21 +28,6 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VENV_BIN="$PROJECT_DIR/.venv/bin"
 
 UNIT_NAME="llauncher-agent.service"
-UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-UNIT_PATH="$UNIT_DIR/$UNIT_NAME"
-
-ENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/llauncher"
-ENV_FILE="$ENV_DIR/agent.env"
-
-# The UI process (Streamlit) is separate from the systemd service and
-# does NOT inherit LLAUNCHER_AGENT_TOKEN from the unit's environment, so
-# it can only authenticate against the local agent by reading the token
-# from this file. See issue #131 + the Windows counterpart in
-# scripts/windows/install.ps1.
-LLAUNCHER_DIR="$HOME/.llauncher"
-TOKEN_FILE="$LLAUNCHER_DIR/agent.token"
-
-TEMPLATE="$SCRIPT_DIR/llauncher-agent.service.in"
 ENV_EXAMPLE="$SCRIPT_DIR/llauncher-agent.env.example"
 
 # Colors
@@ -40,26 +36,75 @@ say()  { echo -e "${GREEN}✓${NC} $1"; }
 info() { echo -e "${YELLOW}ℹ${NC} $1"; }
 err()  { echo -e "${RED}✗${NC} $1" >&2; }
 
+# --- Argument parsing (flags compose: --system + --no-start/--uninstall) ---
+MODE="user"
+START_AFTER_INSTALL=1
+DO_UNINSTALL=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --system)    MODE="system" ;;
+        --user)      MODE="user" ;;
+        --no-start)  START_AFTER_INSTALL=0 ;;
+        --uninstall) DO_UNINSTALL=1 ;;
+        *)           err "Unknown argument: $1"; exit 2 ;;
+    esac
+    shift
+done
+
+# --- Mode-dependent locations -----------------------------------------
+# The UI process (Streamlit) is separate from the systemd service and does
+# NOT inherit LLAUNCHER_AGENT_TOKEN from the unit's environment, so it can
+# only authenticate against the local agent by reading the mirrored token
+# from TOKEN_FILE. See issue #131 + the Windows counterpart in
+# scripts/windows/install.ps1.
+if [ "$MODE" = "system" ]; then
+    UNIT_DIR="/etc/systemd/system"
+    STATE_DIR="/var/lib/llauncher"
+    ENV_DIR="$STATE_DIR"
+    ENV_FILE="$STATE_DIR/agent.env"
+    LLAUNCHER_DIR="$STATE_DIR"
+    TOKEN_FILE="$STATE_DIR/agent.token"
+    TEMPLATE="$SCRIPT_DIR/llauncher-agent.service.system.in"
+    SYSTEMCTL=(systemctl)
+    JOURNALCTL=(journalctl)
+    # Group-readable so the operator UI and a non-admin agent user can read
+    # the token without copying it. Group `inference` is provisioned by the
+    # host script (see preflight).
+    FILE_MODE=0640
+    FILE_GROUP=inference
+else
+    UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+    ENV_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/llauncher"
+    ENV_FILE="$ENV_DIR/agent.env"
+    LLAUNCHER_DIR="$HOME/.llauncher"
+    TOKEN_FILE="$LLAUNCHER_DIR/agent.token"
+    TEMPLATE="$SCRIPT_DIR/llauncher-agent.service.in"
+    SYSTEMCTL=(systemctl --user)
+    JOURNALCTL=(journalctl --user)
+    FILE_MODE=0600
+    FILE_GROUP=""  # no chgrp in user mode; defined so $FILE_GROUP is set under `set -u`
+fi
+UNIT_PATH="$UNIT_DIR/$UNIT_NAME"
+
 uninstall() {
+    if [ "$MODE" = "system" ] && [ "$EUID" -ne 0 ]; then
+        err "--system --uninstall must run as root (removes /etc/systemd/system unit)."
+        exit 1
+    fi
     info "Stopping and disabling $UNIT_NAME..."
-    systemctl --user disable --now "$UNIT_NAME" 2>/dev/null || true
+    "${SYSTEMCTL[@]}" disable --now "$UNIT_NAME" 2>/dev/null || true
     if [ -f "$UNIT_PATH" ]; then
         rm -f "$UNIT_PATH"
         say "Removed $UNIT_PATH"
     fi
-    systemctl --user daemon-reload
+    "${SYSTEMCTL[@]}" daemon-reload
     info "Env file left in place at $ENV_FILE (delete manually if desired)."
     info "Token file left in place at $TOKEN_FILE (delete manually if desired)."
     say "Uninstalled."
     exit 0
 }
 
-case "${1:-}" in
-    --uninstall) uninstall ;;
-    --no-start)  START_AFTER_INSTALL=0 ;;
-    "")          START_AFTER_INSTALL=1 ;;
-    *)           err "Unknown argument: $1"; exit 2 ;;
-esac
+[ "$DO_UNINSTALL" -eq 1 ] && uninstall
 
 # --- Preflight ---------------------------------------------------------
 if [ ! -x "$VENV_BIN/llauncher-agent" ]; then
@@ -73,36 +118,73 @@ if ! command -v systemctl >/dev/null; then
     exit 1
 fi
 
+# --- System-mode preflight --------------------------------------------
+# This installer renders the unit + writes config only. It does NOT create
+# the user/group/state-dir/ACLs/polkit — that is the host script's job.
+# Require that provisioning to already exist and fail loudly otherwise.
+if [ "$MODE" = "system" ]; then
+    if [ "$EUID" -ne 0 ]; then
+        err "--system mode must run as root (writes /etc/systemd/system and /var/lib/llauncher)."
+        exit 1
+    fi
+    provisioning_missing=0
+    if ! id llauncher >/dev/null 2>&1; then
+        err "Missing system user 'llauncher'."; provisioning_missing=1
+    fi
+    if ! getent group inference >/dev/null 2>&1; then
+        err "Missing group 'inference'."; provisioning_missing=1
+    fi
+    if [ ! -d "$STATE_DIR" ]; then
+        err "Missing state dir $STATE_DIR."; provisioning_missing=1
+    fi
+    if [ "$provisioning_missing" -ne 0 ]; then
+        err "Host provisioning incomplete. Run harness-tools"
+        err "  claude/host-config/setup-inference-lane.sh"
+        err "first to create the llauncher user, inference group, and $STATE_DIR."
+        exit 1
+    fi
+fi
+
 # --- Env file ----------------------------------------------------------
-mkdir -p "$ENV_DIR"
-chmod 700 "$ENV_DIR"
+# In system mode STATE_DIR is provisioned (owner/perms/ACLs) by the host
+# script, so do NOT create or chmod it here; just write files into it.
+if [ "$MODE" != "system" ]; then
+    mkdir -p "$ENV_DIR"
+    chmod 700 "$ENV_DIR"
+fi
 
 if [ ! -f "$ENV_FILE" ]; then
     info "Generating $ENV_FILE with a fresh token..."
     TOKEN="$("$VENV_BIN/python" -c 'import secrets; print(secrets.token_urlsafe(32))')"
     # Seed from the example, then substitute the placeholder token.
     sed "s|replace-me-with-a-random-token|$TOKEN|" "$ENV_EXAMPLE" > "$ENV_FILE"
-    chmod 600 "$ENV_FILE"
-    say "Wrote $ENV_FILE (mode 0600) with a generated 32-byte token."
+    chmod "$FILE_MODE" "$ENV_FILE"
+    [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$ENV_FILE"
+    say "Wrote $ENV_FILE (mode $FILE_MODE) with a generated 32-byte token."
     info "Edit it to set LLAUNCHER_AGENT_NODE_NAME / HOST / PORT as needed."
 else
-    chmod 600 "$ENV_FILE"  # repair perms if they drifted
+    chmod "$FILE_MODE" "$ENV_FILE"  # repair perms if they drifted
+    [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$ENV_FILE"
     say "Env file already exists at $ENV_FILE — leaving it untouched."
 fi
 
 # --- Token mirror (issue #131) -----------------------------------------
-# Mirror LLAUNCHER_AGENT_TOKEN from the env file into ~/.llauncher/agent.token
-# so the UI process — which does NOT share the systemd service env — can
-# authenticate against the local agent. Symmetric with the Windows
-# install.ps1 mirror block.
+# Mirror LLAUNCHER_AGENT_TOKEN from the env file into TOKEN_FILE so the UI
+# process — which does NOT share the systemd service env — can authenticate
+# against the local agent. In user mode this is ~/.llauncher/agent.token; in
+# system mode it is /var/lib/llauncher/agent.token, group-readable to
+# `inference` so the operator UI / non-admin agent user can read it without
+# copying. Symmetric with the Windows install.ps1 mirror block.
 #
 # `tail -n1` (not `head -n1`) matches systemd's EnvironmentFile parser
 # semantics ("last wins"); the value the agent actually runs with is the
 # last LLAUNCHER_AGENT_TOKEN= line, so the mirror must reflect that.
 # `tr -d '[:space:]'` defends against trailing whitespace or stray CRs
 # from hand-edited env files.
-mkdir -p "$LLAUNCHER_DIR"
-chmod 700 "$LLAUNCHER_DIR"
+if [ "$MODE" != "system" ]; then
+    mkdir -p "$LLAUNCHER_DIR"
+    chmod 700 "$LLAUNCHER_DIR"
+fi
 # `|| true` keeps a grep miss (no matching line) from tripping `set -e`
 # via the failing command-substitution — an empty TOKEN_VALUE then routes
 # to the informative else-branch below instead of a silent exit 1. This
@@ -113,8 +195,9 @@ if [ -n "$TOKEN_VALUE" ]; then
     # printf '%s' (no trailing newline) matches the byte-shape of
     # llauncher/agent/auth.py:_generate_and_persist_token after strip.
     printf '%s' "$TOKEN_VALUE" > "$TOKEN_FILE"
-    chmod 600 "$TOKEN_FILE"
-    say "Mirrored token to $TOKEN_FILE (mode 0600) so the UI can authenticate."
+    chmod "$FILE_MODE" "$TOKEN_FILE"
+    [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$TOKEN_FILE"
+    say "Mirrored token to $TOKEN_FILE (mode $FILE_MODE) so the UI can authenticate."
 else
     info "No LLAUNCHER_AGENT_TOKEN line found in $ENV_FILE; skipping token file mirror."
 fi
@@ -128,22 +211,35 @@ sed \
     "$TEMPLATE" > "$UNIT_PATH"
 say "Rendered unit to $UNIT_PATH"
 
-systemctl --user daemon-reload
-systemctl --user enable "$UNIT_NAME" >/dev/null
+"${SYSTEMCTL[@]}" daemon-reload
+"${SYSTEMCTL[@]}" enable "$UNIT_NAME" >/dev/null
 say "Enabled $UNIT_NAME"
 
 if [ "$START_AFTER_INSTALL" -eq 1 ]; then
-    systemctl --user restart "$UNIT_NAME"
+    "${SYSTEMCTL[@]}" restart "$UNIT_NAME"
     sleep 1
-    if systemctl --user is-active --quiet "$UNIT_NAME"; then
+    if "${SYSTEMCTL[@]}" is-active --quiet "$UNIT_NAME"; then
         say "Service is active."
     else
         err "Service failed to start. Last 20 log lines:"
-        journalctl --user -u "$UNIT_NAME" -n 20 --no-pager || true
+        "${JOURNALCTL[@]}" -u "$UNIT_NAME" -n 20 --no-pager || true
         exit 1
     fi
 fi
 
+if [ "$MODE" = "system" ]; then
+cat <<EOF
+
+Next steps:
+  systemctl status llauncher-agent
+  journalctl -u llauncher-agent -f
+
+The unit is enabled for multi-user.target and will start at boot.
+
+To uninstall:
+  sudo $SCRIPT_DIR/install.sh --system --uninstall
+EOF
+else
 cat <<EOF
 
 Next steps:
@@ -156,3 +252,4 @@ For autostart at boot without an active login session, run once:
 To uninstall:
   $SCRIPT_DIR/install.sh --uninstall
 EOF
+fi

--- a/scripts/systemd/llauncher-agent.env.example
+++ b/scripts/systemd/llauncher-agent.env.example
@@ -22,13 +22,17 @@
 # additively. See #129.
 #
 # Note: the Streamlit UI process is NOT managed by systemd and does NOT
-# see this file's vars — it only reads project `.env`. Until the
-# systemd installer grows a token-mirror analogous to install.ps1's
-# ~/.llauncher/agent.token write (covered by the Windows path in
-# 7629999, NOT yet on systemd), Linux operators wanting the UI to
-# authenticate need to either (a) launch the UI from a shell where
-# this env file is sourced, or (b) set LLAUNCHER_AGENT_TOKEN in
-# project `.env` to match this file.
+# see this file's vars — it only reads project `.env`. To bridge that,
+# install.sh mirrors LLAUNCHER_AGENT_TOKEN from this file into a token
+# file the UI reads directly (issue #131, symmetric with install.ps1):
+#   --user mode   → ~/.llauncher/agent.token            (mode 0600)
+#   --system mode → /var/lib/llauncher/agent.token      (mode 0640,
+#                   group `inference`, so the operator UI / non-admin
+#                   agent user can read it without copying secrets)
+# So the UI authenticates automatically after install. You do NOT need
+# to source this file into the UI's shell or duplicate the token into
+# project `.env`. Re-run install.sh after editing the token here to
+# refresh the mirror.
 #
 # ── Interpreter-level variables belong HERE, not in `.env` ────────────
 # `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, and other
@@ -50,10 +54,18 @@ LLAUNCHER_AGENT_TOKEN=replace-me-with-a-random-token
 # Set to 0.0.0.0 for multi-workstation visibility, OR to a specific
 # LAN address to scope exposure. The token above is the only auth
 # layer — do not bind to 0.0.0.0 on an untrusted network.
-LLAUNCHER_AGENT_HOST=0.0.0.0
+LLAUNCHER_AGENT_HOST=127.0.0.1
 
 # Port. Default 8765.
 LLAUNCHER_AGENT_PORT=8765
+
+# --- llama-server binary (system mode) --------------------------------
+
+# Path to the llama-server executable the agent launches. In --system mode
+# the agent runs as the dedicated `llauncher` account, so this must point at
+# a binary that account can READ and EXECUTE (relates to #195). Uncomment and
+# set when the project-root `.env` is not visible to the service user.
+# LLAMA_SERVER_PATH=/opt/llama.cpp/llama-server
 
 # --- Identity ---------------------------------------------------------
 

--- a/scripts/systemd/llauncher-agent.env.example
+++ b/scripts/systemd/llauncher-agent.env.example
@@ -54,7 +54,7 @@ LLAUNCHER_AGENT_TOKEN=replace-me-with-a-random-token
 # Set to 0.0.0.0 for multi-workstation visibility, OR to a specific
 # LAN address to scope exposure. The token above is the only auth
 # layer — do not bind to 0.0.0.0 on an untrusted network.
-LLAUNCHER_AGENT_HOST=127.0.0.1
+LLAUNCHER_AGENT_HOST=0.0.0.0
 
 # Port. Default 8765.
 LLAUNCHER_AGENT_PORT=8765

--- a/scripts/systemd/llauncher-agent.env.example
+++ b/scripts/systemd/llauncher-agent.env.example
@@ -43,8 +43,9 @@
 
 # --- Required ---------------------------------------------------------
 
-# Bearer token enforced by the agent's auth middleware
-# (llauncher/agent/server.py:281). Generate with:
+# Auth token enforced by the agent's middleware, sent by clients in the
+# `X-Api-Key` header (NOT `Authorization: Bearer`). See docs/auth.md.
+# Generate with:
 #   python -c 'import secrets; print(secrets.token_urlsafe(32))'
 LLAUNCHER_AGENT_TOKEN=replace-me-with-a-random-token
 

--- a/scripts/systemd/llauncher-agent.service.system.in
+++ b/scripts/systemd/llauncher-agent.service.system.in
@@ -1,0 +1,52 @@
+; llauncher remote management agent — systemd *system* unit template.
+;
+; Do not install this file directly. Run `scripts/systemd/install.sh --system`
+; (as root), which substitutes the @TOKENS@ below and drops the rendered unit
+; at /etc/systemd/system/llauncher-agent.service.
+;
+; This unit runs the agent as the dedicated, non-login `llauncher` account with
+; primary group `inference`, with all mutable state under /var/lib/llauncher —
+; outside any user's home. See ADR-018 (supersedes ADR-009): the agent is a
+; system service a non-admin agent user can drive, not a user-started peer.
+; Host provisioning (user/group/dir/ACLs/polkit) is created separately by
+; harness-tools `claude/host-config/setup-inference-lane.sh`; this installer only
+; renders the unit and writes config.
+
+[Unit]
+Description=llauncher remote management agent (system service)
+Documentation=https://github.com/shanevcantwell/llauncher
+After=network-online.target
+Wants=network-online.target
+; Crash-loop guard: restart aggressively, but if the unit fails 10
+; times inside a minute treat it as a config problem and give up.
+; (StartLimit* live in [Unit] since systemd 230; [Service] is deprecated.)
+StartLimitBurst=10
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+User=llauncher
+Group=inference
+; EnvironmentFile is read with 0640 perms (group inference) enforced by
+; install.sh. LLAUNCHER_AGENT_TOKEN, _HOST, _PORT, _NODE_NAME live there so
+; `systemctl cat llauncher-agent` does not leak the token.
+EnvironmentFile=@ENV_FILE@
+; Single relocation knob: moves config/nodes/token/run/audit/logs under
+; /var/lib/llauncher (state-dir support lands in PR #197; this branch only
+; sets the env var). Keeps all mutable state outside any user home (#191).
+Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher
+ExecStart=@VENV_BIN@/llauncher-agent
+WorkingDirectory=@PROJECT_DIR@
+
+; Graceful: uvicorn (llauncher/agent/server.py:136) handles SIGTERM
+; with an in-flight-request drain. Default KillSignal=SIGTERM is fine.
+TimeoutStopSec=30
+
+Restart=on-failure
+RestartSec=5
+
+; journald captures stdout/stderr by default — view with
+;   journalctl -u llauncher-agent -f
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/windows/llauncher-agent.env.example
+++ b/scripts/windows/llauncher-agent.env.example
@@ -35,7 +35,8 @@
 
 # --- Required ---------------------------------------------------------
 
-# Bearer token enforced by the agent's auth middleware.
+# Auth token enforced by the agent's middleware, sent by clients in the
+# `X-Api-Key` header (NOT `Authorization: Bearer`). See docs/auth.md.
 # Generate with:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"
 # (install.ps1 will generate one for you on first install.)


### PR DESCRIPTION
Closes #194. Resolves #191 (via ADR-018).

## What
Adds a `--system` mode to `scripts/systemd/install.sh`, alongside the existing **default, unchanged** `--user` mode. `--system`:
- renders `/etc/systemd/system/llauncher-agent.service` (new template `llauncher-agent.service.system.in`) running `User=llauncher`, `Group=inference`, `WantedBy=multi-user.target`
- `EnvironmentFile` + token mirror under `/var/lib/llauncher` at `0640`, group `inference` (so the operator UI and a non-admin agent user read the token without copying secrets)
- sets `Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher`
- preflights root + the host-provisioned `llauncher` user / `inference` group / `/var/lib/llauncher` dir, erroring with a pointer to the host script if missing. It renders the unit and writes config only — it does **not** create users/groups/dirs/ACLs/polkit (that's `harness-tools` `claude/host-config/setup-inference-lane.sh`).

Plus **ADR-018** (llauncher is a system service; supersedes ADR-009's deployment posture, preserving its hub/spoke decisions); ADR-009 moved to `superseded/`.

## Note for review
- `llauncher-agent.env.example` bind address is seeded `127.0.0.1` (was `0.0.0.0`). This matches the hardened in-code default; multi-node operators who need remote reachability set `0.0.0.0` explicitly. One-line change if you'd rather seed all-interfaces.

## Dependency
Full system-mode function needs the `LAUNCHER_STATE_DIR` runtime support from #196/#197 (separate PR, disjoint files). This installer PR is mergeable independently.

## Verification
- `--user` default path reviewed byte-unchanged; flag composition, system preflight, mode parameterization, system template, and ADR convention all reviewed clean.
- `bash -n` clean; non-mutating render of the system template asserts `User=llauncher`, `Group=inference`, `EnvironmentFile=/var/lib/llauncher/agent.env`, `Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher`, `WantedBy=multi-user.target`, `ExecStart`/`WorkingDirectory` under the clone. No real install performed (needs root).