### PR TITLE
fix(config): make _skip_path_validation context-scoped and non-racy (#88)

### DIFF
--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -7,14 +7,43 @@ is implemented in M1, vLLM follows in M6.
 """
 
 import shlex
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import Iterator, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from llauncher.core.settings import BLACKLISTED_PORTS as _ENV_BLACKLISTED_PORTS
+
+
+# Per-context skip flag for ``ModelConfig.model_path`` existence validation
+# (issue #88b). A ``ContextVar`` replaces the prior class-attribute toggle,
+# which mutated shared class state (``cls._skip_path_validation = True/False``)
+# and was racy: concurrent callers could clobber each other's flag — one
+# resetting to ``False`` while another was still mid-``model_validate`` with
+# the skip expected. A ContextVar is isolated per thread / async task, so each
+# caller sees only its own value (default ``False``) and the race cannot occur.
+_skip_path_validation_var: ContextVar[bool] = ContextVar(
+    "llauncher_skip_path_validation", default=False
+)
+
+
+@contextmanager
+def _skip_path_validation() -> Iterator[None]:
+    """Suppress ``ModelConfig.model_path`` existence checks within the block.
+
+    Scoped to the calling context only (see :data:`_skip_path_validation_var`);
+    nesting is safe because the token-based ``reset`` restores the prior value
+    rather than unconditionally clearing to ``False``.
+    """
+    token = _skip_path_validation_var.set(True)
+    try:
+        yield
+    finally:
+        _skip_path_validation_var.reset(token)
 
 
 # Deny-list of llama-server flags llauncher manages at its own boundary
@@ -99,14 +128,6 @@ class ModelConfig(BaseModel):
     mlock: bool = False
     extra_args: str = ""
 
-    # ClassVar (not Pydantic field): underscore-prefixed annotations are
-    # treated as PrivateAttr descriptors by Pydantic v2, which made
-    # ``getattr(cls, "_skip_path_validation", False)`` truthy at the class
-    # level and silently no-op'd the validator on a fresh process. ClassVar
-    # makes this a plain Python class variable so the validator runs as
-    # intended on first construction (see issue #88).
-    _skip_path_validation: ClassVar[bool] = False
-
     @field_validator("extra_args", mode="before")
     @classmethod
     def extra_args_no_managed_flags(cls, v):
@@ -154,7 +175,7 @@ class ModelConfig(BaseModel):
     @classmethod
     def model_exists(cls, v: str, info) -> str:
         """Validate that the model path exists (supports shard patterns)."""
-        if getattr(cls, "_skip_path_validation", False):
+        if _skip_path_validation_var.get():
             return v
 
         path = Path(v)
@@ -187,11 +208,8 @@ class ModelConfig(BaseModel):
         # Migrate extra_args from list[str] to str (legacy v1 shape).
         if "extra_args" in data and isinstance(data["extra_args"], list):
             data["extra_args"] = " ".join(data["extra_args"])
-        cls._skip_path_validation = True
-        try:
+        with _skip_path_validation():
             return cls.model_validate(data)
-        finally:
-            cls._skip_path_validation = False
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""

--- a/tests/unit/test_models_config_extended.py
+++ b/tests/unit/test_models_config_extended.py
@@ -6,6 +6,7 @@ path validators.
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from llauncher.models.config import (
     ChangeRules,
     AuditEntry,
     RunningServer,
+    _skip_path_validation,
+    _skip_path_validation_var,
 )
 
 
@@ -82,6 +85,91 @@ class TestFromDictUnvalidated:
         f.write_bytes(b"x")
         cfg = ModelConfig.from_dict({"name": "m", "model_path": str(f)})
         assert cfg.name == "m"
+
+
+# ---------------------------------------------------------------------------
+# Issue #88(b): skip flag is context-scoped, effective, and non-racy
+# ---------------------------------------------------------------------------
+
+class TestSkipPathValidationContext:
+    """The path-validation skip flag is a context-scoped, non-racy switch.
+
+    Pre-#88(b) the skip flag toggled a shared class attribute, which both
+    (a) leaked across constructions until reset and (b) raced under
+    concurrency. These tests pin the ContextVar replacement.
+    """
+
+    def test_skip_suppresses_validation_for_missing_path(self) -> None:
+        """``from_dict_unvalidated`` constructs even when the path is absent.
+
+        This is the load-bearing behavior #88 said was broken on a fresh
+        process: the skip must actually suppress the existence check.
+        """
+        cfg = ModelConfig.from_dict_unvalidated(
+            {"name": "m", "model_path": "/definitely/does/not/exist.gguf"}
+        )
+        assert cfg.model_path == "/definitely/does/not/exist.gguf"
+
+    def test_skip_does_not_leak_after_from_dict_unvalidated(self) -> None:
+        """The skip is scoped to the call; a later normal construct validates."""
+        ModelConfig.from_dict_unvalidated(
+            {"name": "m", "model_path": "/no/such/path.gguf"}
+        )
+        # Flag must be back to its default outside the context.
+        assert _skip_path_validation_var.get() is False
+        with pytest.raises(ValueError, match="does not exist"):
+            ModelConfig(name="m", model_path="/still/missing.gguf")
+
+    def test_context_manager_restores_prior_value_when_nested(self) -> None:
+        """Token-based reset restores the outer value rather than forcing False."""
+        with _skip_path_validation():
+            assert _skip_path_validation_var.get() is True
+            with _skip_path_validation():
+                assert _skip_path_validation_var.get() is True
+            # Inner exit restores the outer True, not the global default.
+            assert _skip_path_validation_var.get() is True
+        assert _skip_path_validation_var.get() is False
+
+    def test_skip_flag_does_not_bleed_across_threads(self) -> None:
+        """Concurrent constructions do not share the skip flag (no race).
+
+        One thread holds the skip open and builds a config with a missing
+        path; a second thread, started while the first is inside the skip
+        context, must still see validation enforced (its own context's
+        default ``False``). Pre-#88(b) the shared class attribute let the
+        first thread's ``True`` leak into the second.
+        """
+        gate = threading.Event()
+        release = threading.Event()
+        other_validated = {"raised": None}
+
+        def hold_skip_open() -> None:
+            with _skip_path_validation():
+                # Build with a missing path: must succeed under the skip.
+                ModelConfig(name="a", model_path="/missing/a.gguf")
+                gate.set()  # signal: skip is now open in this thread
+                release.wait(timeout=5)  # keep the context alive
+
+        def expect_validation() -> None:
+            gate.wait(timeout=5)  # enter while the other thread's skip is open
+            try:
+                ModelConfig(name="b", model_path="/missing/b.gguf")
+                other_validated["raised"] = False
+            except ValueError:
+                other_validated["raised"] = True
+            finally:
+                release.set()
+
+        t1 = threading.Thread(target=hold_skip_open)
+        t2 = threading.Thread(target=expect_validation)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        # The second thread saw validation enforced despite the first
+        # thread holding the skip open — no cross-thread bleed.
+        assert other_validated["raised"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

Issue #88 had two orthogonal hazards. #88(a) — the `ModelConfig._skip_path_validation` underscore annotation being treated as a Pydantic `PrivateAttr` descriptor (truthy at the class level, no-op'ing the validator on a fresh process) — was already fixed in PR #93 via the `ClassVar[bool]` annotation.

This PR closes the **secondary hazard (#88b)**: `from_dict_unvalidated` toggled shared class state —

```python
cls._skip_path_validation = True
try:
    return cls.model_validate(data)
finally:
    cls._skip_path_validation = False
```

That mutation is racy. Concurrent callers share one class attribute, so one caller's `finally` reset to `False` can land while another caller is still mid-`model_validate` expecting the skip — re-enabling path-existence checks under it and spuriously raising (or, inversely, leaking the skip into a caller that wanted validation).

## Fix

Replace the class-attribute toggle with a module-level `ContextVar[bool]` and a `_skip_path_validation()` context manager:

- `model_exists` reads `_skip_path_validation_var.get()` instead of `getattr(cls, "_skip_path_validation", False)`.
- `from_dict_unvalidated` wraps `model_validate` in `with _skip_path_validation():`.
- The `ClassVar` declaration is removed (no external consumers; private surface).

A `ContextVar` is isolated per thread / async task, so each caller sees only its own value (default `False`) — the cross-caller race cannot occur. Token-based `reset` makes nesting safe (restores the prior value rather than forcing `False`). Public surface (`from_dict_unvalidated`, `from_dict`, `model_exists`) is unchanged.

## Tests (profiled on the changed behavior)

New `TestSkipPathValidationContext`:
- `test_skip_suppresses_validation_for_missing_path` — the skip actually suppresses the existence check (the behavior #88 said was broken).
- `test_skip_does_not_leak_after_from_dict_unvalidated` — flag returns to default; a subsequent normal construct still validates.
- `test_context_manager_restores_prior_value_when_nested` — nested reset restores the outer value.
- `test_skip_flag_does_not_bleed_across_threads` — one thread holds the skip open while a second thread constructs concurrently and must still see validation enforced (pins the race regression).

## Gates

Full `pytest`: 1172 passed, 13 skipped. Coverage 94.98% (`--cov-fail-under=93` satisfied); `llauncher/models/config.py` at 99% (sole uncovered line is a pre-existing, unrelated legacy-list branch in the `extra_args` validator).

Closes #88.
