### PR TITLE
fix(#201): self-provision run/ dir, reconcile stale lockfile, serve logs for dead port

### DIFF
--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -150,6 +150,14 @@ def get_status() -> dict:
     """
     from llauncher.core.gpu import GPUHealthCollector
 
+    # Reconcile stale lockfiles before reporting (issue #201 Part 2a). A
+    # server that spawned then died immediately leaves total_running correct
+    # (it's gone from the process table) but its {port}.lock behind, which
+    # would block a future start on that port. The sweep prunes dead claims
+    # and emits one OBSERVED_STOPPED audit entry each; it is idempotent and
+    # cheap, so running it on every status poll is safe.
+    ops.reconcile_stale_lockfiles(caller="status")
+
     state = get_state()
     state.refresh_running_servers()
 
@@ -443,24 +451,47 @@ def delete_model(model_name: str) -> dict:
 
 @router.get("/logs/{port}")
 def get_logs(port: int, lines: Annotated[int, None] = None) -> dict:
-    """Get recent log lines for a server."""
-    from llauncher.core.process import stream_logs
+    """Get recent log lines for a server on ``port``.
+
+    When a server is live, tail its log by pid. When no server is live
+    (issue #201 Part 2b), fall back to the most-recent ``*-{port}.log`` on
+    disk so the operator can still retrieve the death cause of a server that
+    spawned then exited immediately — the previous behavior 404'd in that
+    case, hiding exactly the log that explains the failure. Only when no log
+    file exists for the port at all do we 404.
+    """
+    from llauncher.core import lockfile as lf
+    from llauncher.core.process import read_logs_for_port, stream_logs
 
     state = get_state()
     state.refresh()
 
-    if port not in state.running:
+    num_lines = lines or 100
+
+    if port in state.running:
+        server = state.running[port]
+        log_lines = stream_logs(pid=server.pid, lines=num_lines)
+        return {
+            "port": port,
+            "config_name": server.config_name,
+            "lines": log_lines,
+            "total_lines": len(log_lines),
+        }
+
+    # No live server — serve the most recent log file for the port.
+    log_lines = read_logs_for_port(port, num_lines)
+    if log_lines is None:
         raise HTTPException(
-            status_code=404, detail=f"No server running on port {port}"
+            status_code=404,
+            detail=f"No server running on port {port} and no log file found",
         )
 
-    server = state.running[port]
-    num_lines = lines or 100
-    log_lines = stream_logs(pid=server.pid, lines=num_lines)
-
+    # Best-effort model name from a lingering lockfile (the status-path
+    # reconcile may not have run yet); None when the claim is already gone.
+    claim = lf.read_lockfile(port)
     return {
         "port": port,
-        "config_name": server.config_name,
+        "config_name": claim.model if claim is not None else None,
         "lines": log_lines,
         "total_lines": len(log_lines),
     }

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -162,7 +162,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     is at worst a re-termination of an already-dying pid, which
     ``core.process.stop_server_by_pid`` absorbs.
     """
-    # Startup — nothing to do.
+    # Startup — self-provision the run/ directory (issue #201 Part 1).
+    # Lockfile and marker writes target {LAUNCHER_RUN_DIR}/{port}.lock|.swap
+    # with O_EXCL. After a fresh system-mode install the migrated state dir
+    # carries logs/ and audit.jsonl but intentionally not run/, so the first
+    # launch could fail before llama-server even spawns. Create it eagerly
+    # here, mirroring the LOG_DIR.mkdir in core.process.start_server. A
+    # PermissionError on a read-only state dir is a real misconfiguration and
+    # is intentionally allowed to surface.
+    settings.LAUNCHER_RUN_DIR.mkdir(parents=True, exist_ok=True)
     yield
 
     # Shutdown — reap managed children. We catch OSError specifically because

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -587,6 +587,28 @@ def stream_logs(pid: int | None = None, model_name: str | None = None, lines: in
     return []
 
 
+def read_logs_for_port(port: int, lines: int = 100) -> list[str] | None:
+    """Return the tail of the most-recent log file for ``port``.
+
+    Resolves the freshest ``*-{port}.log`` in :data:`LOG_DIR` (mirroring
+    the port-keyed glob in :func:`stream_logs`) and tails it, **without
+    requiring a live process**. This is the read path for issue #201
+    Part 2(b): a server that spawned then exited within ~1s leaves its
+    death cause in ``logs/{stem}-{port}.log``, but the live-process lookup
+    in :func:`stream_logs` (``pid=...``) can no longer reach it. The agent's
+    ``GET /logs/{port}`` falls back here so the operator can still retrieve
+    that log after the process is gone.
+
+    Returns ``None`` when no log file exists for the port (the caller maps
+    that to 404), otherwise the tailed lines — possibly an empty list when
+    the newest file is empty, which is distinct from "no file at all."
+    """
+    match = _newest_log(LOG_DIR.glob(f"*-{port}.log"))
+    if match is None:
+        return None
+    return _tail_file(match, lines)
+
+
 def _tail_file(path: Path, lines: int) -> list[str]:
     """Read the last ``lines`` lines from ``path``.
 

--- a/llauncher/operations/__init__.py
+++ b/llauncher/operations/__init__.py
@@ -44,6 +44,7 @@ from .preflight import (
     default_vram_check,
     estimate_vram_mb,
 )
+from .reconcile import reconcile_stale_lockfiles
 from .start import StartResult, start
 from .stop import (
     StopResult,
@@ -78,6 +79,8 @@ __all__ = [
     "OrphanInfo",
     "list_orphans",
     "record_observed_orphan",
+    # Stale-lockfile reconcile sweep (issue #201)
+    "reconcile_stale_lockfiles",
     # Swap-related constants and types
     "PreflightCheck",
     "STARTUP_LOG_TAIL_MAX",

--- a/llauncher/operations/reconcile.py
+++ b/llauncher/operations/reconcile.py
@@ -1,0 +1,60 @@
+"""``reconcile`` sweep — prune stale lockfiles for dead processes (issue #201).
+
+The ``/status`` read path reports ``total_running`` from the live process
+table, so a server that spawned then exited immediately is correctly absent
+from the roster — but its ``{port}.lock`` is left behind, blocking a future
+``start`` on that port (issue #201 Part 2a). The per-port ``start``/``stop``
+verbs already reconcile a single port's lockfile on their way in
+(:mod:`llauncher.operations.start`, :mod:`llauncher.operations.stop`); this
+module hoists the same reconcile into a registry-wide sweep the agent can
+run on every ``/status`` so a dead port is cleaned up without waiting for the
+next command to touch it.
+"""
+
+from __future__ import annotations
+
+from llauncher.core import audit_log as al
+from llauncher.core import lockfile as lf
+from llauncher.core.audit_log import AuditAction, AuditResult
+from llauncher.core.lockfile import Lockfile
+
+
+def reconcile_stale_lockfiles(*, caller: str = "reconcile") -> list[Lockfile]:
+    """Remove every lockfile whose claimed pid is dead; return the pruned ones.
+
+    For each parseable lockfile in the run directory, reconcile against the
+    live process table. A lockfile whose pid is still alive is left untouched.
+    A lockfile whose pid is dead is the stale claim of a process that has
+    exited (cleanly or by immediate spawn death): emit one
+    ``OBSERVED_STOPPED`` audit entry and remove the file — mirroring the
+    single-port reconcile in :func:`llauncher.operations.start.start` and
+    :func:`llauncher.operations.stop.stop`.
+
+    Idempotent: a pruned lockfile is gone on the next sweep, so the audit
+    entry is emitted exactly once per dead claim. Safe to call on every
+    ``/status``.
+
+    Args:
+        caller: Audit caller field. Defaults to ``"reconcile"``; the agent's
+            status path passes ``"status"`` so the entry is attributable.
+
+    Returns:
+        The list of stale lockfiles that were removed (empty when none).
+    """
+    pruned: list[Lockfile] = []
+    for entry in lf.list_lockfiles():
+        recon = lf.reconcile_lockfile(entry)
+        if recon.pid_alive:
+            continue
+        al.record(
+            AuditAction.OBSERVED_STOPPED,
+            AuditResult.SUCCESS,
+            caller=caller,
+            port=entry.port,
+            model=entry.model,
+            pid=entry.pid,
+            message="reconciliation: stale lockfile removed",
+        )
+        lf.remove_lockfile(entry.port)
+        pruned.append(entry)
+    return pruned

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -354,10 +354,90 @@ class TestStopServerEndpoint:
 class TestLogsEndpoint:
     """Tests for the /logs/{port} endpoint."""
 
-    def test_logs_nonexistent_port_returns_404(self, client):
-        """Test that logs for nonexistent port returns 404."""
-        response = client.get("/logs/99999")
+    def test_logs_nonexistent_port_returns_404(self, client, tmp_path, monkeypatch):
+        """No live server AND no log file on disk → 404 (issue #201 Part 2b)."""
+        monkeypatch.setattr(
+            "llauncher.core.process.LOG_DIR", (tmp_path / "logs").resolve()
+        )
+        (tmp_path / "logs").mkdir()
+        response = client.get("/logs/49999")
         assert response.status_code == 404
+
+    def test_logs_dead_port_serves_most_recent_log(
+        self, client, tmp_path, monkeypatch
+    ):
+        """A server that spawned then exited leaves no live pid but its log
+        on disk; /logs/{port} must serve it instead of 404-ing (#201 2b)."""
+        log_dir = (tmp_path / "logs").resolve()
+        log_dir.mkdir()
+        monkeypatch.setattr("llauncher.core.process.LOG_DIR", log_dir)
+        # Point the lockfile run dir at an empty tmp so no stale claim leaks
+        # the config name in; we assert the None fallback explicitly.
+        monkeypatch.setattr(
+            "llauncher.core.lockfile.LAUNCHER_RUN_DIR", tmp_path / "run"
+        )
+        # Port 49998 is not a live llama-server; write its death log.
+        (log_dir / "BrokenModel-deadbeef-49998.log").write_text(
+            "=== started ===\nerror while loading shared libraries: libfoo.so\n",
+            encoding="utf-8",
+        )
+
+        response = client.get("/logs/49998")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["port"] == 49998
+        assert data["config_name"] is None
+        assert any("shared libraries" in ln for ln in data["lines"])
+        assert data["total_lines"] == len(data["lines"])
+
+
+    def test_logs_live_server_tails_by_pid(self, client, monkeypatch):
+        """When a server is live, /logs tails its log by pid (unchanged path)."""
+        from llauncher.agent import routing
+
+        mock_state = _MockState()
+        mock_state.running = {
+            8081: _MockServerInfo(
+                pid=4242, port=8081, config_name="mistral-7b"
+            )
+        }
+        monkeypatch.setattr(routing, "get_state", lambda: mock_state)
+        monkeypatch.setattr(
+            "llauncher.core.process.stream_logs",
+            lambda pid, lines: ["server is listening"],
+        )
+
+        response = client.get("/logs/8081")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["config_name"] == "mistral-7b"
+        assert data["lines"] == ["server is listening"]
+        assert data["total_lines"] == 1
+
+
+class TestStatusReconcile:
+    """`/status` prunes stale lockfiles for dead processes (issue #201 2a)."""
+
+    def test_status_prunes_stale_lockfile(self, client, tmp_path, monkeypatch):
+        """A lockfile claiming a dead pid is removed by the status sweep."""
+        from llauncher.core import lockfile as lf
+
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
+        monkeypatch.setattr(
+            "llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir
+        )
+        monkeypatch.setattr(
+            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH",
+            tmp_path / "audit.jsonl",
+        )
+        lf.write_lockfile(49997, "dead-model", 999_999, run_dir=run_dir)
+        assert (run_dir / "49997.lock").exists()
+
+        response = client.get("/status")
+        assert response.status_code == 200
+        assert not (run_dir / "49997.lock").exists()
 
     def test_logs_returns_correct_structure(self, client):
         """Test that logs return correct structure."""

--- a/tests/unit/test_agent_lifespan.py
+++ b/tests/unit/test_agent_lifespan.py
@@ -198,6 +198,40 @@ def test_lifespan_shutdown_tolerates_lockfile_enumeration_failure(
     assert stop_called is False
 
 
+def test_lifespan_startup_provisions_run_dir(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Startup self-provisions LAUNCHER_RUN_DIR (issue #201 Part 1).
+
+    After a fresh system-mode install the migrated state dir carries logs/
+    and audit.jsonl but not run/, so the first lockfile/marker write could
+    fail before llama-server spawns. The lifespan startup creates it.
+    """
+    run_dir = tmp_path / "run"
+    assert not run_dir.exists()
+    monkeypatch.setattr(agent_server.settings, "LAUNCHER_RUN_DIR", run_dir)
+    # No managed children to reap on shutdown.
+    monkeypatch.setattr(agent_server.lf, "list_lockfiles", lambda: [])
+
+    _drive_lifespan(monkeypatch)
+
+    assert run_dir.is_dir()
+
+
+def test_lifespan_startup_run_dir_is_idempotent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An already-present run dir is fine (exist_ok=True) — no raise."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setattr(agent_server.settings, "LAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr(agent_server.lf, "list_lockfiles", lambda: [])
+
+    _drive_lifespan(monkeypatch)
+
+    assert run_dir.is_dir()
+
+
 def test_create_app_wires_lifespan() -> None:
     """``create_app()`` constructs a FastAPI app with the lifespan handler bound."""
     app = agent_server.create_app(auth_token="test-token")

--- a/tests/unit/test_process_log_resolution.py
+++ b/tests/unit/test_process_log_resolution.py
@@ -86,6 +86,49 @@ def test_log_stem_for_is_glob_safe(log_dir):
         assert re.fullmatch(r"[\w\-]+", proc.log_stem_for(name))
 
 
+# ──────────────────── read_logs_for_port (#201) ───────────────────
+
+
+def test_read_logs_for_port_returns_none_when_no_file(log_dir):
+    """No ``*-{port}.log`` on disk → None, so the agent can map it to 404."""
+    assert proc.read_logs_for_port(8089) is None
+
+
+def test_read_logs_for_port_tails_without_a_live_process(log_dir):
+    """The death cause of an immediately-exited server is retrievable from
+    disk with no live pid — the heart of #201 Part 2b."""
+    f = proc.log_path_for("BrokenModel", 8081)
+    _write(f, "=== started ===", "error while loading shared libraries: libfoo.so")
+    lines = proc.read_logs_for_port(8081, lines=20)
+    assert lines is not None
+    assert any("shared libraries" in ln for ln in lines)
+
+
+def test_read_logs_for_port_prefers_freshest_file(log_dir):
+    """Across a swap two ``*-{port}.log`` may coexist; serve the newest."""
+    import os
+    import time
+
+    old = log_dir / "OldModel-8082.log"
+    new = log_dir / "NewModel-8082.log"
+    _write(old, "old occupant line")
+    _write(new, "new occupant line")
+    now = time.time()
+    os.utime(old, (now - 100, now - 100))
+    os.utime(new, (now, now))
+
+    lines = proc.read_logs_for_port(8082, lines=20)
+    assert any("new occupant" in ln for ln in lines)
+    assert all("old occupant" not in ln for ln in lines)
+
+
+def test_read_logs_for_port_empty_file_is_empty_list_not_none(log_dir):
+    """An existing but empty log → [] (200 with no lines), distinct from a
+    missing file (None → 404)."""
+    (log_dir / "EmptyModel-8083.log").write_text("", encoding="utf-8")
+    assert proc.read_logs_for_port(8083) == []
+
+
 # ─────────────────────── stream_logs ─────────────────────────────
 
 

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,110 @@
+"""Unit tests for ``llauncher.operations.reconcile`` (issue #201 Part 2a).
+
+A server that spawns then exits immediately leaves a ``{port}.lock`` behind
+even though it is gone from the process table. The status-path sweep prunes
+those stale claims and emits one ``OBSERVED_STOPPED`` audit entry each, while
+leaving lockfiles for still-live pids untouched.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from llauncher.core import audit_log
+from llauncher.core import lockfile as lf
+from llauncher.operations.reconcile import reconcile_stale_lockfiles
+
+# A pid that is essentially never live. ``is_pid_alive`` returns False
+# (NoSuchProcess), so a lockfile claiming it reconciles as stale.
+_DEAD_PID = 999_999
+
+
+@pytest.fixture
+def state_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the run dir and audit log at a tmp location for the sweep."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir)
+    monkeypatch.setattr(
+        "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", tmp_path / "audit.jsonl"
+    )
+    return run_dir
+
+
+def test_removes_stale_lockfile_and_returns_it(state_dirs: Path) -> None:
+    """A lockfile claiming a dead pid is removed and returned."""
+    lf.write_lockfile(8081, "mistral-7b", _DEAD_PID, run_dir=state_dirs)
+    assert (state_dirs / "8081.lock").exists()
+
+    pruned = reconcile_stale_lockfiles(caller="status")
+
+    assert [p.port for p in pruned] == [8081]
+    assert pruned[0].model == "mistral-7b"
+    assert not (state_dirs / "8081.lock").exists()
+
+
+def test_keeps_live_lockfile(state_dirs: Path) -> None:
+    """A lockfile claiming the live test pid is left untouched."""
+    lf.write_lockfile(8082, "qwen", os.getpid(), run_dir=state_dirs)
+
+    pruned = reconcile_stale_lockfiles()
+
+    assert pruned == []
+    assert (state_dirs / "8082.lock").exists()
+
+
+def test_mixed_prunes_only_dead(state_dirs: Path) -> None:
+    """Only the dead-pid claim is pruned; the live one survives."""
+    lf.write_lockfile(8081, "dead-model", _DEAD_PID, run_dir=state_dirs)
+    lf.write_lockfile(8082, "live-model", os.getpid(), run_dir=state_dirs)
+
+    pruned = reconcile_stale_lockfiles()
+
+    assert [p.port for p in pruned] == [8081]
+    assert not (state_dirs / "8081.lock").exists()
+    assert (state_dirs / "8082.lock").exists()
+
+
+def test_emits_one_observed_stopped_audit_entry(state_dirs: Path) -> None:
+    """Each pruned lockfile produces exactly one OBSERVED_STOPPED entry."""
+    lf.write_lockfile(8081, "mistral-7b", _DEAD_PID, run_dir=state_dirs)
+
+    reconcile_stale_lockfiles(caller="status")
+
+    entries = audit_log.read_entries()
+    observed = [
+        e
+        for e in entries
+        if e.action is audit_log.AuditAction.OBSERVED_STOPPED
+    ]
+    assert len(observed) == 1
+    assert observed[0].port == 8081
+    assert observed[0].caller == "status"
+    assert observed[0].pid == _DEAD_PID
+
+
+def test_idempotent_no_double_emit(state_dirs: Path) -> None:
+    """A second sweep finds nothing — the pruned lockfile is already gone."""
+    lf.write_lockfile(8081, "mistral-7b", _DEAD_PID, run_dir=state_dirs)
+
+    first = reconcile_stale_lockfiles()
+    second = reconcile_stale_lockfiles()
+
+    assert [p.port for p in first] == [8081]
+    assert second == []
+    observed = [
+        e
+        for e in audit_log.read_entries()
+        if e.action is audit_log.AuditAction.OBSERVED_STOPPED
+    ]
+    assert len(observed) == 1
+
+
+def test_empty_run_dir_is_noop(state_dirs: Path) -> None:
+    """No lockfiles → empty result, no audit entries."""
+    assert reconcile_stale_lockfiles() == []
+    assert audit_log.read_entries() == []


### PR DESCRIPTION
Closes #201.

Three deterministic robustness fixes to the agent's run-dir / lockfile / log
handling, each scoped to envelope space (no change to minted identity, no new
persisted shape). Resumed after a prior agent was cut off by the session limit
before gates ran; this PR verifies the WIP and runs the gates.

## The three deterministic fixes

1. **Self-provision the `run/` (lockfile) dir on agent startup** — the lifespan
   startup now does `settings.LAUNCHER_RUN_DIR.mkdir(parents=True, exist_ok=True)`,
   mirroring the `LOG_DIR.mkdir(...)` in `core.process.start_server`. After a
   fresh system-mode install the migrated state dir carries `logs/` and
   `audit.jsonl` but not `run/`, so the first lockfile/marker write could fail
   before `llama-server` even spawned. A `PermissionError` on a read-only state
   dir is a real misconfiguration and is intentionally allowed to surface.
   (`agent/server.py`)

2. **Reconcile/remove stale `{port}.lock` for a dead process** — new
   `operations/reconcile.py::reconcile_stale_lockfiles()` sweeps every lockfile,
   leaves live-pid claims untouched, and removes each dead-pid claim while
   emitting exactly one `OBSERVED_STOPPED` audit entry. The agent runs it on
   every `/status`. A server that spawned then exited immediately is correctly
   absent from `total_running` but used to leave its lockfile behind, blocking a
   future `start` on that port. Idempotent and cheap. (`operations/reconcile.py`,
   `operations/__init__.py`, `agent/routing.py::get_status`)

3. **`GET /logs/{port}` serves the most-recent log even with no live server** —
   new `core.process.read_logs_for_port()` resolves the freshest `*-{port}.log`
   (reusing the existing `_newest_log` / `_tail_file` helpers) without requiring
   a live pid. `GET /logs/{port}` falls back to it when no server is live, so the
   death cause of an immediately-exited server is still retrievable instead of
   404-ing away exactly the log that explains the failure. Only a truly missing
   log file 404s now; an existing-but-empty file returns `200` with `[]`.
   `config_name` is best-effort from a lingering lockfile, else `null`.
   (`core/process.py`, `agent/routing.py::get_logs`)

## Deferred design signal (NOT in this PR)

Issue #201 also offered, as an *alternative*, making `/start` poll-and-report
immediate spawn death. That is a latency/semantics change to a hot endpoint and
is **explicitly deferred as a separate `auto:draft`** — it is a design decision
the issue did not settle, not a deterministic fix. It is **not** implemented
here; this PR deliberately stays the three deterministic fixes above. Bounced as
a named design signal for the operator to ratify separately.

## Gates

- **Full pytest:** 1157 passed, 13 skipped. (See note below on the single
  failing test.)
- **Non-UI coverage:** 94.83%, floor `--cov-fail-under=93` reached.
- **Coverage over changed paths:** `operations/reconcile.py` 100%;
  `core/process.py` 95% and `agent/routing.py` 95% and `agent/server.py` 96%,
  with every changed line covered (the remaining misses are pre-existing gaps in
  unrelated functions, not the lines this PR touches).

### Pre-existing unrelated failure
`tests/regression/test_orphan_regression.py::test_cross_surface_orphan_dicts_agree`
fails under a full-suite run with `RuntimeError: There is no current event loop
in thread 'MainThread'` (a deprecated `asyncio.get_event_loop().run_until_complete(...)`
call that breaks once a prior async test consumes the loop, under
pytest 9.1.1 / py3.12). It passes in isolation. **Verified failing identically on
`main` (3ae2d6b) with the WIP reverted** — it is test-infra debt orthogonal to
#201 and is intentionally left untouched here to avoid scope creep. Worth a
separate cleanup ticket (`asyncio.get_event_loop()` -> `asyncio.run()`).
