### PR TITLE
fix(delegation): extend launch-delegation gate to CLI server start/stop (#203)

### DIFF
--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -89,6 +89,27 @@ def _json_output(data) -> None:
     console.print(json.dumps(data, indent=2, default=str))
 
 
+def _delegated_outcome(res: dict | None, verb: str, port: int) -> tuple[bool, str]:
+    """Reduce a delegated ``RemoteNode`` verb result to ``(success, message)``.
+
+    Mirrors the MCP server's ``_delegated_or_error`` dict|None guard
+    (``mcp_server/tools/servers.py``) but for the CLI's render contract: a
+    delegated launch returns the agent's ADR-010 envelope over HTTP (a
+    ``dict`` with ``success``/``message``); a transport or HTTP failure
+    returns ``{"success": False, "error": ...}``; and a 200-with-JSON-null
+    body surfaces as Python ``None``. Collapse all three to the ``(bool,
+    str)`` pair the CLI renders, never raising on the ``None`` seam.
+    """
+    if res is None:
+        return (
+            False,
+            f"Local agent returned an empty response for {verb} on port {port}",
+        )
+    success = bool(res.get("success"))
+    message = res.get("message") or res.get("error") or f"{verb} on port {port}"
+    return success, message
+
+
 # ---------------------------------------------------------------------------
 # model subcommands
 # ---------------------------------------------------------------------------
@@ -160,12 +181,26 @@ def start_server(
     for human invocations — pick a port deliberately.
     """
     from llauncher import operations
+    from llauncher.core import delegation
+    from llauncher.remote.node import local_agent_node
 
-    result = operations.start(name, port, caller=caller)
-    if not result.success:
-        console.print(f"[red]✗ {result.message}[/red]")
+    # Delegation gate (#200/#203): with a healthy local agent present (or an
+    # explicit ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT`` override) POST the launch
+    # to the agent over HTTP so the ``llama-server`` is a child of the
+    # systemd-managed agent — the sole spawner under system-mode (#194). With
+    # no agent reachable, fall back to the in-process op (dev/standalone).
+    if delegation.should_delegate():
+        success, message = _delegated_outcome(
+            local_agent_node().start_server(name, port), "start", port
+        )
+    else:
+        result = operations.start(name, port, caller=caller)
+        success, message = result.success, result.message
+
+    if not success:
+        console.print(f"[red]✗ {message}[/red]")
         raise typer.Exit(code=1)
-    console.print(_color(result.message, "running"))
+    console.print(_color(message, "running"))
 
 
 @server_app.command("stop")
@@ -175,12 +210,24 @@ def stop_server(
 ) -> None:
     """Stop a running server on the specified port."""
     from llauncher import operations
+    from llauncher.core import delegation
+    from llauncher.remote.node import local_agent_node
 
-    result = operations.stop(port, caller=caller)
-    if not result.success:
-        console.print(f"[red]✗ {result.message}[/red]")
+    # Delegation gate (#200/#203): mirror ``start`` — delegate to the local
+    # agent over HTTP when one is reachable (sole-spawner intent, #194),
+    # else stop in-process (dev/standalone).
+    if delegation.should_delegate():
+        success, message = _delegated_outcome(
+            local_agent_node().stop_server(port), "stop", port
+        )
+    else:
+        result = operations.stop(port, caller=caller)
+        success, message = result.success, result.message
+
+    if not success:
+        console.print(f"[red]✗ {message}[/red]")
         raise typer.Exit(code=1)
-    console.print(_color(result.message, "stopped"))
+    console.print(_color(message, "stopped"))
 
 
 @server_app.command("cancel")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,12 +6,14 @@ Covers all four subcommand groups: model, server, node, config.
 
 import json
 import pytest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import typer
 from typer.testing import CliRunner
 
+from llauncher import cli
 from llauncher.cli import app, console
 from llauncher.core.config import ConfigStore
 from llauncher.models.config import ModelConfig
@@ -282,6 +284,164 @@ def test_stop_nonexistent_port(mock_config_store):
         result = runner.invoke(app, ["server", "stop", "9000"])
         assert result.exit_code == 0
         mock_stop.assert_called_once_with(9000, caller="cli")
+
+
+# ---------------------------------------------------------------------------
+# server delegation gate (#203, mirrors MCP/UI #200 delegation tests)
+# ---------------------------------------------------------------------------
+#
+# The autouse ``_deterministic_delegation`` fixture (tests/conftest.py) pins
+# ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=0`` and clears the agent stamp, so the
+# CLI's gate takes the in-process path unless a test overrides it. These tests
+# mirror ``TestDelegationRouting`` (mcp) / ``test_model_card_delegation`` (ui):
+# the gate decision is patched (or env-forced), the local-agent-node factory is
+# mocked, and we assert delegate → HTTP via the node, in-process → ``ops.*``.
+
+
+@contextmanager
+def _cli_delegate(node, *, enabled=True):
+    """Patch the gate decision and the local-agent-node factory the CLI uses.
+
+    ``cli.start_server`` / ``cli.stop_server`` import ``delegation`` and
+    ``local_agent_node`` at call time, so patch them at their definition
+    sites (``llauncher.core.delegation.should_delegate`` and
+    ``llauncher.remote.node.local_agent_node``).
+    """
+    with patch(
+        "llauncher.core.delegation.should_delegate", return_value=enabled
+    ), patch(
+        "llauncher.remote.node.local_agent_node", return_value=node
+    ) as factory:
+        yield factory
+
+
+class TestCliStartDelegation:
+    def test_start_delegates_over_http_when_agent_present(self, mock_config_store):
+        node = MagicMock()
+        node.start_server.return_value = {
+            "success": True,
+            "action": "started",
+            "port": 8080,
+            "message": "Started m on port 8080",
+        }
+        with patch("llauncher.operations.start") as mock_ops_start, _cli_delegate(node):
+            result = runner.invoke(app, ["server", "start", "m", "--port", "8080"])
+
+        assert result.exit_code == 0
+        node.start_server.assert_called_once_with("m", 8080)
+        mock_ops_start.assert_not_called()
+
+    def test_start_in_process_when_no_agent(self, mock_config_store):
+        from llauncher.operations import StartResult
+
+        result_obj = StartResult(
+            success=True, action="started", port=8080, model="m",
+            pid=7, message="Started m on port 8080",
+        )
+        with patch(
+            "llauncher.operations.start", return_value=result_obj
+        ) as mock_ops_start, _cli_delegate(MagicMock(), enabled=False) as factory:
+            result = runner.invoke(app, ["server", "start", "m", "--port", "8080"])
+
+        assert result.exit_code == 0
+        mock_ops_start.assert_called_once_with("m", 8080, caller="cli")
+        factory.assert_not_called()
+
+    def test_start_env_override_forces_delegation(self, mock_config_store, monkeypatch):
+        """Real gate: ``LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=1`` → HTTP, no probe."""
+        monkeypatch.setenv("LLAUNCHER_DELEGATE_TO_LOCAL_AGENT", "1")
+        monkeypatch.delenv("LLAUNCHER_IS_AGENT_PROCESS", raising=False)
+        node = MagicMock()
+        node.start_server.return_value = {"success": True, "message": "ok"}
+        with patch("llauncher.operations.start") as mock_ops_start, patch(
+            "llauncher.remote.node.local_agent_node", return_value=node
+        ):
+            result = runner.invoke(app, ["server", "start", "m", "--port", "8080"])
+
+        assert result.exit_code == 0
+        node.start_server.assert_called_once_with("m", 8080)
+        mock_ops_start.assert_not_called()
+
+    def test_start_delegated_failure_exits_nonzero(self, mock_config_store):
+        node = MagicMock()
+        node.start_server.return_value = {
+            "success": False, "error": "agent refused", "port": 8080,
+        }
+        with patch("llauncher.operations.start"), _cli_delegate(node):
+            result = runner.invoke(app, ["server", "start", "m", "--port", "8080"])
+
+        assert result.exit_code == 1
+        assert "agent refused" in result.stdout
+
+    def test_start_delegated_none_result_is_safe(self, mock_config_store):
+        """A ``None`` delegated body must surface as an error, not raise."""
+        node = MagicMock()
+        node.start_server.return_value = None
+        with patch("llauncher.operations.start"), _cli_delegate(node):
+            result = runner.invoke(app, ["server", "start", "m", "--port", "8080"])
+
+        assert result.exit_code == 1
+        assert "empty response" in result.stdout.lower()
+
+
+class TestCliStopDelegation:
+    def test_stop_delegates_over_http_when_agent_present(self, mock_config_store):
+        node = MagicMock()
+        node.stop_server.return_value = {
+            "success": True, "action": "stopped", "port": 8080,
+            "message": "Stopped server on port 8080",
+        }
+        with patch("llauncher.operations.stop") as mock_ops_stop, _cli_delegate(node):
+            result = runner.invoke(app, ["server", "stop", "8080"])
+
+        assert result.exit_code == 0
+        node.stop_server.assert_called_once_with(8080)
+        mock_ops_stop.assert_not_called()
+
+    def test_stop_in_process_when_no_agent(self, mock_config_store):
+        from llauncher.operations import StopResult
+
+        result_obj = StopResult(
+            success=True, action="stopped", port=8080,
+            message="Stopped server on port 8080",
+        )
+        with patch(
+            "llauncher.operations.stop", return_value=result_obj
+        ) as mock_ops_stop, _cli_delegate(MagicMock(), enabled=False) as factory:
+            result = runner.invoke(app, ["server", "stop", "8080"])
+
+        assert result.exit_code == 0
+        mock_ops_stop.assert_called_once_with(8080, caller="cli")
+        factory.assert_not_called()
+
+    def test_stop_delegated_failure_exits_nonzero(self, mock_config_store):
+        node = MagicMock()
+        node.stop_server.return_value = {
+            "success": False, "error": "No server running on port 8080",
+        }
+        with patch("llauncher.operations.stop"), _cli_delegate(node):
+            result = runner.invoke(app, ["server", "stop", "8080"])
+
+        assert result.exit_code == 1
+        assert "no server running" in result.stdout.lower()
+
+    def test_stop_delegated_message_fallback(self, mock_config_store):
+        """Envelope lacking message/error/success → synthesized 'stop on port'."""
+        node = MagicMock()
+        node.stop_server.return_value = {"port": 8080}
+        with patch("llauncher.operations.stop"), _cli_delegate(node):
+            result = runner.invoke(app, ["server", "stop", "8080"])
+
+        # success defaults False (no 'success' key) → exit 1, synthesized msg.
+        assert result.exit_code == 1
+        assert "stop on port 8080" in result.stdout
+
+
+def test_delegated_outcome_none_seam():
+    """Unit-level guard on the dict|None reducer (mirrors MCP ``_delegated_or_error``)."""
+    ok, msg = cli._delegated_outcome(None, "start", 8080)
+    assert ok is False
+    assert "empty response" in msg.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Extends the #200 launch-delegation gate to the **CLI** `server start` / `server stop`
commands (`llauncher/cli.py`), mirroring the existing MCP-server exemplar
(`mcp_server/tools/servers.py`). With a healthy local agent reachable (or an explicit
`LLAUNCHER_DELEGATE_TO_LOCAL_AGENT` override) the verb is POSTed to the agent over HTTP
so the `llama-server` is a child of the systemd-managed agent — the sole spawner under
system-mode (#194). With no agent reachable, the CLI falls back to the in-process
`operations.*` op (dev/standalone), unchanged.

- New `_delegated_outcome(res, verb, port)` reducer collapses the delegated
  `RemoteNode` result (`dict` envelope | transport-error dict | 200-with-null `None`)
  to the `(success, message)` pair the CLI renders — mirrors the MCP server's
  `_delegated_or_error` `dict|None` guard, never raising on the `None` seam.

## Reused gate (no new decision logic)

The decision point is the existing `llauncher.core.delegation.should_delegate()` (from
#200) — agent-process self-call short-circuit, env override, then `GET /health`
auto-detect. The CLI imports it and the `remote.node.local_agent_node()` factory at call
time; no new `remote → agent` edge is introduced. No `swap` change: the CLI exposes no
`swap` subcommand (only start/stop/cancel/status); cancel/status are not launch verbs, so
start + stop is the complete gateable set at the CLI layer.

## Test coverage

10 new tests in `tests/unit/test_cli.py` (`TestCliStartDelegation`,
`TestCliStopDelegation`, plus a `_delegated_outcome` unit guard): delegate→HTTP and
in-process→`ops.*` for both verbs, env-forced delegation (`LLAUNCHER_DELEGATE_TO_LOCAL_AGENT=1`,
real gate, no probe), delegated-failure non-zero exit, `None`-body safety, and the
message-fallback path. All 10 pass. `delegation.py` 100%; every changed line in `cli.py`
covered. Non-UI suite coverage **94.72%** (floor 93%).

## Gate status

`1152 passed, 13 skipped, 1 failed`. The single failure —
`tests/regression/test_orphan_regression.py::test_cross_surface_orphan_dicts_agree` — is
**pre-existing on `main`** (`main` full suite: `1142 passed, 1 failed`, same test) and
**unrelated to this change**. Root cause: that test calls
`asyncio.get_event_loop().run_until_complete(...)`, which raises
`RuntimeError: There is no current event loop` due to event-loop pollution from a prior
test in the file under `asyncio_mode=auto` (it passes standalone, fails in-file/in-suite).
Surfaced as a **contract-mismatch / pre-existing-red-baseline** signal rather than absorbed
into this PR's scope — fixing the regression-test loop handling is out of scope for #203.

Resumed after session-limit cutoff of the prior `auto:fix` agent (WIP committed at 80d90f3,
gates not yet run). Verification + push + PR completed here.

Closes #203. Refs #194, #200.
