### PR TITLE
fix(test): use asyncio.run in cross-surface orphan regression test (#206)

### DIFF
--- a/tests/regression/test_orphan_regression.py
+++ b/tests/regression/test_orphan_regression.py
@@ -268,9 +268,7 @@ def test_cross_surface_orphan_dicts_agree(http_client, monkeypatch) -> None:
     # MCP
     mcp_state = MagicMock()
     mcp_state.orphans = list(orphans)
-    mcp_result = asyncio.get_event_loop().run_until_complete(
-        mcp_list(mcp_state, {})
-    )
+    mcp_result = asyncio.run(mcp_list(mcp_state, {}))
     mcp_orphans = mcp_result["orphans"]
 
     # CLI


### PR DESCRIPTION
## The change
`tests/regression/test_orphan_regression.py` — one line. Replace:
```python
mcp_result = asyncio.get_event_loop().run_until_complete(mcp_list(mcp_state, {}))
```
with:
```python
mcp_result = asyncio.run(mcp_list(mcp_state, {}))
```
No other change. Test-only; package and coverage unaffected.

## Root cause
On Python 3.12, `asyncio.get_event_loop()` raises `RuntimeError: There is no current event loop` under full-suite ordering — a prior `@pytest.mark.asyncio` test closes the loop on teardown, leaving no current loop for this synchronous test to reuse. `asyncio.run()` creates and closes its own loop, so the test is order-independent.

This matches the repo house idiom (`asyncio.run` at `tests/unit/test_agent_lifespan.py:44`). After this change, `grep -rn get_event_loop --include=*.py` over the repo returns zero hits.

## Verification
- Reproduced red on unmodified `main` (Py 3.12.3): `test_cross_surface_orphan_dicts_agree` fails with the RuntimeError under default full-suite ordering (1 failed, 1142 passed).
- After fix: target test passes both in-isolation and in-file (order-independent).
- Full suite green: **1143 passed, 13 skipped**; non-UI coverage **94.64%** (`--cov-fail-under=93` satisfied).

## Impact
Makes `main`'s baseline green and unblocks #204/#205.

Fixes #206