### PR TITLE
fix(settings): import-safe LLAMA_SERVER_PATH probe

### DIFF
--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -17,19 +17,44 @@ _llama_server_path = Path(os.getenv(
     str(Path.home() / ".local" / "bin" / "llama-server")
 ))
 
-# If the path is a directory, try to auto-detect llama-server binary
-if _llama_server_path.is_dir():
-    # Try llama-server first, then llama-server.exe (Windows)
+# If the path is a directory, try to auto-detect llama-server binary.
+#
+# Every filesystem probe here (`.is_dir()`, `.exists()`) is guarded
+# against OSError (incl. PermissionError / FileNotFoundError on the
+# parent). A stale, unreadable, or migrated LLAMA_SERVER_PATH must never
+# raise at *import* time — that would brick the entire package (issue
+# #195: `import llauncher`, `llauncher --help`, and test collection all
+# fail). On any probe failure we fall back to the configured path as a
+# plain Path — the same graceful fallback the happy path already takes
+# when the path isn't a directory — so the failure surfaces with a clear
+# message at point-of-use (start/preflight), not at import.
+def _resolve_llama_server_path(configured: Path) -> Path:
+    try:
+        is_dir = configured.is_dir()
+    except OSError:
+        logger.warning(
+            "Could not probe LLAMA_SERVER_PATH %r (%s); deferring "
+            "validation to start/preflight.",
+            str(configured),
+            "unreadable",
+        )
+        return configured
+    if not is_dir:
+        return configured
+    # Directory: try llama-server first, then llama-server.exe (Windows).
     for candidate in ["llama-server", "llama-server.exe"]:
-        binary_path = _llama_server_path / candidate
-        if binary_path.exists():
-            LLAMA_SERVER_PATH = binary_path
-            break
-    else:
-        # Fallback: use the directory path (will fail later with FileNotFoundError)
-        LLAMA_SERVER_PATH = _llama_server_path
-else:
-    LLAMA_SERVER_PATH = _llama_server_path
+        binary_path = configured / candidate
+        try:
+            exists = binary_path.exists()
+        except OSError:
+            continue
+        if exists:
+            return binary_path
+    # Fallback: use the directory path (will fail later with a clear error).
+    return configured
+
+
+LLAMA_SERVER_PATH = _resolve_llama_server_path(_llama_server_path)
 
 # Path to launch scripts directory
 SCRIPTS_PATH = Path(os.getenv(

--- a/tests/unit/test_settings_import_safety.py
+++ b/tests/unit/test_settings_import_safety.py
@@ -1,0 +1,114 @@
+"""Import-safety tests for the LLAMA_SERVER_PATH probe (issue #195).
+
+``llauncher.core.settings`` resolves ``LLAMA_SERVER_PATH`` at module
+import time, auto-detecting the ``llama-server`` binary when the
+configured path is a directory. A stale / unreadable / migrated path
+must **never** raise at import — an ``os.stat`` ``PermissionError`` or
+``FileNotFoundError`` during ``import llauncher`` would brick the entire
+package (CLI, agent, test collection all fail to load). The accessibility
+of an external runtime dependency should not gate *importing the library*;
+the failure must surface at point-of-use (start/preflight) instead.
+
+These tests use ``importlib.reload`` under a patched environment to
+re-execute the module body, mirroring ``tests/unit/test_state_dir.py``.
+A teardown fixture reloads the module back to the ambient environment so
+reloads here do not leak module state into the rest of the suite.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from llauncher.core import settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def _restore_settings():
+    """Reload settings back to the ambient env after each test."""
+    yield
+    importlib.reload(settings_mod)
+
+
+def test_reload_does_not_raise_when_is_dir_probe_errors(monkeypatch, tmp_path):
+    """A PermissionError from the ``.is_dir()`` probe must not propagate.
+
+    This is the issue #195 repro: running as a user who cannot stat the
+    configured ``LLAMA_SERVER_PATH``. The reload must succeed and the path
+    must fall back to the configured value verbatim.
+    """
+    configured = tmp_path / "unreadable" / "llama-server"
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(configured))
+
+    real_is_dir = Path.is_dir
+
+    def boom_is_dir(self):
+        if self == configured:
+            raise PermissionError(13, "Permission denied")
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", boom_is_dir)
+
+    # Must not raise.
+    importlib.reload(settings_mod)
+
+    assert settings_mod.LLAMA_SERVER_PATH == configured
+
+
+def test_reload_does_not_raise_when_exists_probe_errors(monkeypatch, tmp_path):
+    """A PermissionError from the per-candidate ``.exists()`` probe is tolerated.
+
+    The configured path *is* a readable directory, but stat'ing the
+    candidate binaries inside it raises. The resolver swallows the per
+    candidate error and falls back to the directory path.
+    """
+    configured = tmp_path / "bindir"
+    configured.mkdir()
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(configured))
+
+    real_exists = Path.exists
+
+    def boom_exists(self):
+        if self.parent == configured:
+            raise PermissionError(13, "Permission denied")
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", boom_exists)
+
+    importlib.reload(settings_mod)
+
+    assert settings_mod.LLAMA_SERVER_PATH == configured
+
+
+def test_directory_autodetects_binary(monkeypatch, tmp_path):
+    """Happy path: a directory containing ``llama-server`` auto-detects it."""
+    bindir = tmp_path / "bindir"
+    bindir.mkdir()
+    binary = bindir / "llama-server"
+    binary.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(bindir))
+
+    importlib.reload(settings_mod)
+
+    assert settings_mod.LLAMA_SERVER_PATH == binary
+
+
+def test_file_path_passes_through_unchanged(monkeypatch, tmp_path):
+    """A plain file path (not a directory) passes through verbatim."""
+    binary = tmp_path / "custom-llama-server"
+    binary.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(binary))
+
+    importlib.reload(settings_mod)
+
+    assert settings_mod.LLAMA_SERVER_PATH == binary
+
+
+def test_nonexistent_path_passes_through_unchanged(monkeypatch, tmp_path):
+    """A nonexistent path resolves to itself (failure deferred to use)."""
+    missing = tmp_path / "does" / "not" / "exist" / "llama-server"
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(missing))
+
+    importlib.reload(settings_mod)
+
+    assert settings_mod.LLAMA_SERVER_PATH == missing


### PR DESCRIPTION
Closes #195.

A stale/unreadable LLAMA_SERVER_PATH made the import-time `.is_dir()`/`.exists()` probe raise, bricking every `import llauncher`. The probe is now wrapped in a guarded helper that catches `OSError` and falls back to the configured path; failure surfaces at point-of-use (preflight/start) instead.

Behavior-preserving on happy paths (dir auto-detect, file passthrough). 5 new tests in `tests/unit/test_settings_import_safety.py`; full suite 1103 passed, coverage 94.82%. Reviewed clean.