### PR TITLE
fix(lockfile): treat AccessDenied pid as alive in reconcile (#208)

### DIFF
--- a/llauncher/core/lockfile.py
+++ b/llauncher/core/lockfile.py
@@ -160,12 +160,31 @@ def list_lockfiles(*, run_dir: Path | None = None) -> list[Lockfile]:
 
 
 def is_pid_alive(pid: int) -> bool:
-    """Return True if ``pid`` corresponds to a live, non-zombie process."""
+    """Return True if ``pid`` corresponds to a live, non-zombie process.
+
+    Process *absence* and process *inaccessibility* are deliberately
+    distinguished (issue #208):
+
+    - ``psutil.NoSuchProcess`` — the pid genuinely does not exist. The
+      process is dead; its lockfile (or swap marker) is a stale claim and is
+      safe to reclaim. Returns ``False``.
+    - ``psutil.AccessDenied`` — the pid *exists* but this uid cannot read its
+      status. Under system-mode (#191/#194) ``llama-server`` runs as the
+      ``llauncher`` service account while CLI/agent callers run as a different
+      uid, so a genuinely *live* server reads as inaccessible. Treating that
+      as dead would let reconciliation remove the lockfile of a running
+      cross-uid server (and, in the sweep, every such lockfile on every
+      ``/status``). Returns ``True`` (unknown-alive) so no caller reclaims an
+      inaccessible-but-present process.
+    """
     try:
         proc = psutil.Process(pid)
         return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
+    except psutil.NoSuchProcess:
         return False
+    except psutil.AccessDenied:
+        # Present but unreadable from this uid — assume alive (do not reclaim).
+        return True
 
 
 def reconcile_lockfile(

--- a/llauncher/operations/reconcile.py
+++ b/llauncher/operations/reconcile.py
@@ -34,6 +34,20 @@ def reconcile_stale_lockfiles(*, caller: str = "reconcile") -> list[Lockfile]:
     entry is emitted exactly once per dead claim. Safe to call on every
     ``/status``.
 
+    Liveness is decided by :func:`llauncher.core.lockfile.is_pid_alive`,
+    which treats an inaccessible-but-present pid (``psutil.AccessDenied``,
+    e.g. a cross-uid ``llama-server`` under system-mode #191/#194) as
+    **alive** — so the sweep never removes the lockfile of a running server
+    it merely cannot read (issue #208).
+
+    TOCTOU note: there is a microsecond window between the dead-check and
+    :func:`llauncher.core.lockfile.remove_lockfile` in which a racing
+    ``/start`` on the same port could write a fresh lockfile that this sweep
+    then removes. Single-operator, single-host operation makes this window
+    negligible; if concurrent multi-actor starts ever become real, the
+    remove would need to be guarded by re-reading the lockfile and confirming
+    the pid is unchanged. Not worth the complexity at present.
+
     Args:
         caller: Audit caller field. Defaults to ``"reconcile"``; the agent's
             status path passes ``"status"`` so the entry is attributable.

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path
 
+import psutil
 import pytest
 
 from llauncher.core import lockfile as lf
@@ -160,6 +161,35 @@ def test_is_pid_alive_false_for_likely_dead() -> None:
     # Use a sentinel pid that is overwhelmingly unlikely to exist on any
     # system. PID_MAX on Linux is typically 4194304; 2**31-1 exceeds that.
     assert lf.is_pid_alive(2**31 - 1) is False
+
+
+def test_is_pid_alive_true_on_access_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present-but-unreadable pid reads as alive (issue #208).
+
+    Under system-mode (#191/#194) ``llama-server`` runs as a different uid,
+    so ``psutil`` raises ``AccessDenied`` reading a *live* process. That must
+    not be mistaken for death, or reconcile would reclaim a running server.
+    """
+
+    def _raise_access_denied(_pid: int) -> psutil.Process:
+        raise psutil.AccessDenied(pid=_pid)
+
+    monkeypatch.setattr(lf.psutil, "Process", _raise_access_denied)
+    assert lf.is_pid_alive(4242) is True
+
+
+def test_is_pid_alive_false_on_no_such_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely absent pid reads as dead/reclaimable (issue #208)."""
+
+    def _raise_no_such_process(_pid: int) -> psutil.Process:
+        raise psutil.NoSuchProcess(_pid)
+
+    monkeypatch.setattr(lf.psutil, "Process", _raise_no_such_process)
+    assert lf.is_pid_alive(4242) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import psutil
 import pytest
 
 from llauncher.core import audit_log
@@ -102,6 +103,56 @@ def test_idempotent_no_double_emit(state_dirs: Path) -> None:
         if e.action is audit_log.AuditAction.OBSERVED_STOPPED
     ]
     assert len(observed) == 1
+
+
+def test_keeps_access_denied_lockfile(
+    state_dirs: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lockfile whose pid is present-but-unreadable is NOT pruned (#208).
+
+    Under system-mode (#191/#194) the sweep runs as a different uid than the
+    ``llama-server`` it spawned, so ``psutil`` raises ``AccessDenied`` reading
+    a live process. ``is_pid_alive`` treats that as alive, so the sweep must
+    leave the lockfile of a running cross-uid server in place.
+    """
+    lf.write_lockfile(8083, "cross-uid-model", 4242, run_dir=state_dirs)
+
+    def _raise_access_denied(_pid: int) -> psutil.Process:
+        raise psutil.AccessDenied(pid=_pid)
+
+    monkeypatch.setattr(lf.psutil, "Process", _raise_access_denied)
+
+    pruned = reconcile_stale_lockfiles()
+
+    assert pruned == []
+    assert (state_dirs / "8083.lock").exists()
+    assert audit_log.read_entries() == []
+
+
+def test_sweep_keeps_access_denied_prunes_dead(
+    state_dirs: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In one sweep: an unreadable (live) pid survives, a gone pid is pruned.
+
+    This is the #208 blast-radius guard — a single ``AccessDenied`` pid must
+    not cause the sweep to clear other ports, and genuinely-dead claims still
+    reconcile as before.
+    """
+    lf.write_lockfile(8081, "dead-model", _DEAD_PID, run_dir=state_dirs)
+    lf.write_lockfile(8083, "cross-uid-model", 4242, run_dir=state_dirs)
+
+    def _fake_process(pid: int) -> psutil.Process:
+        if pid == 4242:
+            raise psutil.AccessDenied(pid=pid)
+        raise psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(lf.psutil, "Process", _fake_process)
+
+    pruned = reconcile_stale_lockfiles()
+
+    assert [p.port for p in pruned] == [8081]
+    assert not (state_dirs / "8081.lock").exists()
+    assert (state_dirs / "8083.lock").exists()
 
 
 def test_empty_run_dir_is_noop(state_dirs: Path) -> None:


### PR DESCRIPTION
Closes #208.

## The fix

`core/lockfile.py::is_pid_alive` caught `psutil.AccessDenied` in the same
`except` as `psutil.NoSuchProcess` and returned `False` for both —
conflating process **absence** with process **inaccessibility**. Split:

- `NoSuchProcess` → pid genuinely gone → dead/reclaimable → `False`
- `AccessDenied` → pid present but unreadable from this uid → unknown-alive → `True`

## System-mode hazard (why it matters now)

Under system-mode (#191/#194), `llama-server` is spawned by the `llauncher`
service account while CLI/agent callers run as a different uid, so `psutil`
raises `AccessDenied` reading a **live** server. With the old behavior
`is_pid_alive` reported that live server as dead. The sweep-wide reconcile
added in #205 (#201) — called from `get_status` on **every `/status`** —
would then `remove_lockfile` for the running server, and because it is a
registry-wide sweep, across **every port** at once. Result: spurious "no
server running" plus freed ports a later `start` could collide with. This
lands exactly as the system-mode migration (#191 B1) makes cross-uid the
normal case.

## Caller audit (all share `is_pid_alive`, all now consistent)

- `operations/reconcile.py` sweep — the amplified blast radius; now keeps
  inaccessible-but-present lockfiles.
- per-port `start` / `stop` / `swap` / `delete` reconcile paths — same
  conservative treatment; no longer reclaim a cross-uid live server.
- `core/marker.py::reconcile_marker` — swap-marker owner liveness; now
  refuses to clear a marker whose holder is merely unreadable.
- `operations/orphan.py` — a claim pointing at an unreadable (live) pid is
  no longer mistaken for a stale claim.

The change is conservative everywhere: "unknown → do not reclaim."

## TOCTOU note

Documented in `operations/reconcile.py` the microsecond window between the
sweep's dead-check and `remove_lockfile` where a racing `/start` on the same
port could have a fresh lockfile pruned. Negligible under single-operator /
single-host operation; flagged for a re-read-and-confirm guard only if
concurrent multi-actor starts ever become real.

## Tests (profiled on changed behavior)

- `is_pid_alive` returns `True` on mocked `AccessDenied`, `False` on mocked
  `NoSuchProcess`, `True` for a genuinely live pid (existing self-pid test).
- Sweep does NOT remove a lockfile whose pid raises `AccessDenied`; DOES
  remove one whose pid is gone; mixed sweep keeps the unreadable one while
  pruning the dead one (blast-radius guard).

## Gates

- Full `pytest`: **1172 passed, 13 skipped** GREEN.
- Non-UI coverage: **94.95%** (gate 93%).
- Changed lines (`is_pid_alive` split, sweep docstring): fully covered;
  `reconcile.py` 100%.

Refs #201 #205 #191 #194.