### PR TITLE
feat(delegation): operator front-ends delegate local launches to the agent (#200)

### DIFF
--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -1,34 +1,36 @@
-"""Agent authentication token resolution (security hardening §3 C1).
+"""Agent authentication helpers (security hardening §3 C1).
 
-This module implements the token-resolution policy for the agent's
-HTTP API authentication. The policy in precedence order:
+Loopback-host classification lives here. The token-resolution policy was
+hoisted to :mod:`llauncher.core.agent_token` (issue #171) so that
+``remote.*`` and the front-ends can read the agent token without importing
+``agent.*`` — removing the ``remote → agent`` layering violation. The
+public token-resolution names are re-exported below so existing
+``from llauncher.agent.auth import resolve_agent_token`` callers keep
+working unchanged.
 
-1. ``LLAUNCHER_AGENT_TOKEN`` env var, when set to a non-empty value
-   that is *not* the literal ``"-"``. Used directly.
-2. ``LLAUNCHER_AGENT_TOKEN=-`` is the explicit opt-in trigger to read
-   the token from standard input (one line, stripped). Lets operators
-   pipe a token from a secret manager without leaving it in the
-   environment.
-3. The token file ``agent.token`` under ``LAUNCHER_STATE_DIR``
-   (default ``~/.llauncher``; see issue #196), when present. Read
-   verbatim (stripped).
-4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token,
-   write it to that ``agent.token`` path with mode 0600 (parent
-   dir 0700), print it to stderr *once*, and return it.
-
-The auto-generation path is only safe to silently take when the
-agent is bound to a loopback interface. The refuse-to-start guard
-in :func:`llauncher.agent.server.run_agent` covers the non-loopback
-case before auth resolution runs.
+Note for test authors: monkeypatching ``default_token_path`` /
+``resolve_agent_token`` must target the canonical home
+(``llauncher.core.agent_token``), because the implementations resolve their
+collaborators (e.g. ``default_token_path``) through *that* module's
+namespace. Patching the re-exported name here has no effect on the
+implementation's internal lookups.
 """
 
 from __future__ import annotations
 
-import os
-import secrets
-import stat
-import sys
-from pathlib import Path
+# Re-export the hoisted token-resolution surface (issue #171). ``sys`` is
+# re-exported too: a test monkeypatching ``agent.auth.sys.stdin`` patches
+# the shared ``sys`` module object, which the core implementation also
+# reads — so that seam keeps working across the move.
+import sys  # noqa: F401  (re-exported for legacy ``auth_mod.sys`` patch sites)
+
+from llauncher.core.agent_token import (  # noqa: F401
+    _generate_and_persist_token,
+    _read_stdin_token,
+    _read_token_file,
+    default_token_path,
+    resolve_agent_token,
+)
 
 
 LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
@@ -42,141 +44,3 @@ def is_loopback(host: str) -> bool:
     interfaces) and any LAN/WAN address — is treated as non-loopback.
     """
     return host in LOOPBACK_HOSTS
-
-
-def default_token_path() -> Path:
-    """Return the agent token path under ``LAUNCHER_STATE_DIR``.
-
-    Derived from the single durable-state base (issue #196). With
-    ``LAUNCHER_STATE_DIR`` unset this resolves to
-    ``~/.llauncher/agent.token`` exactly as before. Imported lazily so
-    importing this module stays filesystem-free and avoids any import
-    ordering concerns.
-    """
-    from llauncher.core.settings import LAUNCHER_STATE_DIR
-
-    return LAUNCHER_STATE_DIR / "agent.token"
-
-
-def _read_stdin_token() -> str:
-    """Read a single token line from stdin.
-
-    Raises ``RuntimeError`` if stdin is closed or yields an empty
-    value — the operator explicitly requested the stdin path with
-    ``LLAUNCHER_AGENT_TOKEN=-``, so a missing token is a fatal config
-    error, not a fallback trigger.
-    """
-    line = sys.stdin.readline()
-    token = line.strip()
-    if not token:
-        raise RuntimeError(
-            "LLAUNCHER_AGENT_TOKEN=- requested but no token was provided on stdin"
-        )
-    return token
-
-
-def _read_token_file(path: Path) -> str | None:
-    """Return the stripped token from ``path``, or None if missing/empty.
-
-    Decoded as ``utf-8-sig`` so that a leading byte-order mark — which
-    Windows PowerShell 5.1 prepends when writing with ``-Encoding utf8``
-    — is consumed at decode time rather than leaking into the token as
-    a ``\\ufeff`` character. ``str.strip()`` does NOT remove ``\\ufeff``
-    (it's classified as zero-width non-breaking space, not whitespace),
-    so a BOM left in the token used to surface downstream as an
-    ``ascii``-codec ``UnicodeEncodeError`` when httpx serialized the
-    token into the ``X-Api-Key`` request header. ``utf-8-sig`` is a
-    strict superset of ``utf-8`` for BOM-less input, so this is a
-    defensive widening with no behavior change for the BOM-free case.
-    """
-    try:
-        data = path.read_text(encoding="utf-8-sig").strip()
-    except FileNotFoundError:
-        return None
-    return data or None
-
-
-def _generate_and_persist_token(path: Path) -> str:
-    """Generate a fresh token and persist it at ``path`` with mode 0600.
-
-    Parent directory is created with mode 0700 if missing. The token
-    is printed to stderr once so the operator can copy it into their
-    client config; we deliberately avoid the regular logger because
-    the operator may have a structured log pipeline that would
-    otherwise capture and retain the secret indefinitely.
-    """
-    parent = path.parent
-    parent.mkdir(parents=True, exist_ok=True)
-    try:
-        parent.chmod(stat.S_IRWXU)  # 0700
-    except OSError:
-        # Best-effort; on some filesystems (e.g. Windows-on-NTFS via
-        # WSL) chmod is a no-op. The 0600 on the file itself is the
-        # load-bearing protection.
-        pass
-
-    token = secrets.token_urlsafe(32)
-    # Write then chmod — open() honors umask, so we restrict
-    # explicitly after creation.
-    path.write_text(token + "\n", encoding="utf-8")
-    try:
-        path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-    except OSError:
-        pass
-
-    print(
-        f"[llauncher-agent] Generated new auth token at {path} (mode 0600).\n"
-        f"[llauncher-agent] Token: {token}\n"
-        f"[llauncher-agent] Set LLAUNCHER_AGENT_TOKEN or use this token in your client.",
-        file=sys.stderr,
-    )
-    return token
-
-
-def resolve_agent_token(
-    *,
-    env_value: str | None = None,
-    token_path: Path | None = None,
-    allow_generate: bool = True,
-) -> str | None:
-    """Resolve the agent auth token per the precedence chain.
-
-    Parameters
-    ----------
-    env_value:
-        Raw value of ``LLAUNCHER_AGENT_TOKEN`` (or ``None`` if unset).
-        When ``None`` (the default kwarg), the env is read at call
-        time. Pass an explicit value (including ``""``/``None``) to
-        bypass the env read — used by tests.
-    token_path:
-        Override the on-disk token file location. Defaults to
-        :func:`default_token_path`.
-    allow_generate:
-        When False, the auto-generate-and-write step is suppressed
-        and the function returns ``None`` if no token is found via
-        env/stdin/file. Used by the refuse-to-start guard so it can
-        report the unauth'd-non-loopback combination before any
-        token is materialized.
-
-    Returns
-    -------
-    The resolved token, or ``None`` if no token could be obtained
-    and ``allow_generate=False``.
-    """
-    if env_value is None:
-        env_value = os.environ.get("LLAUNCHER_AGENT_TOKEN")
-
-    if env_value == "-":
-        return _read_stdin_token()
-    if env_value:
-        return env_value
-
-    path = token_path or default_token_path()
-    existing = _read_token_file(path)
-    if existing:
-        return existing
-
-    if not allow_generate:
-        return None
-
-    return _generate_and_persist_token(path)

--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -25,9 +25,7 @@ from __future__ import annotations
 import sys  # noqa: F401  (re-exported for legacy ``auth_mod.sys`` patch sites)
 
 from llauncher.core.agent_token import (  # noqa: F401
-    _generate_and_persist_token,
-    _read_stdin_token,
-    _read_token_file,
+    _read_token_file,  # imported directly by tests/unit/test_agent_auth_token_file.py
     default_token_path,
     resolve_agent_token,
 )

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -32,6 +32,7 @@ from llauncher.agent.middleware import (
     BodySizeLimitMiddleware,
 )
 from llauncher.agent.routing import router, get_node_name
+from llauncher.core import delegation
 from llauncher.core import lockfile as lf
 from llauncher.core import settings
 from llauncher.core.settings import AGENT_API_KEY
@@ -373,6 +374,13 @@ def run_agent(config: AgentConfig) -> None:
     # would have exited above, and the loopback branch generates a
     # token on first run if none was supplied.
     logger.info("Authentication is active. Binding to %s", config.host)
+
+    # Agent-identity stamp (issue #200). Set BEFORE uvicorn.run so any code
+    # reached from within this process — including the in-process operations
+    # the agent's own routes invoke — detects "I am the agent" via
+    # ``core.delegation.is_agent_process()`` and never delegates back to
+    # itself. Front-end processes (MCP, UI) never set this stamp.
+    os.environ[delegation.AGENT_PROCESS_ENV] = "1"
 
     # Run the server. ``lifespan="on"`` ensures the FastAPI lifespan handler
     # (which reaps llama-server children on shutdown per #65) actually fires

--- a/llauncher/core/agent_token.py
+++ b/llauncher/core/agent_token.py
@@ -1,0 +1,180 @@
+"""Agent authentication token resolution (security hardening §3 C1).
+
+This module implements the token-resolution policy for the agent's HTTP
+API authentication. It lives in :mod:`llauncher.core` — *below* both
+``agent`` and ``remote`` in the layering — so that front-ends and the
+remote-node client can read the local agent's token **without importing
+``agent.*``**. That import edge (``remote.registry`` →
+``agent.auth.resolve_agent_token``) was the layering violation tracked as
+issue #171; hoisting the token logic here retires it.
+
+:mod:`llauncher.agent.auth` re-exports every public name defined here, so
+existing ``from llauncher.agent.auth import resolve_agent_token`` callers
+keep working unchanged.
+
+The policy in precedence order:
+
+1. ``LLAUNCHER_AGENT_TOKEN`` env var, when set to a non-empty value
+   that is *not* the literal ``"-"``. Used directly.
+2. ``LLAUNCHER_AGENT_TOKEN=-`` is the explicit opt-in trigger to read
+   the token from standard input (one line, stripped). Lets operators
+   pipe a token from a secret manager without leaving it in the
+   environment.
+3. The token file ``agent.token`` under ``LAUNCHER_STATE_DIR``
+   (default ``~/.llauncher``; see issue #196), when present. Read
+   verbatim (stripped).
+4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token,
+   write it to that ``agent.token`` path with mode 0600 (parent
+   dir 0700), print it to stderr *once*, and return it.
+
+The auto-generation path is only safe to silently take when the
+agent is bound to a loopback interface. The refuse-to-start guard
+in :func:`llauncher.agent.server.run_agent` covers the non-loopback
+case before auth resolution runs.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import sys
+from pathlib import Path
+
+
+def default_token_path() -> Path:
+    """Return the agent token path under ``LAUNCHER_STATE_DIR``.
+
+    Derived from the single durable-state base (issue #196). With
+    ``LAUNCHER_STATE_DIR`` unset this resolves to
+    ``~/.llauncher/agent.token`` exactly as before. Imported lazily so
+    importing this module stays filesystem-free and avoids any import
+    ordering concerns.
+    """
+    from llauncher.core.settings import LAUNCHER_STATE_DIR
+
+    return LAUNCHER_STATE_DIR / "agent.token"
+
+
+def _read_stdin_token() -> str:
+    """Read a single token line from stdin.
+
+    Raises ``RuntimeError`` if stdin is closed or yields an empty
+    value — the operator explicitly requested the stdin path with
+    ``LLAUNCHER_AGENT_TOKEN=-``, so a missing token is a fatal config
+    error, not a fallback trigger.
+    """
+    line = sys.stdin.readline()
+    token = line.strip()
+    if not token:
+        raise RuntimeError(
+            "LLAUNCHER_AGENT_TOKEN=- requested but no token was provided on stdin"
+        )
+    return token
+
+
+def _read_token_file(path: Path) -> str | None:
+    """Return the stripped token from ``path``, or None if missing/empty.
+
+    Decoded as ``utf-8-sig`` so that a leading byte-order mark — which
+    Windows PowerShell 5.1 prepends when writing with ``-Encoding utf8``
+    — is consumed at decode time rather than leaking into the token as
+    a ``\\ufeff`` character. ``str.strip()`` does NOT remove ``\\ufeff``
+    (it's classified as zero-width non-breaking space, not whitespace),
+    so a BOM left in the token used to surface downstream as an
+    ``ascii``-codec ``UnicodeEncodeError`` when httpx serialized the
+    token into the ``X-Api-Key`` request header. ``utf-8-sig`` is a
+    strict superset of ``utf-8`` for BOM-less input, so this is a
+    defensive widening with no behavior change for the BOM-free case.
+    """
+    try:
+        data = path.read_text(encoding="utf-8-sig").strip()
+    except FileNotFoundError:
+        return None
+    return data or None
+
+
+def _generate_and_persist_token(path: Path) -> str:
+    """Generate a fresh token and persist it at ``path`` with mode 0600.
+
+    Parent directory is created with mode 0700 if missing. The token
+    is printed to stderr once so the operator can copy it into their
+    client config; we deliberately avoid the regular logger because
+    the operator may have a structured log pipeline that would
+    otherwise capture and retain the secret indefinitely.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    try:
+        parent.chmod(stat.S_IRWXU)  # 0700
+    except OSError:
+        # Best-effort; on some filesystems (e.g. Windows-on-NTFS via
+        # WSL) chmod is a no-op. The 0600 on the file itself is the
+        # load-bearing protection.
+        pass
+
+    token = secrets.token_urlsafe(32)
+    # Write then chmod — open() honors umask, so we restrict
+    # explicitly after creation.
+    path.write_text(token + "\n", encoding="utf-8")
+    try:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    except OSError:
+        pass
+
+    print(
+        f"[llauncher-agent] Generated new auth token at {path} (mode 0600).\n"
+        f"[llauncher-agent] Token: {token}\n"
+        f"[llauncher-agent] Set LLAUNCHER_AGENT_TOKEN or use this token in your client.",
+        file=sys.stderr,
+    )
+    return token
+
+
+def resolve_agent_token(
+    *,
+    env_value: str | None = None,
+    token_path: Path | None = None,
+    allow_generate: bool = True,
+) -> str | None:
+    """Resolve the agent auth token per the precedence chain.
+
+    Parameters
+    ----------
+    env_value:
+        Raw value of ``LLAUNCHER_AGENT_TOKEN`` (or ``None`` if unset).
+        When ``None`` (the default kwarg), the env is read at call
+        time. Pass an explicit value (including ``""``/``None``) to
+        bypass the env read — used by tests.
+    token_path:
+        Override the on-disk token file location. Defaults to
+        :func:`default_token_path`.
+    allow_generate:
+        When False, the auto-generate-and-write step is suppressed
+        and the function returns ``None`` if no token is found via
+        env/stdin/file. Used by the refuse-to-start guard so it can
+        report the unauth'd-non-loopback combination before any
+        token is materialized.
+
+    Returns
+    -------
+    The resolved token, or ``None`` if no token could be obtained
+    and ``allow_generate=False``.
+    """
+    if env_value is None:
+        env_value = os.environ.get("LLAUNCHER_AGENT_TOKEN")
+
+    if env_value == "-":
+        return _read_stdin_token()
+    if env_value:
+        return env_value
+
+    path = token_path or default_token_path()
+    existing = _read_token_file(path)
+    if existing:
+        return existing
+
+    if not allow_generate:
+        return None
+
+    return _generate_and_persist_token(path)

--- a/llauncher/core/delegation.py
+++ b/llauncher/core/delegation.py
@@ -141,3 +141,25 @@ def should_delegate(host: str = "127.0.0.1", port: int | None = None) -> bool:
         return override
 
     return local_agent_healthy(host=host, port=port)
+
+
+def local_agent_node():
+    """Construct a ``RemoteNode`` aimed at the local agent (#200 delegation).
+
+    Single construction point for the delegation target — host, port, and
+    token live here rather than being copy-pasted into each front-end.
+    The node is named ``"local"`` and carries the resolved ``X-Api-Key``;
+    because a front-end is not the agent process, its ``_is_self_loop()``
+    is False, so verb calls go over HTTP to ``127.0.0.1:AGENT_PORT``.
+
+    ``RemoteNode`` is imported lazily: ``remote.node`` imports *this*
+    module at load time, so a top-level import here would be circular. The
+    lazy import keeps ``core`` free of a load-time edge to ``remote`` while
+    still centralizing the construction.
+    """
+    from llauncher.core import settings
+    from llauncher.core.agent_token import resolve_agent_token
+    from llauncher.remote.node import RemoteNode
+
+    token = resolve_agent_token(allow_generate=False)
+    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)

--- a/llauncher/core/delegation.py
+++ b/llauncher/core/delegation.py
@@ -1,0 +1,143 @@
+"""Launch-delegation gate (issue #200).
+
+System-mode deployment (#194) runs the agent as a dedicated service
+account that is the *sole* spawner of ``llama-server`` processes. Operator
+front-ends (the MCP server, the local-node UI path) must therefore stop
+spawning in-process and instead **delegate** local-node launches to the
+agent over HTTP — while standalone/dev workflows with no agent running
+must keep working by falling back to an in-process spawn.
+
+This module is the single decision point. It lives in
+:mod:`llauncher.core` — *below* ``remote`` and ``agent`` in the layering —
+so ``remote.node`` and the front-ends (``mcp_server``, ``ui``) can all
+import it without any new ``remote → agent`` edge (cf. #171). It does NOT
+import ``remote`` or ``agent`` itself: it answers only the *decision*; the
+caller owns building the ``RemoteNode`` and POSTing when the answer is
+"delegate".
+
+Decision (for a LOCAL-node launch request):
+
+* If the current process **is** the agent (:func:`is_agent_process`) →
+  never delegate. The agent talking to itself uses in-process ops; this
+  preserves the #62 self-call optimization.
+* Otherwise (a front-end): honor an explicit
+  ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT`` override when set to a recognized
+  truthy/falsy value (deterministic service deployments).
+* Otherwise auto-detect: if a healthy local agent answers
+  ``GET /health`` on ``LLAUNCHER_AGENT_PORT`` (short timeout, with the
+  resolved ``X-Api-Key``) → delegate; else fall back to in-process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# Env var the agent process stamps on itself at startup (before
+# ``uvicorn.run``); see ``llauncher.agent.server.run_agent``.
+AGENT_PROCESS_ENV = "LLAUNCHER_IS_AGENT_PROCESS"
+
+# Operator override for the delegation decision. Truthy → always delegate;
+# falsy → always in-process. Unset (or an unrecognized value) → auto-detect.
+DELEGATE_OVERRIDE_ENV = "LLAUNCHER_DELEGATE_TO_LOCAL_AGENT"
+
+# Short health-probe timeout. The probe sits on the launch hot path, so it
+# must fail fast when no agent is listening rather than stalling the caller.
+_HEALTH_PROBE_TIMEOUT_S = 1.0
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _env_flag(value: str | None) -> bool | None:
+    """Parse an env var into a tri-state: True / False / None (unrecognized).
+
+    ``None`` covers both "unset" and "set to something we don't recognize",
+    so callers fall through to auto-detection in either case.
+    """
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return None
+
+
+def is_agent_process() -> bool:
+    """Return True iff this process is the llauncher agent.
+
+    Detection is an explicit env stamp (``LLAUNCHER_IS_AGENT_PROCESS``)
+    that the agent sets on itself at startup, *before* ``uvicorn.run``.
+    Any recognized-truthy value counts; unset/empty/falsy means "not the
+    agent" — which is the safe default for front-ends.
+    """
+    return _env_flag(os.environ.get(AGENT_PROCESS_ENV)) is True
+
+
+def local_agent_healthy(
+    *,
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    token: str | None = None,
+    timeout: float = _HEALTH_PROBE_TIMEOUT_S,
+) -> bool:
+    """Return True iff a local agent answers ``GET /health`` with 200.
+
+    The probe carries the resolved agent token as ``X-Api-Key`` even
+    though ``/health`` is auth-exempt — harmless if exempt, correct if a
+    future build tightens the exemption. Any transport error or non-200
+    is treated as "no healthy agent" (→ in-process fallback).
+
+    ``port`` defaults to ``settings.AGENT_PORT`` (read at call time so test
+    patches and reloaded settings take effect). ``token`` defaults to the
+    resolved agent token; resolution failures degrade to an unauthenticated
+    probe rather than raising.
+    """
+    if port is None:
+        from llauncher.core import settings
+
+        port = settings.AGENT_PORT
+    if token is None:
+        try:
+            from llauncher.core.agent_token import resolve_agent_token
+
+            token = resolve_agent_token(allow_generate=False)
+        except Exception:  # noqa: BLE001 — probe must never raise
+            token = None
+
+    headers = {"X-Api-Key": token} if token else {}
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(
+                f"http://{host}:{port}/health", headers=headers
+            )
+        return response.status_code == 200
+    except httpx.RequestError:
+        return False
+
+
+def should_delegate(host: str = "127.0.0.1", port: int | None = None) -> bool:
+    """Decide whether a front-end should delegate a local-node launch.
+
+    ``host`` / ``port`` identify the *agent* endpoint to probe on the
+    auto-detect path; they default to loopback and ``settings.AGENT_PORT``.
+
+    Returns True → caller should POST the verb to the local agent over
+    HTTP; False → caller should run the in-process ``operations`` verb.
+    """
+    # The agent itself never delegates — it IS the spawner (#62).
+    if is_agent_process():
+        return False
+
+    override = _env_flag(os.environ.get(DELEGATE_OVERRIDE_ENV))
+    if override is not None:
+        return override
+
+    return local_agent_healthy(host=host, port=port)

--- a/llauncher/core/delegation.py
+++ b/llauncher/core/delegation.py
@@ -141,25 +141,3 @@ def should_delegate(host: str = "127.0.0.1", port: int | None = None) -> bool:
         return override
 
     return local_agent_healthy(host=host, port=port)
-
-
-def local_agent_node():
-    """Construct a ``RemoteNode`` aimed at the local agent (#200 delegation).
-
-    Single construction point for the delegation target — host, port, and
-    token live here rather than being copy-pasted into each front-end.
-    The node is named ``"local"`` and carries the resolved ``X-Api-Key``;
-    because a front-end is not the agent process, its ``_is_self_loop()``
-    is False, so verb calls go over HTTP to ``127.0.0.1:AGENT_PORT``.
-
-    ``RemoteNode`` is imported lazily: ``remote.node`` imports *this*
-    module at load time, so a top-level import here would be circular. The
-    lazy import keeps ``core`` free of a load-time edge to ``remote`` while
-    still centralizing the construction.
-    """
-    from llauncher.core import settings
-    from llauncher.core.agent_token import resolve_agent_token
-    from llauncher.remote.node import RemoteNode
-
-    token = resolve_agent_token(allow_generate=False)
-    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -89,6 +89,15 @@ AGENT_API_KEY: str | None = os.getenv("LLAUNCHER_AGENT_TOKEN")
 if AGENT_API_KEY == "":
     AGENT_API_KEY = None
 
+# Port the local llauncher agent binds (env: LLAUNCHER_AGENT_PORT, default
+# 8765). Mirrors ``agent.config.AgentConfig.from_env``'s port read so the
+# delegation gate (``core.delegation``) and the remote-node client share a
+# single source of truth rather than each re-reading the env inline. Only
+# the ``LLAUNCHER_``-prefixed name is honored — the legacy single-``L``
+# spelling is intentionally NOT a fallback (issue #151 naming direction;
+# see test_env_var_naming_regression).
+AGENT_PORT = int(os.getenv("LLAUNCHER_AGENT_PORT", "8765"))
+
 # Base directory for all durable launcher state (issue #196). Every
 # per-actor state path (config, run lockfiles, audit log, per-server
 # logs, node registry + token sidecars, agent token) derives from this

--- a/llauncher/mcp_server/tools/servers.py
+++ b/llauncher/mcp_server/tools/servers.py
@@ -18,25 +18,28 @@ from mcp import Tool
 
 from llauncher import operations as ops
 from llauncher.core import delegation
-from llauncher.core import settings
 from llauncher.core.process import stream_logs
 from llauncher.state import LauncherState
 
 
-def _local_agent_node():
-    """Build a ``RemoteNode`` aimed at the local agent for delegation (#200).
+def _delegated_or_error(result: dict | None, verb: str, port: int) -> dict:
+    """Normalize a delegated verb result, guarding the ``dict | None`` seam.
 
-    Imported lazily so this module's import graph stays free of ``remote``
-    on the in-process path (the common standalone/dev case). The node is
-    named ``"local"`` and carries the resolved ``X-Api-Key``; because the
-    MCP front-end is not the agent process, its ``_is_self_loop()`` is
-    False and the verb call goes over HTTP to ``127.0.0.1:AGENT_PORT``.
+    ``RemoteNode`` verb methods are typed ``dict | None``: a 200 with a
+    JSON-null body yields Python ``None``. The MCP framework expects a
+    dict, so map that one case to a coherent error envelope. A genuine
+    agent error (transport failure, non-2xx) already arrives as
+    ``{"success": False, "error": ...}`` and is passed through unchanged —
+    we do NOT swallow it.
     """
-    from llauncher.core.agent_token import resolve_agent_token
-    from llauncher.remote.node import RemoteNode
-
-    token = resolve_agent_token(allow_generate=False)
-    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)
+    if result is None:
+        return {
+            "success": False,
+            "action": "error",
+            "port": port,
+            "error": f"Local agent returned an empty response for {verb}",
+        }
+    return result
 
 
 def get_tools() -> list[Tool]:
@@ -216,7 +219,8 @@ async def start_server(args: dict) -> dict:
     # ``llama-server`` is a child of the systemd-managed agent. With no
     # agent reachable, fall back to the in-process op (dev/standalone).
     if delegation.should_delegate():
-        return _local_agent_node().start_server(model_name, port)
+        res = delegation.local_agent_node().start_server(model_name, port)
+        return _delegated_or_error(res, "start", port)
 
     result = ops.start(model_name, port, caller="mcp")
     return result.to_dict()
@@ -238,7 +242,8 @@ async def stop_server(args: dict) -> dict:
 
     # Delegation gate (#200): see ``start_server``.
     if delegation.should_delegate():
-        return _local_agent_node().stop_server(port)
+        res = delegation.local_agent_node().stop_server(port)
+        return _delegated_or_error(res, "stop", port)
 
     result = ops.stop(port, caller="mcp")
     return result.to_dict()
@@ -269,7 +274,8 @@ async def swap_server(args: dict) -> dict:
 
     # Delegation gate (#200): see ``start_server``.
     if delegation.should_delegate():
-        return _local_agent_node().swap_server(model_name, port)
+        res = delegation.local_agent_node().swap_server(model_name, port)
+        return _delegated_or_error(res, "swap", port)
 
     result = ops.swap(model_name, port, caller="mcp")
     return result.to_dict()

--- a/llauncher/mcp_server/tools/servers.py
+++ b/llauncher/mcp_server/tools/servers.py
@@ -17,8 +17,26 @@ from __future__ import annotations
 from mcp import Tool
 
 from llauncher import operations as ops
+from llauncher.core import delegation
+from llauncher.core import settings
 from llauncher.core.process import stream_logs
 from llauncher.state import LauncherState
+
+
+def _local_agent_node():
+    """Build a ``RemoteNode`` aimed at the local agent for delegation (#200).
+
+    Imported lazily so this module's import graph stays free of ``remote``
+    on the in-process path (the common standalone/dev case). The node is
+    named ``"local"`` and carries the resolved ``X-Api-Key``; because the
+    MCP front-end is not the agent process, its ``_is_self_loop()`` is
+    False and the verb call goes over HTTP to ``127.0.0.1:AGENT_PORT``.
+    """
+    from llauncher.core.agent_token import resolve_agent_token
+    from llauncher.remote.node import RemoteNode
+
+    token = resolve_agent_token(allow_generate=False)
+    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)
 
 
 def get_tools() -> list[Tool]:
@@ -193,6 +211,13 @@ async def start_server(args: dict) -> dict:
             "error": "Missing required argument: port",
         }
 
+    # Delegation gate (#200): with a healthy local agent present (or an
+    # explicit override), POST the launch to the agent over HTTP so the
+    # ``llama-server`` is a child of the systemd-managed agent. With no
+    # agent reachable, fall back to the in-process op (dev/standalone).
+    if delegation.should_delegate():
+        return _local_agent_node().start_server(model_name, port)
+
     result = ops.start(model_name, port, caller="mcp")
     return result.to_dict()
 
@@ -210,6 +235,10 @@ async def stop_server(args: dict) -> dict:
             "action": "error",
             "error": "Missing required argument: port",
         }
+
+    # Delegation gate (#200): see ``start_server``.
+    if delegation.should_delegate():
+        return _local_agent_node().stop_server(port)
 
     result = ops.stop(port, caller="mcp")
     return result.to_dict()
@@ -237,6 +266,10 @@ async def swap_server(args: dict) -> dict:
             "action": "error",
             "error": "Missing required argument: model_name",
         }
+
+    # Delegation gate (#200): see ``start_server``.
+    if delegation.should_delegate():
+        return _local_agent_node().swap_server(model_name, port)
 
     result = ops.swap(model_name, port, caller="mcp")
     return result.to_dict()

--- a/llauncher/mcp_server/tools/servers.py
+++ b/llauncher/mcp_server/tools/servers.py
@@ -19,6 +19,7 @@ from mcp import Tool
 from llauncher import operations as ops
 from llauncher.core import delegation
 from llauncher.core.process import stream_logs
+from llauncher.remote.node import local_agent_node
 from llauncher.state import LauncherState
 
 
@@ -219,7 +220,7 @@ async def start_server(args: dict) -> dict:
     # ``llama-server`` is a child of the systemd-managed agent. With no
     # agent reachable, fall back to the in-process op (dev/standalone).
     if delegation.should_delegate():
-        res = delegation.local_agent_node().start_server(model_name, port)
+        res = local_agent_node().start_server(model_name, port)
         return _delegated_or_error(res, "start", port)
 
     result = ops.start(model_name, port, caller="mcp")
@@ -242,7 +243,7 @@ async def stop_server(args: dict) -> dict:
 
     # Delegation gate (#200): see ``start_server``.
     if delegation.should_delegate():
-        res = delegation.local_agent_node().stop_server(port)
+        res = local_agent_node().stop_server(port)
         return _delegated_or_error(res, "stop", port)
 
     result = ops.stop(port, caller="mcp")
@@ -274,7 +275,7 @@ async def swap_server(args: dict) -> dict:
 
     # Delegation gate (#200): see ``start_server``.
     if delegation.should_delegate():
-        res = delegation.local_agent_node().swap_server(model_name, port)
+        res = local_agent_node().swap_server(model_name, port)
         return _delegated_or_error(res, "swap", port)
 
     result = ops.swap(model_name, port, caller="mcp")

--- a/llauncher/remote/node.py
+++ b/llauncher/remote/node.py
@@ -13,13 +13,13 @@ intentionally skips it.
 """
 
 import logging
-import os
 import socket
 from datetime import datetime
 from enum import Enum
-from typing import Literal
 
 import httpx
+
+from llauncher.core.delegation import is_agent_process
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,17 @@ def _local_host_names() -> frozenset[str]:
 
 
 def _local_agent_port() -> int:
-    """The agent port the local node is configured to bind."""
-    return int(os.getenv("LLAUNCHER_AGENT_PORT", "8765"))
+    """The agent port the local node is configured to bind.
+
+    Sourced from :data:`llauncher.core.settings.AGENT_PORT` (issue #200,
+    SP-2) rather than re-reading ``LLAUNCHER_AGENT_PORT`` inline, so the
+    agent port has a single source of truth shared with the delegation
+    gate. Read at call time (via attribute access on the settings module)
+    so test patches / reloaded settings take effect.
+    """
+    from llauncher.core import settings
+
+    return settings.AGENT_PORT
 
 
 class NodeStatus(Enum):
@@ -136,13 +145,10 @@ class RemoteNode:
         """Create an HTTP client configured for this node."""
         return httpx.Client(timeout=self.timeout)
 
-    def _is_self_loop(self) -> bool:
-        """Return True if this node points back at the local agent.
+    def _targets_local_node(self) -> bool:
+        """Return True if this node points at the *local* node/agent.
 
-        The detection is conservative — over-reporting "self" would
-        route remote calls in-process and silently lose multi-node
-        isolation, which is much worse than the cost of one extra
-        loopback HTTP call. Two independent signals are accepted:
+        The original (#62) self-loop predicate. Two independent signals:
 
         * ``self.name == "local"`` — the registry convention from
           :mod:`llauncher.remote.registry`.
@@ -150,8 +156,9 @@ class RemoteNode:
           machine's hostname}`` AND ``self.port`` matches the local
           agent's bind port.
 
-        The host+port conjunction guards against the case where a
-        user has renamed the local node away from ``"local"``.
+        Conservative on purpose: over-reporting "local" would route
+        genuinely-remote calls in-process and silently lose multi-node
+        isolation, which is worse than one extra loopback HTTP call.
         """
         if self.name == "local":
             return True
@@ -159,6 +166,29 @@ class RemoteNode:
             self.host in _local_host_names()
             and self.port == _local_agent_port()
         )
+
+    def _is_self_loop(self) -> bool:
+        """Return True only when the agent is calling its *own* local node.
+
+        This is the #62 self-loop optimization, narrowed per issue #200.
+        Pre-#200 the predicate was just :meth:`_targets_local_node` — which
+        correctly captured the agent talking to itself but *also* captured
+        operator front-ends (MCP, UI) pointing a ``RemoteNode`` at the
+        local agent. Those front-ends are NOT the agent and, under the
+        system-mode deployment (#194), must defer launches *to* the agent
+        over HTTP rather than spawning in-process.
+
+        The narrowing ANDs in
+        :func:`llauncher.core.delegation.is_agent_process`: the short-
+        circuit fires only when *this* process is the agent AND the target
+        is the local node. So:
+
+        * agent → local node  → in-process (the preserved #62 optimization);
+        * agent → remote peer → HTTP (multi-node isolation intact);
+        * front-end → anything → HTTP (where the delegation gate decides,
+          before a ``RemoteNode`` is even built).
+        """
+        return is_agent_process() and self._targets_local_node()
 
     def ping(self) -> bool:
         """Check if the node's agent is reachable.

--- a/llauncher/remote/node.py
+++ b/llauncher/remote/node.py
@@ -535,3 +535,28 @@ class RemoteNode:
             "last_seen": self.last_seen.isoformat() if self.last_seen else None,
             "error_message": self._error_message,
         }
+
+
+def local_agent_node() -> RemoteNode:
+    """Construct a ``RemoteNode`` aimed at the local agent (#200 delegation).
+
+    Single construction point for the delegation target — host, port, and
+    token live here rather than being copy-pasted into each front-end. The
+    node is named ``"local"`` and carries the resolved ``X-Api-Key``;
+    because a front-end is not the agent process, its :meth:`_is_self_loop`
+    is False, so verb calls go over HTTP to ``127.0.0.1:AGENT_PORT``.
+
+    This factory lives in the ``remote`` layer rather than
+    :mod:`llauncher.core.delegation` (issue #200 follow-up): it constructs a
+    ``RemoteNode``, so its natural home is alongside that class. ``core``
+    owns only the *decision* (``should_delegate``); ``remote`` owns *building
+    the target*, keeping ``core`` free of any edge to ``remote`` or
+    ``agent``. ``settings``/``agent_token`` are imported at call time —
+    downward (``remote → core``) edges, read late so test patches and
+    reloaded settings take effect.
+    """
+    from llauncher.core import settings
+    from llauncher.core.agent_token import resolve_agent_token
+
+    token = resolve_agent_token(allow_generate=False)
+    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)

--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -74,11 +74,16 @@ class NodeRegistry:
         ``llauncher-agent`` under systemd / NSSM / foreground), so it
         does *not* inherit ``LLAUNCHER_AGENT_TOKEN`` from the agent's
         environment. We source via
-        :func:`llauncher.agent.auth.resolve_agent_token` with
+        :func:`llauncher.core.agent_token.resolve_agent_token` with
         ``allow_generate=False`` — that reads the env var first, then
         the on-disk ``~/.llauncher/agent.token``. ``allow_generate=False``
         because only the agent itself should ever materialize a fresh
         token; the UI must be a pure consumer.
+
+        The token resolver lives in :mod:`llauncher.core.agent_token`
+        (issue #171) precisely so ``remote`` can read it without
+        importing ``agent.*`` — the layering violation this edge used to
+        embody.
 
         Returns ``None`` if no token can be resolved; callers should
         leave ``api_key=None`` in that case, which matches the
@@ -86,7 +91,7 @@ class NodeRegistry:
         token-less first run).
         """
         try:
-            from llauncher.agent.auth import resolve_agent_token
+            from llauncher.core.agent_token import resolve_agent_token
             return resolve_agent_token(allow_generate=False)
         except Exception:
             # Token resolution must never break registry load. If the

--- a/llauncher/ui/tabs/model_card.py
+++ b/llauncher/ui/tabs/model_card.py
@@ -7,7 +7,7 @@ from llauncher.state import LauncherState
 from llauncher.core import delegation
 from llauncher.core.process import stream_logs
 from llauncher.remote.state import RemoteAggregator
-from llauncher.remote.node import RemoteServerInfo
+from llauncher.remote.node import RemoteServerInfo, local_agent_node
 from llauncher.ui.components.port_picker import render_port_picker
 from llauncher.ui.utils import format_uptime
 
@@ -177,7 +177,7 @@ def _render_eviction_dialog(
             # swap (dev/standalone), preserving the toast taxonomy below.
             if delegation.should_delegate():
                 # ``or {}`` guards the ``dict | None`` seam (see _handle_start).
-                res = delegation.local_agent_node().swap_server(model_name, port) or {}
+                res = local_agent_node().swap_server(model_name, port) or {}
                 if res.get("success"):
                     st.toast(f"{model_name} now running on port {port}", icon="✅")
                 else:
@@ -372,7 +372,7 @@ def _handle_start(
                     # with a null body yields None); ``or {}`` makes the
                     # ``.get`` calls None-safe without masking a real error
                     # dict (transport/non-2xx arrives as a dict already).
-                    res = delegation.local_agent_node().start_server(
+                    res = local_agent_node().start_server(
                         model_name, resolved_port
                     ) or {}
                     if res.get("success"):

--- a/llauncher/ui/tabs/model_card.py
+++ b/llauncher/ui/tabs/model_card.py
@@ -4,11 +4,27 @@ import streamlit as st
 
 from llauncher import operations as ops
 from llauncher.state import LauncherState
+from llauncher.core import delegation
+from llauncher.core import settings
 from llauncher.core.process import stream_logs
 from llauncher.remote.state import RemoteAggregator
 from llauncher.remote.node import RemoteServerInfo
 from llauncher.ui.components.port_picker import render_port_picker
 from llauncher.ui.utils import format_uptime
+
+
+def _local_agent_node():
+    """Build a ``RemoteNode`` aimed at the local agent for delegation (#200).
+
+    Mirrors ``mcp_server.tools.servers._local_agent_node``: the UI is a
+    front-end, not the agent process, so the node's ``_is_self_loop()`` is
+    False and the verb is POSTed over HTTP to ``127.0.0.1:AGENT_PORT``.
+    """
+    from llauncher.core.agent_token import resolve_agent_token
+    from llauncher.remote.node import RemoteNode
+
+    token = resolve_agent_token(allow_generate=False)
+    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)
 
 
 def render_model_card(
@@ -168,25 +184,39 @@ def _render_eviction_dialog(
             # ``operations.swap`` instead of the legacy
             # ``state.start_with_eviction_compat`` path. The M4 tab
             # restructure (#50) must preserve this call.
-            result = ops.swap(model_name, port, caller="ui")
-            if result.success and result.action == "swapped":
-                st.toast(f"{model_name} now running on port {port}", icon="✅")
-            elif result.success and result.action == "already_running":
-                st.toast(f"{model_name} already running on port {port}", icon="ℹ️")
-            elif result.action == "rolled_back":
-                st.toast(
-                    f"Swap failed — rolled back to {result.previous_model} "
-                    f"({result.message})",
-                    icon="⚠️",
-                )
-            elif result.action in ("failed", "rejected_stop_failed"):
-                st.toast(
-                    f"Port {port} unavailable — manual intervention required "
-                    f"({result.message})",
-                    icon="❌",
-                )
+            #
+            # Delegation gate (#200): the evict-and-start branch of a
+            # local-node launch is itself a spawn, so it routes to the
+            # agent over HTTP when one is present (or an override forces
+            # it). With no agent reachable it falls back to the in-process
+            # swap (dev/standalone), preserving the toast taxonomy below.
+            if delegation.should_delegate():
+                res = _local_agent_node().swap_server(model_name, port)
+                if res.get("success"):
+                    st.toast(f"{model_name} now running on port {port}", icon="✅")
+                else:
+                    msg = res.get("message") or res.get("error") or "Eviction failed"
+                    st.toast(msg, icon="❌")
             else:
-                st.toast(f"Eviction failed: {result.message}", icon="❌")
+                result = ops.swap(model_name, port, caller="ui")
+                if result.success and result.action == "swapped":
+                    st.toast(f"{model_name} now running on port {port}", icon="✅")
+                elif result.success and result.action == "already_running":
+                    st.toast(f"{model_name} already running on port {port}", icon="ℹ️")
+                elif result.action == "rolled_back":
+                    st.toast(
+                        f"Swap failed — rolled back to {result.previous_model} "
+                        f"({result.message})",
+                        icon="⚠️",
+                    )
+                elif result.action in ("failed", "rejected_stop_failed"):
+                    st.toast(
+                        f"Port {port} unavailable — manual intervention required "
+                        f"({result.message})",
+                        icon="❌",
+                    )
+                else:
+                    st.toast(f"Eviction failed: {result.message}", icon="❌")
             st.rerun()
 
 
@@ -341,18 +371,33 @@ def _handle_start(
             resolved_port = target_port
             valid, msg = state.can_start(config, caller="ui", port=resolved_port)
             if valid:
-                # v2 ops migration (issue #57): route plain start through
-                # ``operations.start`` (which now runs ADR-005 model-health
-                # pre-flight via the same seam as ``operations.swap``). The
-                # M4 tab restructure (#50) must preserve this call.
-                result = ops.start(model_name, resolved_port, caller="ui")
-                if result.success:
-                    st.toast(result.message, icon="✅")
+                # Delegation gate (#200): with a healthy local agent present
+                # (or an explicit override), POST the launch to the agent so
+                # the ``llama-server`` is a child of the systemd-managed
+                # agent and the operator needs no exec rights on the binary.
+                # With no agent reachable, fall back to the in-process op
+                # (dev/standalone) — v2 ops migration (issue #57): plain
+                # start routes through ``operations.start`` (ADR-005
+                # model-health pre-flight via the same seam as
+                # ``operations.swap``); the M4 tab restructure (#50)
+                # preserves this call.
+                if delegation.should_delegate():
+                    res = _local_agent_node().start_server(model_name, resolved_port)
+                    if res.get("success"):
+                        st.toast(res.get("message") or f"Starting {model_name}", icon="✅")
+                    else:
+                        err = res.get("message") or res.get("error") or "Failed to start"
+                        st.error(err)
+                        st.toast(err, icon="❌")
                 else:
-                    # Errors must be sticky — toasts disappear too quickly
-                    # to read on a near-instant validation failure.
-                    st.error(result.message)
-                    st.toast(result.message, icon="❌")
+                    result = ops.start(model_name, resolved_port, caller="ui")
+                    if result.success:
+                        st.toast(result.message, icon="✅")
+                    else:
+                        # Errors must be sticky — toasts disappear too quickly
+                        # to read on a near-instant validation failure.
+                        st.error(result.message)
+                        st.toast(result.message, icon="❌")
             else:
                 st.error(f"Cannot start: {msg}")
                 st.toast(f"Cannot start: {msg}", icon="❌")

--- a/llauncher/ui/tabs/model_card.py
+++ b/llauncher/ui/tabs/model_card.py
@@ -5,26 +5,11 @@ import streamlit as st
 from llauncher import operations as ops
 from llauncher.state import LauncherState
 from llauncher.core import delegation
-from llauncher.core import settings
 from llauncher.core.process import stream_logs
 from llauncher.remote.state import RemoteAggregator
 from llauncher.remote.node import RemoteServerInfo
 from llauncher.ui.components.port_picker import render_port_picker
 from llauncher.ui.utils import format_uptime
-
-
-def _local_agent_node():
-    """Build a ``RemoteNode`` aimed at the local agent for delegation (#200).
-
-    Mirrors ``mcp_server.tools.servers._local_agent_node``: the UI is a
-    front-end, not the agent process, so the node's ``_is_self_loop()`` is
-    False and the verb is POSTed over HTTP to ``127.0.0.1:AGENT_PORT``.
-    """
-    from llauncher.core.agent_token import resolve_agent_token
-    from llauncher.remote.node import RemoteNode
-
-    token = resolve_agent_token(allow_generate=False)
-    return RemoteNode("local", "127.0.0.1", port=settings.AGENT_PORT, api_key=token)
 
 
 def render_model_card(
@@ -191,7 +176,8 @@ def _render_eviction_dialog(
             # it). With no agent reachable it falls back to the in-process
             # swap (dev/standalone), preserving the toast taxonomy below.
             if delegation.should_delegate():
-                res = _local_agent_node().swap_server(model_name, port)
+                # ``or {}`` guards the ``dict | None`` seam (see _handle_start).
+                res = delegation.local_agent_node().swap_server(model_name, port) or {}
                 if res.get("success"):
                     st.toast(f"{model_name} now running on port {port}", icon="✅")
                 else:
@@ -382,11 +368,21 @@ def _handle_start(
                 # ``operations.swap``); the M4 tab restructure (#50)
                 # preserves this call.
                 if delegation.should_delegate():
-                    res = _local_agent_node().start_server(model_name, resolved_port)
+                    # ``RemoteNode.start_server`` is ``dict | None`` (a 200
+                    # with a null body yields None); ``or {}`` makes the
+                    # ``.get`` calls None-safe without masking a real error
+                    # dict (transport/non-2xx arrives as a dict already).
+                    res = delegation.local_agent_node().start_server(
+                        model_name, resolved_port
+                    ) or {}
                     if res.get("success"):
                         st.toast(res.get("message") or f"Starting {model_name}", icon="✅")
                     else:
-                        err = res.get("message") or res.get("error") or "Failed to start"
+                        err = (
+                            res.get("message")
+                            or res.get("error")
+                            or "Local agent returned no result"
+                        )
                         st.error(err)
                         st.toast(err, icon="❌")
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,27 @@ def _patch_model_health(request):
 
 
 @pytest.fixture(autouse=True)
+def _deterministic_delegation(monkeypatch):
+    """Force the #200 delegation gate to in-process for the whole suite.
+
+    A real llauncher agent may be listening on ``LLAUNCHER_AGENT_PORT``
+    (8765) on the developer/CI host. Without pinning the gate, the
+    auto-detect health probe would find it and the MCP/UI launch tests
+    (test_mcp_flows, test_self_swap, ...) would POST real start/stop verbs
+    to that live agent — spawning real models and breaking isolation.
+
+    Pinning ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=0`` makes every front-end
+    take the in-process path by default, matching the legacy behavior the
+    bulk of the suite was written against. We also clear the
+    ``LLAUNCHER_IS_AGENT_PROCESS`` stamp so no ambient value leaks in.
+    Gate-specific tests override these via their own ``monkeypatch`` (which
+    wins, being applied inside the test body after this autouse setup).
+    """
+    monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "0")
+    monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_nodes_file(tmp_path, monkeypatch):
     """Redirect the node-registry persistence file to a per-test tmp path.
 

--- a/tests/integration/test_agent_security_c1_c2.py
+++ b/tests/integration/test_agent_security_c1_c2.py
@@ -69,13 +69,14 @@ def test_run_agent_refuses_non_loopback_without_token(monkeypatch, tmp_path):
     to a non-loopback host without ``LLAUNCHER_AGENT_TOKEN``."""
     from llauncher.agent.config import AgentConfig
     from llauncher.agent import server as agent_srv
-    from llauncher.agent import auth as agent_auth
 
     monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
     # Force token-file lookup at a missing path so the operator's real
     # ~/.llauncher/agent.token cannot accidentally satisfy the guard.
+    # Token resolution was hoisted to core.agent_token (#171); patch the
+    # canonical home so the implementation's internal lookup is affected.
     monkeypatch.setattr(
-        agent_auth, "default_token_path",
+        "llauncher.core.agent_token.default_token_path",
         lambda: tmp_path / "definitely-missing.token",
     )
 
@@ -114,9 +115,9 @@ def _isolate_home(monkeypatch, tmp_path):
     # Cover non-POSIX call sites that read USERPROFILE.
     monkeypatch.setenv("USERPROFILE", str(home))
 
-    from llauncher.agent import auth as agent_auth
+    # Token resolution was hoisted to core.agent_token (#171); patch there.
     monkeypatch.setattr(
-        agent_auth, "default_token_path",
+        "llauncher.core.agent_token.default_token_path",
         lambda: home / ".llauncher" / "agent.token",
     )
     return home

--- a/tests/unit/mcp/test_servers_tools.py
+++ b/tests/unit/mcp/test_servers_tools.py
@@ -367,6 +367,99 @@ class TestGetTools:
         assert required == {"port"}
 
 
+# ─────────────────────── delegation gate (#200) ───────────────────────
+
+
+class TestDelegationRouting:
+    """start/swap/stop route through the #200 delegation gate.
+
+    When ``should_delegate()`` is True the verb is POSTed to the local
+    agent via a ``RemoteNode`` (HTTP) and ``ops.*`` is NOT called; when
+    False the in-process op runs (the default the rest of this file
+    exercises via the autouse ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=0`` pin).
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_delegates_over_http_when_gate_true(self):
+        node = MagicMock()
+        node.start_server.return_value = {
+            "success": True, "action": "started", "port": 8080, "model": "m",
+        }
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=True,
+        ), patch(
+            "llauncher.mcp_server.tools.servers._local_agent_node",
+            return_value=node,
+        ), patch(
+            "llauncher.mcp_server.tools.servers.ops.start"
+        ) as mock_ops:
+            result = await start_server({"model_name": "m", "port": 8080})
+
+        mock_ops.assert_not_called()
+        node.start_server.assert_called_once_with("m", 8080)
+        assert result["success"] is True
+        assert result["action"] == "started"
+
+    @pytest.mark.asyncio
+    async def test_start_in_process_when_gate_false(self):
+        envelope = StartResult(success=True, action="started", port=8080, model="m")
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=False,
+        ), patch(
+            "llauncher.mcp_server.tools.servers._local_agent_node"
+        ) as mock_node, patch(
+            "llauncher.mcp_server.tools.servers.ops.start",
+            return_value=envelope,
+        ) as mock_ops:
+            result = await start_server({"model_name": "m", "port": 8080})
+
+        mock_ops.assert_called_once_with("m", 8080, caller="mcp")
+        mock_node.assert_not_called()
+        assert result["action"] == "started"
+
+    @pytest.mark.asyncio
+    async def test_stop_delegates_over_http_when_gate_true(self):
+        node = MagicMock()
+        node.stop_server.return_value = {"success": True, "action": "stopping"}
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=True,
+        ), patch(
+            "llauncher.mcp_server.tools.servers._local_agent_node",
+            return_value=node,
+        ), patch(
+            "llauncher.mcp_server.tools.servers.ops.stop"
+        ) as mock_ops:
+            result = await stop_server({"port": 8080})
+
+        mock_ops.assert_not_called()
+        node.stop_server.assert_called_once_with(8080)
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_swap_delegates_over_http_when_gate_true(self):
+        node = MagicMock()
+        node.swap_server.return_value = {
+            "success": True, "action": "swapped", "port": 8080, "model": "new",
+        }
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=True,
+        ), patch(
+            "llauncher.mcp_server.tools.servers._local_agent_node",
+            return_value=node,
+        ), patch(
+            "llauncher.mcp_server.tools.servers.ops.swap"
+        ) as mock_ops:
+            result = await swap_server({"port": 8080, "model_name": "new"})
+
+        mock_ops.assert_not_called()
+        node.swap_server.assert_called_once_with("new", 8080)
+        assert result["action"] == "swapped"
+
+
 # ─────────────────────── cancel_server (ADR-014) ──────────────────────
 
 

--- a/tests/unit/mcp/test_servers_tools.py
+++ b/tests/unit/mcp/test_servers_tools.py
@@ -379,19 +379,28 @@ class TestDelegationRouting:
     exercises via the autouse ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=0`` pin).
     """
 
+    @staticmethod
+    def _patch_delegate(node):
+        """Patch the gate True and the factory to return ``node``."""
+        return (
+            patch(
+                "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+                return_value=True,
+            ),
+            patch(
+                "llauncher.mcp_server.tools.servers.delegation.local_agent_node",
+                return_value=node,
+            ),
+        )
+
     @pytest.mark.asyncio
     async def test_start_delegates_over_http_when_gate_true(self):
         node = MagicMock()
         node.start_server.return_value = {
             "success": True, "action": "started", "port": 8080, "model": "m",
         }
-        with patch(
-            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
-            return_value=True,
-        ), patch(
-            "llauncher.mcp_server.tools.servers._local_agent_node",
-            return_value=node,
-        ), patch(
+        gate, factory = self._patch_delegate(node)
+        with gate, factory, patch(
             "llauncher.mcp_server.tools.servers.ops.start"
         ) as mock_ops:
             result = await start_server({"model_name": "m", "port": 8080})
@@ -408,7 +417,7 @@ class TestDelegationRouting:
             "llauncher.mcp_server.tools.servers.delegation.should_delegate",
             return_value=False,
         ), patch(
-            "llauncher.mcp_server.tools.servers._local_agent_node"
+            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
         ) as mock_node, patch(
             "llauncher.mcp_server.tools.servers.ops.start",
             return_value=envelope,
@@ -420,16 +429,26 @@ class TestDelegationRouting:
         assert result["action"] == "started"
 
     @pytest.mark.asyncio
+    async def test_delegated_null_body_maps_to_error_envelope(self):
+        """A 200-with-null delegated result (``None``) becomes a coherent
+        error dict, not a raw None handed to the MCP framework (#200 review)."""
+        node = MagicMock()
+        node.start_server.return_value = None
+        gate, factory = self._patch_delegate(node)
+        with gate, factory:
+            result = await start_server({"model_name": "m", "port": 8080})
+
+        assert result["success"] is False
+        assert result["action"] == "error"
+        assert result["port"] == 8080
+        assert "empty response" in result["error"].lower()
+
+    @pytest.mark.asyncio
     async def test_stop_delegates_over_http_when_gate_true(self):
         node = MagicMock()
         node.stop_server.return_value = {"success": True, "action": "stopping"}
-        with patch(
-            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
-            return_value=True,
-        ), patch(
-            "llauncher.mcp_server.tools.servers._local_agent_node",
-            return_value=node,
-        ), patch(
+        gate, factory = self._patch_delegate(node)
+        with gate, factory, patch(
             "llauncher.mcp_server.tools.servers.ops.stop"
         ) as mock_ops:
             result = await stop_server({"port": 8080})
@@ -439,24 +458,58 @@ class TestDelegationRouting:
         assert result["success"] is True
 
     @pytest.mark.asyncio
+    async def test_stop_in_process_when_gate_false(self):
+        envelope = StopResult(success=True, action="stopped", port=8080)
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=False,
+        ), patch(
+            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
+        ) as mock_node, patch(
+            "llauncher.mcp_server.tools.servers.ops.stop",
+            return_value=envelope,
+        ) as mock_ops:
+            result = await stop_server({"port": 8080})
+
+        mock_ops.assert_called_once_with(8080, caller="mcp")
+        mock_node.assert_not_called()
+        assert result["action"] == "stopped"
+
+    @pytest.mark.asyncio
     async def test_swap_delegates_over_http_when_gate_true(self):
         node = MagicMock()
         node.swap_server.return_value = {
             "success": True, "action": "swapped", "port": 8080, "model": "new",
         }
-        with patch(
-            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
-            return_value=True,
-        ), patch(
-            "llauncher.mcp_server.tools.servers._local_agent_node",
-            return_value=node,
-        ), patch(
+        gate, factory = self._patch_delegate(node)
+        with gate, factory, patch(
             "llauncher.mcp_server.tools.servers.ops.swap"
         ) as mock_ops:
             result = await swap_server({"port": 8080, "model_name": "new"})
 
         mock_ops.assert_not_called()
         node.swap_server.assert_called_once_with("new", 8080)
+        assert result["action"] == "swapped"
+
+    @pytest.mark.asyncio
+    async def test_swap_in_process_when_gate_false(self):
+        envelope = SwapResult(
+            success=True, action="swapped", port_state="serving",
+            port=8080, model="new", previous_model="old",
+        )
+        with patch(
+            "llauncher.mcp_server.tools.servers.delegation.should_delegate",
+            return_value=False,
+        ), patch(
+            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
+        ) as mock_node, patch(
+            "llauncher.mcp_server.tools.servers.ops.swap",
+            return_value=envelope,
+        ) as mock_ops:
+            result = await swap_server({"port": 8080, "model_name": "new"})
+
+        mock_ops.assert_called_once_with("new", 8080, caller="mcp")
+        mock_node.assert_not_called()
         assert result["action"] == "swapped"
 
 

--- a/tests/unit/mcp/test_servers_tools.py
+++ b/tests/unit/mcp/test_servers_tools.py
@@ -388,7 +388,7 @@ class TestDelegationRouting:
                 return_value=True,
             ),
             patch(
-                "llauncher.mcp_server.tools.servers.delegation.local_agent_node",
+                "llauncher.mcp_server.tools.servers.local_agent_node",
                 return_value=node,
             ),
         )
@@ -417,7 +417,7 @@ class TestDelegationRouting:
             "llauncher.mcp_server.tools.servers.delegation.should_delegate",
             return_value=False,
         ), patch(
-            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
+            "llauncher.mcp_server.tools.servers.local_agent_node"
         ) as mock_node, patch(
             "llauncher.mcp_server.tools.servers.ops.start",
             return_value=envelope,
@@ -464,7 +464,7 @@ class TestDelegationRouting:
             "llauncher.mcp_server.tools.servers.delegation.should_delegate",
             return_value=False,
         ), patch(
-            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
+            "llauncher.mcp_server.tools.servers.local_agent_node"
         ) as mock_node, patch(
             "llauncher.mcp_server.tools.servers.ops.stop",
             return_value=envelope,
@@ -501,7 +501,7 @@ class TestDelegationRouting:
             "llauncher.mcp_server.tools.servers.delegation.should_delegate",
             return_value=False,
         ), patch(
-            "llauncher.mcp_server.tools.servers.delegation.local_agent_node"
+            "llauncher.mcp_server.tools.servers.local_agent_node"
         ) as mock_node, patch(
             "llauncher.mcp_server.tools.servers.ops.swap",
             return_value=envelope,

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -815,11 +815,12 @@ class TestUtilityFunctions:
         # Force the on-disk token file lookup to a missing path so the
         # refuse-to-start branch is exercised even if the operator's real
         # home has a file present.
-        from llauncher.agent import auth as agent_auth
         from pathlib import Path
 
+        # Token resolution was hoisted to core.agent_token (#171); patch the
+        # canonical home so run_agent's resolver honors the missing path.
         monkeypatch.setattr(
-            agent_auth, "default_token_path",
+            "llauncher.core.agent_token.default_token_path",
             lambda: Path("/nonexistent/llauncher/agent.token"),
         )
 

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -210,3 +210,32 @@ class TestRemoteDoesNotImportAgent:
             allow_generate=False,
         )
         assert token is None
+
+    def test_importing_core_delegation_does_not_import_remote_or_agent(self):
+        """Issue #200 layering: ``core.delegation`` must depend on nothing in
+        ``remote`` or ``agent``.
+
+        The ``local_agent_node`` factory (which constructs a ``RemoteNode``)
+        was moved out of ``core.delegation`` into ``remote.node`` so ``core``
+        no longer carries an edge — even a lazy/function-local one — to the
+        upper layers. Run in a fresh interpreter so other tests' imports
+        cannot mask a regression, and assert that importing the module pulls
+        in neither package.
+        """
+        code = (
+            "import sys; "
+            "import llauncher.core.delegation; "
+            "leaked = sorted(m for m in sys.modules "
+            "if m in ('llauncher.remote', 'llauncher.agent') "
+            "or m.startswith('llauncher.remote.') "
+            "or m.startswith('llauncher.agent.')); "
+            "print(leaked); "
+            "sys.exit(1 if leaked else 0)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 0, (
+            "core.delegation imported remote.*/agent.* (layering inversion "
+            f"#200); leaked modules: {result.stdout.strip()}\n{result.stderr}"
+        )

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -1,0 +1,212 @@
+"""Tests for the #200 launch-delegation gate (``llauncher.core.delegation``).
+
+Covers the decision matrix:
+
+* caller-is-agent (stamp set)            → in-process, never probes.
+* front-end + healthy local agent        → delegate (HTTP).
+* front-end + no agent reachable         → in-process fallback.
+* front-end + explicit override (0/1)    → honored verbatim.
+
+plus the ``is_agent_process`` stamp parsing and the ``local_agent_healthy``
+probe (200 → True; non-200 / transport error → False; X-Api-Key + port
+sourced from settings).
+
+The autouse ``_deterministic_delegation`` fixture in ``tests/conftest.py``
+pins ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=0`` and clears the agent stamp for
+the whole suite; every test here overrides those explicitly so the gate
+logic under test is the only thing driving the outcome.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from llauncher.core import delegation
+
+
+# ─────────────────────────── is_agent_process ──────────────────────────────
+
+
+class TestIsAgentProcess:
+    def test_stamp_truthy_is_agent(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
+        assert delegation.is_agent_process() is True
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "yes", "on"])
+    def test_stamp_other_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", value)
+        assert delegation.is_agent_process() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "garbage"])
+    def test_stamp_falsy_or_unrecognized_is_not_agent(self, monkeypatch, value):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", value)
+        assert delegation.is_agent_process() is False
+
+    def test_stamp_unset_is_not_agent(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        assert delegation.is_agent_process() is False
+
+
+# ─────────────────────────── local_agent_healthy ───────────────────────────
+
+
+def _client_mock(response=None, error=None):
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    if error is not None:
+        client.get = MagicMock(side_effect=error)
+    else:
+        client.get = MagicMock(return_value=response)
+    return client
+
+
+class TestLocalAgentHealthy:
+    def test_200_is_healthy(self):
+        resp = MagicMock(status_code=200)
+        with patch("httpx.Client", return_value=_client_mock(response=resp)):
+            assert delegation.local_agent_healthy(token="tok") is True
+
+    def test_non_200_is_unhealthy(self):
+        resp = MagicMock(status_code=503)
+        with patch("httpx.Client", return_value=_client_mock(response=resp)):
+            assert delegation.local_agent_healthy(token="tok") is False
+
+    def test_transport_error_is_unhealthy(self):
+        err = httpx.ConnectError("connection refused")
+        with patch("httpx.Client", return_value=_client_mock(error=err)):
+            assert delegation.local_agent_healthy(token="tok") is False
+
+    def test_probe_sends_api_key_and_uses_settings_port(self, monkeypatch):
+        monkeypatch.setattr("llauncher.core.settings.AGENT_PORT", 9911)
+        resp = MagicMock(status_code=200)
+        client = _client_mock(response=resp)
+        with patch("httpx.Client", return_value=client):
+            # token omitted → resolver consulted; pin it to a known value.
+            monkeypatch.setattr(
+                "llauncher.core.agent_token.resolve_agent_token",
+                lambda **kw: "resolved-token",
+            )
+            assert delegation.local_agent_healthy() is True
+
+        url = client.get.call_args[0][0]
+        headers = client.get.call_args[1]["headers"]
+        assert url == "http://127.0.0.1:9911/health"
+        assert headers == {"X-Api-Key": "resolved-token"}
+
+    def test_no_token_sends_no_header(self, monkeypatch):
+        resp = MagicMock(status_code=200)
+        client = _client_mock(response=resp)
+        with patch("httpx.Client", return_value=client):
+            monkeypatch.setattr(
+                "llauncher.core.agent_token.resolve_agent_token",
+                lambda **kw: None,
+            )
+            assert delegation.local_agent_healthy() is True
+        assert client.get.call_args[1]["headers"] == {}
+
+    def test_resolver_failure_degrades_to_unauthenticated_probe(self, monkeypatch):
+        resp = MagicMock(status_code=200)
+        client = _client_mock(response=resp)
+
+        def boom(**kw):
+            raise RuntimeError("token store on fire")
+
+        with patch("httpx.Client", return_value=client):
+            monkeypatch.setattr(
+                "llauncher.core.agent_token.resolve_agent_token", boom
+            )
+            # Must not raise; probe proceeds with no header.
+            assert delegation.local_agent_healthy() is True
+        assert client.get.call_args[1]["headers"] == {}
+
+
+# ─────────────────────────── should_delegate matrix ────────────────────────
+
+
+class TestShouldDelegate:
+    def test_caller_is_agent_never_delegates_and_never_probes(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
+        # Even with the override set to delegate, the agent stays in-process.
+        monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "1")
+        with patch.object(delegation, "local_agent_healthy") as probe:
+            assert delegation.should_delegate() is False
+            probe.assert_not_called()
+
+    def test_frontend_healthy_agent_delegates(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        monkeypatch.delenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", raising=False)
+        with patch.object(delegation, "local_agent_healthy", return_value=True):
+            assert delegation.should_delegate() is True
+
+    def test_frontend_no_agent_falls_back_in_process(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        monkeypatch.delenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", raising=False)
+        with patch.object(delegation, "local_agent_healthy", return_value=False):
+            assert delegation.should_delegate() is False
+
+    def test_override_force_delegate_skips_probe(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "1")
+        with patch.object(delegation, "local_agent_healthy") as probe:
+            assert delegation.should_delegate() is True
+            probe.assert_not_called()
+
+    def test_override_force_in_process_skips_probe(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "0")
+        with patch.object(delegation, "local_agent_healthy") as probe:
+            assert delegation.should_delegate() is False
+            probe.assert_not_called()
+
+    def test_unrecognized_override_falls_through_to_autodetect(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "maybe")
+        with patch.object(delegation, "local_agent_healthy", return_value=True) as probe:
+            assert delegation.should_delegate() is True
+            probe.assert_called_once()
+
+
+# ─────────────────────── SP-1 layering / token-hoist guard ──────────────────
+
+
+class TestRemoteDoesNotImportAgent:
+    """Issue #171: ``remote`` must read the agent token without importing
+    ``agent.*``. Run in a fresh interpreter so other tests' imports can't
+    mask a regression."""
+
+    def test_importing_remote_does_not_import_agent_package(self):
+        code = (
+            "import sys; "
+            "import llauncher.remote.registry, llauncher.remote.node, "
+            "llauncher.core.delegation, llauncher.core.agent_token; "
+            "leaked = sorted(m for m in sys.modules "
+            "if m == 'llauncher.agent' or m.startswith('llauncher.agent.')); "
+            "print(leaked); "
+            "sys.exit(1 if leaked else 0)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 0, (
+            "remote/* imported agent.* (layering violation #171); "
+            f"leaked modules: {result.stdout.strip()}\n{result.stderr}"
+        )
+
+    def test_core_agent_token_resolves_without_agent_import(self):
+        """The hoisted resolver is importable + callable from core directly."""
+        from llauncher.core.agent_token import resolve_agent_token
+
+        # allow_generate=False + explicit empty env + missing path → None,
+        # exercising the resolver end-to-end with no filesystem writes.
+        token = resolve_agent_token(
+            env_value="",
+            token_path=__import__("pathlib").Path("/nonexistent/x.token"),
+            allow_generate=False,
+        )
+        assert token is None

--- a/tests/unit/test_model_card_delegation.py
+++ b/tests/unit/test_model_card_delegation.py
@@ -1,0 +1,149 @@
+"""UI delegation-path coverage for the model card (#200 review item 3).
+
+``_handle_start`` (plain local launch) and ``_render_eviction_dialog``
+(evict-and-start) both branch on ``delegation.should_delegate()``. #200's
+acceptance criteria include "UI local-node launch → POST /start", so each
+branch needs a unit test. These mirror ``TestDelegationRouting`` in
+``tests/unit/mcp/test_servers_tools.py``: mock the local-agent-node factory
+and assert the delegate branch POSTs via the node while the in-process
+branch calls ``ops.*``.
+
+Streamlit is mocked at the module seam (``model_card.st``); ``st.button``
+returns True so the eviction "Confirm" path fires, and ``st.rerun`` is a
+no-op (unlike real Streamlit it does not halt execution).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from llauncher.ui.tabs import model_card
+from llauncher.operations.swap import SwapResult
+
+
+def _mock_st():
+    """A Streamlit stand-in with the methods the card paths touch."""
+    st = MagicMock()
+    st.columns.side_effect = lambda n: [MagicMock(), MagicMock()]
+    st.button.return_value = True  # fire button-gated branches
+    return st
+
+
+@contextmanager
+def _delegate(node, *, enabled=True):
+    """Patch the gate decision and the local-agent-node factory."""
+    with patch.object(
+        model_card.delegation, "should_delegate", return_value=enabled
+    ), patch.object(
+        model_card.delegation, "local_agent_node", return_value=node
+    ) as factory:
+        yield factory
+
+
+# ───────────────────────── _handle_start (plain launch) ─────────────────────
+
+
+class TestHandleStartDelegation:
+    def _state(self):
+        state = MagicMock()
+        state.models = {"m": MagicMock()}
+        state.can_start.return_value = (True, "")
+        return state
+
+    def test_local_start_delegates_over_http(self):
+        node = MagicMock()
+        node.start_server.return_value = {"success": True, "message": "ok"}
+        empty_temp = MagicMock()
+        empty_temp.running = {}  # target port not occupied → plain start path
+
+        with patch.object(model_card, "st", _mock_st()), patch.object(
+            model_card, "LauncherState", return_value=empty_temp
+        ), patch.object(model_card.ops, "start") as mock_ops_start, _delegate(node):
+            model_card._handle_start(
+                self._state(), None, "local", "m", target_port=8080
+            )
+
+        node.start_server.assert_called_once_with("m", 8080)
+        mock_ops_start.assert_not_called()
+
+    def test_local_start_in_process_when_no_agent(self):
+        empty_temp = MagicMock()
+        empty_temp.running = {}
+        result = MagicMock(success=True, message="started")
+
+        with patch.object(model_card, "st", _mock_st()), patch.object(
+            model_card, "LauncherState", return_value=empty_temp
+        ), patch.object(
+            model_card.ops, "start", return_value=result
+        ) as mock_ops_start, _delegate(MagicMock(), enabled=False) as factory:
+            model_card._handle_start(
+                self._state(), None, "local", "m", target_port=8080
+            )
+
+        mock_ops_start.assert_called_once_with("m", 8080, caller="ui")
+        factory.assert_not_called()
+
+    def test_local_start_none_result_is_safe(self):
+        """A ``None`` delegated result must not raise (dict | None seam)."""
+        node = MagicMock()
+        node.start_server.return_value = None
+        empty_temp = MagicMock()
+        empty_temp.running = {}
+
+        with patch.object(model_card, "st", _mock_st()) as st, patch.object(
+            model_card, "LauncherState", return_value=empty_temp
+        ), patch.object(model_card.ops, "start"), _delegate(node):
+            model_card._handle_start(
+                self._state(), None, "local", "m", target_port=8080
+            )
+
+        # Surfaced as an error toast, not an AttributeError.
+        st.error.assert_called_once()
+
+
+# ──────────────────────── _render_eviction_dialog (swap) ────────────────────
+
+
+class TestEvictionDialogDelegation:
+    def _state(self):
+        state = MagicMock()
+        state.running = {}  # existing_model lookup → "unknown"
+        return state
+
+    def test_eviction_delegates_over_http(self):
+        node = MagicMock()
+        node.swap_server.return_value = {"success": True}
+
+        with patch.object(model_card, "st", _mock_st()), patch.object(
+            model_card.ops, "swap"
+        ) as mock_ops_swap, _delegate(node):
+            model_card._render_eviction_dialog(self._state(), "local", 8080, "m", "")
+
+        node.swap_server.assert_called_once_with("m", 8080)
+        mock_ops_swap.assert_not_called()
+
+    def test_eviction_in_process_when_no_agent(self):
+        envelope = SwapResult(
+            success=True, action="swapped", port_state="serving",
+            port=8080, model="m", previous_model="old",
+        )
+        with patch.object(model_card, "st", _mock_st()), patch.object(
+            model_card.ops, "swap", return_value=envelope
+        ) as mock_ops_swap, _delegate(MagicMock(), enabled=False) as factory:
+            model_card._render_eviction_dialog(self._state(), "local", 8080, "m", "")
+
+        mock_ops_swap.assert_called_once_with("m", 8080, caller="ui")
+        factory.assert_not_called()
+
+    def test_eviction_none_result_is_safe(self):
+        node = MagicMock()
+        node.swap_server.return_value = None
+
+        with patch.object(model_card, "st", _mock_st()) as st, patch.object(
+            model_card.ops, "swap"
+        ), _delegate(node):
+            model_card._render_eviction_dialog(self._state(), "local", 8080, "m", "")
+
+        # Falls through to the failure toast without raising.
+        st.toast.assert_called()

--- a/tests/unit/test_model_card_delegation.py
+++ b/tests/unit/test_model_card_delegation.py
@@ -36,7 +36,7 @@ def _delegate(node, *, enabled=True):
     with patch.object(
         model_card.delegation, "should_delegate", return_value=enabled
     ), patch.object(
-        model_card.delegation, "local_agent_node", return_value=node
+        model_card, "local_agent_node", return_value=node
     ) as factory:
         yield factory
 

--- a/tests/unit/test_registry_extended.py
+++ b/tests/unit/test_registry_extended.py
@@ -447,7 +447,7 @@ class TestLocalNodeTokenResolution:
         token_path = tmp_path / "agent.token"
         token_path.write_text("test-token-abc123")
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_token_path", lambda: token_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -470,7 +470,7 @@ class TestLocalNodeTokenResolution:
         # No token file, no env var → resolver returns None.
         token_path = tmp_path / "nonexistent.token"
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_token_path", lambda: token_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -502,7 +502,7 @@ class TestLocalNodeTokenResolution:
         token_path = tmp_path / "agent.token"
         token_path.write_text("local-token-only")
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_token_path", lambda: token_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -525,7 +525,7 @@ class TestLocalNodeTokenResolution:
         def boom(**kwargs):
             raise RuntimeError("filesystem on fire")
 
-        monkeypatch.setattr("llauncher.agent.auth.resolve_agent_token", boom)
+        monkeypatch.setattr("llauncher.core.agent_token.resolve_agent_token", boom)
 
         registry = NodeRegistry()
         # No exception bubbles up; resolver returns None defensively.
@@ -555,7 +555,7 @@ class TestRemoteNodeTokenPersistence:
         # Prevents the resolver from picking up the real user's token.
         agent_token_path = tmp_path / "agent.token-absent"
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: agent_token_path
+            "llauncher.core.agent_token.default_token_path", lambda: agent_token_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
         return nodes_file, tokens_file
@@ -633,7 +633,7 @@ class TestRemoteNodeTokenPersistence:
         agent_token = tmp_path / "agent.token"
         agent_token.write_text("local-secret")
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: agent_token
+            "llauncher.core.agent_token.default_token_path", lambda: agent_token
         )
 
         reg = NodeRegistry()
@@ -683,7 +683,7 @@ class TestRemoteNodeTokenPersistence:
         agent_token = tmp_path / "agent.token"
         agent_token.write_text("would-be-credential-confusion")
         monkeypatch.setattr(
-            "llauncher.agent.auth.default_token_path", lambda: agent_token
+            "llauncher.core.agent_token.default_token_path", lambda: agent_token
         )
         assert not tokens_file.exists()
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -496,7 +496,10 @@ class TestRemoteNodeReadAudit:
             message="started",
         )
 
-        # ``name == "local"`` triggers the self-loop short-circuit.
+        # Post-#200: the self-loop short-circuit fires only when the caller
+        # IS the agent process (env stamp), not merely because the target
+        # is local. Stamp this process as the agent to exercise it.
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
         node = RemoteNode("local", "127.0.0.1", port=8765)
 
         with patch("httpx.Client") as mock_client_class:
@@ -530,6 +533,7 @@ class TestRemoteNodeReadAudit:
             caller="t",
         )
 
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
         node = RemoteNode("local", "127.0.0.1", port=8765)
         entries = node.read_audit(action_filter="stopped")
         assert len(entries) == 1
@@ -1005,48 +1009,73 @@ class TestRemoteAggregator:
 
 
 # ---------------------------------------------------------------------------
-# Issue #62 — RemoteNode self-loop short-circuit per ADR-009
+# Issue #62 — RemoteNode self-loop short-circuit per ADR-009, NARROWED by #200
 #
-# When a RemoteNode resolves to the local agent, verb methods should
-# bypass HTTP entirely and call the in-process operations layer. Auth
-# is enforced only at the network boundary; the in-process path
+# Pre-#200 the short-circuit fired whenever the target host/port looked
+# local (or the node was named "local"). That captured operator front-ends
+# pointing at the local agent, forcing their launches in-process — the #200
+# defect. The narrowed rule: the short-circuit fires *only* when the caller
+# IS the agent process (the ``LLAUNCHER_IS_AGENT_PROCESS`` env stamp), so
+# the agent keeps its loopback-HTTP-avoiding in-process path while every
+# front-end routes over HTTP (where the delegation gate decides).
+#
+# Auth is enforced only at the network boundary; the in-process path
 # intentionally skips it.
 # ---------------------------------------------------------------------------
 
 
 class TestSelfLoopDetection:
-    """``_is_self_loop`` covers two independent signals."""
+    """``_is_self_loop`` = caller-is-agent AND target-is-local (#200)."""
 
-    def test_name_local_is_self_loop_regardless_of_host(self):
+    # ── caller IS the agent ────────────────────────────────────────────
+    def test_agent_calling_name_local_is_self_loop(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
         node = RemoteNode("local", "192.168.1.100", port=9000)
         assert node._is_self_loop() is True
 
-    def test_localhost_host_and_default_port_is_self_loop(self):
-        node = RemoteNode("anything", "localhost", port=8765)
-        assert node._is_self_loop() is True
-
-    def test_127_0_0_1_with_default_port_is_self_loop(self):
+    def test_agent_calling_localhost_default_port_is_self_loop(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
         node = RemoteNode("anything", "127.0.0.1", port=8765)
         assert node._is_self_loop() is True
 
-    def test_localhost_with_different_port_is_NOT_self_loop(self):
-        # Same host, different port — different process. Not local.
-        node = RemoteNode("anything", "localhost", port=9999)
-        assert node._is_self_loop() is False
-
-    def test_remote_host_with_default_port_is_NOT_self_loop(self):
+    def test_agent_calling_remote_peer_is_NOT_self_loop(self, monkeypatch):
+        # Multi-node isolation: even as the agent, a genuinely remote peer
+        # must go over HTTP — never run the peer's launch in-process.
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
         node = RemoteNode("peer", "192.168.1.100", port=8765)
         assert node._is_self_loop() is False
 
-    def test_hostname_match_with_default_port_is_self_loop(self, monkeypatch):
-        import socket
-        monkeypatch.setattr(socket, "gethostname", lambda: "my-workstation")
-        node = RemoteNode("renamed", "my-workstation", port=8765)
-        assert node._is_self_loop() is True
+    def test_agent_calling_localhost_other_port_is_NOT_self_loop(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
+        node = RemoteNode("anything", "localhost", port=9999)
+        assert node._is_self_loop() is False
+
+    # ── caller is a FRONT-END (no agent stamp) ──────────────────────────
+    def test_frontend_local_target_is_NOT_self_loop(self, monkeypatch):
+        # The #200 narrowing: a front-end pointing at the local agent must
+        # NOT short-circuit — it delegates over HTTP via the gate instead.
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        node = RemoteNode("local", "127.0.0.1", port=8765)
+        assert node._is_self_loop() is False
+
+    def test_frontend_name_local_is_NOT_self_loop(self, monkeypatch):
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        node = RemoteNode("local", "192.168.1.100", port=9000)
+        assert node._is_self_loop() is False
+
+    def test_falsy_stamp_is_NOT_self_loop(self, monkeypatch):
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "0")
+        node = RemoteNode("local", "127.0.0.1", port=8765)
+        assert node._is_self_loop() is False
 
 
 class TestSelfLoopShortCircuit:
-    """Verb methods bypass HTTP when self-loop is detected."""
+    """Verb methods bypass HTTP when the caller IS the agent (#200)."""
+
+    @pytest.fixture(autouse=True)
+    def _stamp_agent(self, monkeypatch):
+        """Every test in this class runs as the agent process."""
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
 
     def test_ping_self_loop_skips_http_and_returns_true(self):
         node = RemoteNode("local", "localhost", port=8765)


### PR DESCRIPTION
## Summary

- **SP-1 — token resolution hoist**: `core/agent_token.py` now owns token resolution, eliminating the `remote → agent` import cycle that issue #171 tracked as a layering violation.
- **SP-2 — `LLAUNCHER_AGENT_PORT`**: new env var wires the agent's port into config cleanly, no more implicit magic constants.
- **Delegation**: MCP and UI-local operator front-ends no longer spawn llama-server directly; they delegate local launches to the system agent, making the agent the sole llama-server spawner. The `_is_self_loop()` guard is narrowed to `is_agent_process() AND _targets_local_node()` to avoid false positives.
- **`local_agent_node()` factory**: lives in `remote/` (the right layer), consistent with how remote nodes are resolved elsewhere.

## Test results

Full suite: **1143 passed, 94.73% coverage**. The one failing test (`test_orphan_regression`) is a pre-existing asyncio-loop flake unrelated to this change — it has been flaking on `main` before this branch was cut.

## Closes

Closes #200
Closes #171