### PR TITLE
fix(remote): short-circuit /node-info on self-loop (#125)

### DIFF
--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -8,7 +8,6 @@ and op results into HTTP status codes.
 
 from __future__ import annotations
 
-import socket
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Response
@@ -35,10 +34,16 @@ def get_state() -> LauncherState:
 
 
 def get_node_name() -> str:
-    """Get the node name from environment or hostname."""
-    import os
+    """Get the node name from environment or hostname.
 
-    return os.getenv("LLAUNCHER_AGENT_NODE_NAME", socket.gethostname())
+    Delegates to :func:`llauncher.core.node_info.get_node_name` — the
+    single resolution point shared with the in-process self-loop path
+    (issue #125). Re-exported here so callers and tests that import it
+    from ``agent.routing`` keep working.
+    """
+    from llauncher.core import node_info as _node_info
+
+    return _node_info.get_node_name()
 
 
 # ─────────── Request body schemas ────────────────────────────────
@@ -121,25 +126,15 @@ async def health_check() -> dict:
 
 @router.get("/node-info")
 def node_info() -> dict:
-    """Get information about this node."""
-    import platform
+    """Get information about this node.
 
-    ips: list[str] = []
-    try:
-        hostname = socket.gethostname()
-        addr_info = socket.getaddrinfo(hostname, None)
-        ips = list(set(str(addr[4][0]) for addr in addr_info))
-    except Exception:
-        pass
+    The payload is built by :func:`llauncher.core.node_info.get_node_info`
+    — the single source shared with the in-process self-loop path so the
+    HTTP endpoint and ``RemoteNode.get_node_info`` never drift (issue #125).
+    """
+    from llauncher.core import node_info as _node_info
 
-    return {
-        "node_name": get_node_name(),
-        "hostname": socket.gethostname(),
-        "os": platform.system(),
-        "os_version": platform.version(),
-        "python_version": platform.python_version(),
-        "ip_addresses": ips,
-    }
+    return _node_info.get_node_info()
 
 
 @router.get("/status")

--- a/llauncher/core/node_info.py
+++ b/llauncher/core/node_info.py
@@ -1,0 +1,55 @@
+"""Local node-info payload builder (issues #62, #125).
+
+The node-info payload is pure local-state introspection — node name,
+hostname, OS, OS version, Python version, and resolved IP addresses. Two
+peers across the network boundary need the *identical* payload:
+
+* ``agent.routing.node_info`` serves it over ``GET /node-info``;
+* ``remote.RemoteNode.get_node_info`` returns it in-process on the #62
+  self-loop short-circuit (issue #125), skipping the loopback HTTP hop.
+
+Per the layer doctrine (``.claude/architecture.md``), ``remote`` must not
+import ``agent`` — they are peers across the wire. The shared builder is
+therefore hoisted *down* into ``core`` rather than reached for sideways,
+so both the server endpoint and the client self-loop path can call it.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import socket
+
+
+def get_node_name() -> str:
+    """Resolve this node's friendly name.
+
+    Sourced from ``LLAUNCHER_AGENT_NODE_NAME`` (the agent's bind-time
+    identity, see ``agent.config``), falling back to the OS hostname.
+    """
+    return os.getenv("LLAUNCHER_AGENT_NODE_NAME", socket.gethostname())
+
+
+def get_node_info() -> dict:
+    """Build the local node-info payload.
+
+    Pure introspection of this process's host: never raises on a
+    misconfigured resolver — IP discovery degrades to an empty list
+    rather than propagating.
+    """
+    ips: list[str] = []
+    try:
+        hostname = socket.gethostname()
+        addr_info = socket.getaddrinfo(hostname, None)
+        ips = list(set(str(addr[4][0]) for addr in addr_info))
+    except Exception:
+        pass
+
+    return {
+        "node_name": get_node_name(),
+        "hostname": socket.gethostname(),
+        "os": platform.system(),
+        "os_version": platform.version(),
+        "python_version": platform.python_version(),
+        "ip_addresses": ips,
+    }

--- a/llauncher/remote/node.py
+++ b/llauncher/remote/node.py
@@ -225,9 +225,23 @@ class RemoteNode:
     def get_node_info(self) -> dict | None:
         """Get detailed information about the node.
 
+        On the #62 self-loop (this process *is* the agent, target is the
+        local node) the payload is pure local-state introspection, so we
+        build it in-process via :func:`llauncher.core.node_info.get_node_info`
+        rather than burning a loopback HTTP round-trip, the auth hop, and
+        the FastAPI middleware chain to read data this process already has
+        (issue #125). The endpoint handler sources the *same* builder, so
+        the in-process and over-the-wire payloads cannot drift.
+
         Returns:
             Node info dictionary or None if unavailable.
         """
+        if self._is_self_loop():
+            from llauncher.core import node_info as _node_info
+
+            self.status = NodeStatus.ONLINE
+            self.last_seen = datetime.now()
+            return _node_info.get_node_info()
         try:
             with self._get_client() as client:
                 response = client.get(

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -1138,6 +1138,47 @@ class TestSelfLoopShortCircuit:
         mock_del.assert_called_once_with("qwen", caller="local")
         assert result["success"] is True
 
+    def test_get_node_info_self_loop_reads_in_process(self):
+        """Self-loop branch builds the payload in-process, no HTTP (#125)."""
+        node = RemoteNode("local", "localhost", port=8765)
+        canned = {
+            "node_name": "this-host",
+            "hostname": "this-host",
+            "os": "Linux",
+            "os_version": "6.x",
+            "python_version": "3.12.0",
+            "ip_addresses": ["127.0.0.1"],
+        }
+        with patch("httpx.Client") as mock_client_class, \
+             patch(
+                 "llauncher.core.node_info.get_node_info", return_value=canned
+             ) as mock_info:
+            result = node.get_node_info()
+
+        mock_client_class.assert_not_called()
+        mock_info.assert_called_once_with()
+        assert result == canned
+        assert node.status == NodeStatus.ONLINE
+        assert node.last_seen is not None
+
+    def test_get_node_info_remote_node_still_uses_http(self):
+        """Regression guard: a genuinely remote node still goes over HTTP."""
+        node = RemoteNode("peer", "192.168.1.100", port=8765)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"node_name": "peer", "os": "Linux"}
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = False
+        mock_client.get.return_value = mock_response
+        with patch("httpx.Client", return_value=mock_client) as mock_client_class, \
+             patch("llauncher.core.node_info.get_node_info") as mock_info:
+            result = node.get_node_info()
+
+        mock_client_class.assert_called_once()
+        mock_info.assert_not_called()
+        assert result == {"node_name": "peer", "os": "Linux"}
+
     def test_self_loop_skips_auth_header_check(self):
         """In-process path is not subject to LLAUNCHER_AGENT_TOKEN — auth is a
         network-boundary concern only."""


### PR DESCRIPTION
## What

`RemoteNode.get_node_info()` was the one read verb that always issued a
loopback `GET /node-info` over HTTP — even when this process *is* the
agent talking to its own local node. That burned the auth hop, the
FastAPI middleware chain, and a TCP round-trip to read pure local-state
the process already has. Closes #125 (extends #62).

Surfaced by a Windows operator hitting `401 Unauthorized` on
`GET /node-info` while loading a model against the local agent.

## Reuse of #202's self-loop helper

No parallel self-loop check. This reuses the exact narrowing PR #202
established — `_is_self_loop() = is_agent_process() AND
_targets_local_node()` — the same predicate `start` / `stop` / `swap` /
`delete_model` / `read_audit` already branch on. On self-loop,
`get_node_info()` builds the payload in-process; otherwise it goes over
HTTP unchanged.

## The shared payload builder (and why it lives in `core`)

The node-info payload (node name + host introspection: OS, OS version,
Python version, hostname, IPs) is hoisted into a new
`core/node_info.py` so the HTTP endpoint and the in-process self-loop
path source the **identical** builder and cannot drift.

It lives in `core`, **not** `agent` (where #125's `Fix shape` loosely
suggested `agent/node_info.py`): `remote -> agent` is a forbidden edge
per `.claude/architecture.md` (client importing its server). The shared
helper is hoisted *down* into `core` instead — `remote -> core` and
`agent -> core` are the allowed downward edges. `agent.routing.node_info`
and `agent.routing.get_node_name` now delegate to it (the latter
re-exported so existing importers keep working).

## Tests (profiled on the changed behavior)

- `get_node_info` self-loop builds the payload in-process, asserts
  `httpx.Client` is never constructed, returns the canned payload, sets
  `ONLINE`.
- A genuinely remote node still goes over HTTP and does **not** call the
  in-process builder (regression guard).
- New `core/node_info.py` at 100% line coverage.

## Gates

- Full `pytest`: 1170 passed, 13 skipped.
- Non-UI coverage: 94.96% (floor 93%).

Refs #125, #62, #202.
