### PR TITLE
docs(operations): consolidate multiuser/systemd migration runbook

### DIFF
--- a/docs/handoffs/BUGFIX_ROADMAP_2026-06-25.md
+++ b/docs/handoffs/BUGFIX_ROADMAP_2026-06-25.md
@@ -1,0 +1,101 @@
+# Bug-Fix Roadmap — shanevcantwell, severity-first (2026-06-25)
+
+**Scope:** 4 live bug-bearing repos — llauncher, harness-tools, thought-vault-integration
+(tvi), semantic-kinematics-mcp (skm). semantic-chunker = legacy/note-only. Windows quartet
++ blocked-infra set = parked. `langgraph-agentic-scaffold` excluded by request.
+
+**Inventory basis:** 56 repos scanned, 59 open bugs, 6 repos with active bug load. Liveness
+validated against June-2026 git activity (additive check): thought-vault-integration,
+llauncher, leap-null-falsify, harness-tools, design-docs, semantic-kinematics-mcp, pi-jail,
+frontier-advisor touched in June 2026. Of the non-roadmap live repos: leap-null-falsify has
+GitHub issues disabled (no backlog); design-docs/pi-jail/frontier-advisor carry only
+non-bug issues.
+
+**Parallelism model:** *Different repos are always concurrent* (separate git repos →
+separate worktrees, zero conflict surface). *Within* a repo, items are grouped into
+**lanes** by subsystem; one lane = one serial PR chain, lanes run concurrently. Lane
+conflicts are the only serialization constraint.
+
+---
+
+## Phase 0 — Hygiene (do first, ~15 min, serial)
+
+| Action | Repo | Disposition |
+|---|---|---|
+| Consolidate **#186/#187/#188** → 1 canonical nonpooled-embeddings bug, close 2 dupes | llauncher | git lane |
+| Confirm-park blocked set: **#1/#2/#9/#11** (`blocked`) + Windows **#127/#130/#132** (`user:gate`) | harness, llauncher | note only |
+
+## Phase 1 — Blocking-runnable + live-model hazards (top severity)
+
+*Parallel across repos; tvi #10 gates the rest of tvi.*
+
+| Bug | Repo | What | Disp. | Lane |
+|---|---|---|---|---|
+| **#10** P0 | tvi | missing runtime deps → repo non-runnable | fix | **tvi-gate** (must land first) |
+| **#11/#12/#13** P1 | tvi | f-string / `_is_tool_only` / dead-code imports | fix | tvi-A/B/C (parallel *after* #10) |
+| **#184** | llauncher | `--cache-reuse` detonates on resident Qwen3.6 | fix | **ll-args** |
+| **#189** | llauncher | MTP+parallel violates `-np 1` | fix | **ll-args** (same lane as #184 — both touch arg-validation/process) |
+| **#54** | harness | qwen3.6 record-skipping (live agent loops) | fix | **h-loop** |
+
+## Phase 1.5 — Self-leverage (small; repays within session)
+
+| Bug | Repo | What | Lane |
+|---|---|---|---|
+| **#29** | harness | allowlist prefix never matches git-lane shapes (dispatch friction) | **h-perm** |
+| **#28** | harness | destructive-git hook false-positives on commit bodies | **h-hook** (parallel with #29 — different files) |
+
+## Phase 2 — Security + silent-failure correctness
+
+| Bug | Repo | What | Disp. | Lane |
+|---|---|---|---|---|
+| **#150** | llauncher | VRAM check silently passes on missing GPU data | `auto:fix` | **ll-preflight** |
+| **#149** | llauncher | VRAM estimate quant/KV-blind (related to #150) | `auto:draft` | **ll-preflight** (same lane; draft→ratify) |
+| **#88** | llauncher | `_skip_path_validation` class-flag leak | `auto:fix` | **ll-config** |
+| **#181** | llauncher | UI eject silent no-op (argv vs lockfile) | fix | **ll-ui** |
+| **#141** | llauncher | extension wrong API endpoints | `auto:fix` | **ll-ext** |
+| **#186★** | llauncher | nonpooled embeddings 400 (post-consolidation) | fix | **ll-embed** (high, not currently-blocking — :8082 pooled is healthy) |
+| **#44** | harness | dead `start_server` renderResult | fix | **h-llauncher-ext** |
+| **#14** | harness | `swap_server` empty-ports → fall back to start | fix | **h-llauncher-ext** (same lane as #44 — same TS extension) |
+
+## Phase 3 — Arch / medium correctness
+
+| Bug | Repo | What | Disp. | Lane |
+|---|---|---|---|---|
+| **#171** | llauncher | remote→agent import regression | fix | **ll-arch** |
+| **#156** | llauncher | `update_model_config` loses batch/parallel | fix | **ll-config** (chains after #88) |
+| **#154** | llauncher | run.sh misleading install banner | `auto:fix` | **ll-install** |
+| **#151** | llauncher | `LAUNCHER_*`→`LLAUNCHER_*` rename | `auto:fix` **breaking** | **ll-envrename** (run **last, alone** — broad sweep, conflicts with everything) |
+| **#1/#9/#16** | skm | null-binding / MCP-contract bypass / non-self-describing checkpoint | fix | **skm-A/B/C** (parallel — distinct areas) |
+
+## Phase 4 — Deferred (note only)
+
+- tvi P2–P4 batch (#14–#22, #25, #26, #33) — cleanups/enhancements, not severity
+- llauncher Windows quartet #127/#130/#132 — operator-parked (#132 security-tagged but `user:gate`)
+- harness blocked set #1/#2/#9/#11 — infra-dependent
+- semantic-chunker #3 — legacy repo
+
+---
+
+## Parallel-execution summary
+
+**Max concurrent fan-out** (no two share a lane / repo file-surface):
+
+- **Repo-level:** tvi ∥ llauncher ∥ harness ∥ skm always run together.
+- **Phase 1 wave:** `tvi-gate(#10)` → then `{tvi-A,B,C}` ∥ `ll-args(#184,#189)` ∥
+  `h-loop(#54)` → **up to 5 concurrent worktrees.**
+- **Phase 2 wave:** `ll-preflight` ∥ `ll-config` ∥ `ll-ui` ∥ `ll-ext` ∥ `ll-embed` ∥
+  `h-llauncher-ext` → **6 llauncher lanes safe to parallelize** *because they touch disjoint
+  subsystems* (preflight / ModelConfig / UI / extension / embeddings).
+- **Serialization hard-rules:**
+  1. `tvi #10` before any other tvi fix.
+  2. `#184`+`#189` share `ll-args` → serial within lane.
+  3. `#44`+`#14` share the llauncher TS extension → serial within lane.
+  4. `#88` before `#156` (both `ll-config`).
+  5. **`#151` env-rename runs dead last, alone** — its sweep collides with every other llauncher lane.
+
+**Budget read:** Token budget (77% weekly as of session start) is not the binding
+constraint — wall-clock (<24h) is. The spine is Phases 0–1.5 (~7 fixes + 1 consolidation);
+everything `auto:fix` can go branch→fix+tests→gates→PR→merge-on-green under the llauncher
+autonomy contract. With repo-level + intra-repo lane parallelism, the practical ceiling is
+~5–6 concurrent worktrees per wave, which is what turns the 24h wall from "spine only" into
+"spine + most of Phases 2–3."

--- a/docs/handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md
+++ b/docs/handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md
@@ -1,0 +1,90 @@
+# Handoff — Multiuser migration + llauncher systemd (2026-06-25)
+
+**Author:** Claude Code (host, user `claude`). **Companion to:** `BUGFIX_ROADMAP_2026-06-25.md` (same dir).
+**Theme of the session:** getting the ecosystem **out of `/home/shane`** and onto a clean multiuser footing, and resolving how llauncher should run as a systemd-controlled service.
+
+---
+
+## TL;DR
+
+1. Audited every `/home/shane` hardcode under `/srv/dev/`; filed **7 portability issues** across 6 repos.
+2. Investigated llauncher logging; filed **3 logging bugs** (#192/#193/#195) and resolved the **systemd design (#191)** to **Option B1**.
+3. Proposed a **multiuser group/user scheme** (`assistant` / `inference` / `llauncher`) — *pending operator ratification*.
+4. Operator is concurrently doing the **privileged user/group + fine-grained `systemctl`** setup. Nothing on the box has been changed by me except the items in "Environment state" below.
+
+---
+
+## Decisions made (durable)
+
+### llauncher systemd → **Option B1** (system unit + dedicated service account)
+Full spec in **llauncher#191** (see the 2026-06-25 comment). Key points:
+- System unit running as a dedicated **`llauncher`** account; `StateDirectory=` (/var/lib) + `LogsDirectory=` (/var/log) + journald for the manager. **Amends ADR-009** (which chose `systemd --user`).
+- Only the per-config **child-stream logs** relocate; the agent's own log is *already* journald.
+- B1 is viable now **because the migration already moved the executables to `/srv/dev`** (built in place → no redeploy tax).
+- **Atomic installer is a hard requirement** (operator loses hours on manual-step context switches): one transactional `sudo scripts/systemd/install-system.sh`, rollback trap, idempotent.
+
+### Multiuser group/user scheme (PROPOSED — needs ratification)
+| Handle | Purpose | Members |
+|---|---|---|
+| `assistant` *(exists)* | edit `/srv/dev` source | shane, claude |
+| `inference` *(new)* | drive+observe the model runtime | shane, claude, `llauncher` |
+| `llauncher` *(new svc acct, nologin)* | run the daemon | (member of `inference`) |
+
+Access model: `/srv/dev` = `2770 root:assistant` setgid+default-ACL; executables = ACL `u:llauncher:rX` (read/exec, never write); `/var/log/llauncher` = `2750 llauncher:inference` (service writes, operator tails); token in `/var/lib/llauncher` = `640 llauncher:inference`. **Principle:** group membership for symmetric peers, ACLs for asymmetric least-privilege; setgid+default-ACL on shared dirs (highest-leverage move for the whole migration).
+
+---
+
+## Issues filed this session
+
+### `/home/shane` portability audit (7)
+| Repo | Issue | What |
+|---|---|---|
+| langgraph-agentic-scaffold | #277 | gemini_webui adapter/schemas hardcodes |
+| langgraph-agentic-scaffold | #278 | docker-compose host-path mount |
+| semantic-kinematics-mcp | #34 | scripts + embeddings adapter hardcodes |
+| thought-vault-integration | #35 | scripts + pyproject hardcodes |
+| semantic-chunker | #5 | forensics script + embeddings adapter |
+| ollama-shim | #1 | untrack committed `.claude/settings.local.json` |
+| llauncher | #191 | relocate logs for systemd (now the B1 design issue) |
+
+**Explicitly deferred (operator calls):** pi-jail (kept under `/home/shane` for now — can of worms), goan/goan-development (legacy), LAS beyond #277/#278.
+**Recurring pattern worth a systemic fix:** duplicated `sentence_transformers_adapter.py` hardcode in *both* semantic-chunker and semantic-kinematics-mcp.
+
+### llauncher logging (3)
+| Issue | Disp. | What |
+|---|---|---|
+| #192 | bug | orphaned logs never reaped (no cross-file GC; delete/rename don't clean) |
+| #193 | auto:draft | ADR-160 hash-in-filename orphans logs on rename/scheme-change |
+| #195 | bug | `settings.py` probes `LLAMA_SERVER_PATH` at import → stale path bricks the package |
+
+Ground truth (live Linux `~/.llauncher/logs`): 18 files, 0 rotations, ~5 confirmed old/new orphan pairs from the ADR-160 scheme change. **The ~4,000-file pile is the Windows agent (parked quartet), not Linux.**
+
+---
+
+## Migration state (facts, 2026-06-25)
+
+- **llama.cpp** now builds in place at `/srv/dev/llama.cpp/` → binary `build/bin/llama-server` (+ `.so`s), `rwxrwxr-x shane:shane`. A `build.working/` sibling exists.
+- **llauncher** code+venv at `/srv/dev/shanevcantwell/llauncher/` (the canonical clone). Its `.venv` **currently can't import** — `.env` still has `LLAMA_SERVER_PATH=/home/shane/github/llama.cpp/build/bin/llama-server` (dead path). **Repoint to `/srv/dev/llama.cpp/build/bin/llama-server`** (see #195).
+- `/srv/dev` is `drwxrwx--- shane:shane` + ACL granting `assistant`. **No `inference` group or `llauncher` account exists yet.**
+- GPU devices `/dev/nvidia*` are `crw-rw-rw-` (world-open — no group needed). All 61 `model_path`s are under `/mnt/storage/LLMs` (no $HOME wall).
+- The **live agent** (pid was 7465 at session start) still runs as `shane` from the *old* `/home/shane/.../llauncher/.venv`, `systemd --user`, on `:8765` (binds 0.0.0.0, token auth via `X-Api-Key`).
+
+---
+
+## Open threads / next steps
+
+1. **Ratify the group scheme** above → then I write the #191 ADR (amending ADR-009) + the atomic `install-system.sh`.
+2. **Repoint `LLAMA_SERVER_PATH`** in the /srv/dev clone `.env` (and the eventual service `agent.env`) → `/srv/dev/llama.cpp/build/bin/llama-server`. Unblocks the venv (#195).
+3. **Original task still pending:** swap `:8082` from `embeddinggemma-300M-F32-nonpooled` → `-pooled`. Blocked all session only because the agent token is shane-private. **The `inference` group (claude + token `640 llauncher:inference`) is the clean unblock** — then I can drive it over HTTP.
+4. **Systemic fix candidate:** duplicated embeddings-adapter hardcode (sc + skm) — one pattern fixes both.
+5. **Pre-commit guard** for `/home/[a-z]+/` in tracked files (stops the hardcode bleed going forward).
+
+## Security / hygiene notes
+- `~/.llauncher/agent.token` + `node_tokens.json` briefly sat world-readable (`0777`) in a `/srv/dev` copy during this session; that copy is being deleted. **Rotate the agent token** to be clean (regenerate in `agent.env` → restart). The token guards `:8765` on `0.0.0.0`.
+- Operator noted a **backup-scheme gap**: host-local secrets/state aren't captured by any backup — parked for a separate context.
+
+## Environment state (what I changed, user `claude`)
+- `gh` authenticated as `shanevcantwell` (token at `/home/claude/.config/gh/hosts.yml`; scopes repo/workflow/gist/read:org); git credential helper → `gh auth git-credential` for HTTPS.
+- git identity (global): `Shane V Cantwell <reflectiveattention@gmail.com>`.
+- `git config --global safe.directory` entries added for the `/srv/dev/shanevcantwell/*` repos (shane-owned, cross-user).
+- Retained read-only snapshot at `/tmp/llauncher-home-snapshot/` (mode 700): `config.json` (61 configs), `config-original.json` (11-config backup), `audit.jsonl`, `nodes.json` (token field redacted), `logs.listing.txt`. **No secret/token files retained.**

--- a/docs/operations/multiuser-migration-runbook.md
+++ b/docs/operations/multiuser-migration-runbook.md
@@ -1,0 +1,279 @@
+# Multiuser / systemd Migration Runbook
+
+The single durable record of moving llauncher from a single-user
+`systemd --user` agent (running as the operator out of `$HOME`) to a
+boot-time **system service** running as a dedicated, unprivileged
+`llauncher` account out of `/var/lib/llauncher`, on a multiuser host
+where a second account (the `claude` agent) must also drive the runtime.
+
+This runbook distills the scattered session handoffs (see
+[`../handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md`](../handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md)
+and the companion [`../handoffs/BUGFIX_ROADMAP_2026-06-25.md`](../handoffs/BUGFIX_ROADMAP_2026-06-25.md))
+into one place. For the decision rationale see
+[ADR-018](../adrs/accepted/018-llauncher-system-service.md); for the
+day-to-day install/operate surface see
+[`run-as-a-service.md`](run-as-a-service.md); for the token/auth model
+across both planes see [`../auth.md`](../auth.md).
+
+**Status as of 2026-06-26: LIVE.** `llauncher-agent.service` is active
+as a system unit, `User=llauncher`, state at `/var/lib/llauncher`
+(`2770 llauncher:inference`). The code-side enablers (#197
+`LAUNCHER_STATE_DIR`, #198 `--system` installer) are merged.
+
+---
+
+## 1. The decision (Option B1)
+
+llauncher runs as a **system unit under a dedicated `llauncher` service
+account**, not as a `systemd --user` unit owned by a human login. This is
+ADR-018's "Option B1" and it **supersedes ADR-009's deployment posture**
+(local agent as a deliberately-user-started peer). ADR-009's symmetric
+hub/spoke *topology* still holds; only the "user-started peer, state under
+`$HOME`" framing is replaced.
+
+Why B1, and why it is viable now:
+
+- **A second local user must drive the runtime.** The `claude` agent
+  account needs to start/stop/swap servers. It does so through its **own
+  tokenless, in-process MCP server** — that plane crosses no network
+  boundary and needs no token. The real enabler is therefore **shared
+  access to state** (lockfiles, `config.json`, the run dir), which a
+  per-user `0700` `$HOME` install cannot provide. The blocker was state
+  *locality*, not the token (see [`../auth.md`](../auth.md) "Multiuser /
+  system mode").
+- **State must leave any human's `$HOME`.** A single relocation knob,
+  `LAUNCHER_STATE_DIR=/var/lib/llauncher`, moves config, node registry,
+  token, run dir, audit, and logs out of `$HOME`. This resolves #191.
+- **Real boot-time semantics.** `[Install] WantedBy=multi-user.target`;
+  no `enable-linger` hack, no scoping to a user manager.
+- **No redeploy tax.** B1 became viable once the migration moved the
+  executables into `/srv/dev` (built in place), so there is no
+  copy-into-home step to redo.
+
+### Ownership split: in-repo installer vs. host provisioning
+
+- The **in-repo installer** (`scripts/systemd/install.sh --system`) only
+  *renders the unit and writes config*. Its `--system` preflight requires
+  root and asserts provisioning already exists, erroring out and pointing
+  at the host script otherwise.
+- **Host provisioning** (identity, dirs, ACLs, polkit) is a separate,
+  privileged, one-time concern that lives in **harness-tools**, not in
+  this repo. See §3.
+
+---
+
+## 2. Live ground truth (verified 2026-06-26)
+
+| Fact | Value |
+|------|-------|
+| Service | `llauncher-agent.service`, **active**, system unit |
+| Runs as | `User=llauncher`, `Group=inference` |
+| State dir | `/var/lib/llauncher`, mode `2770 llauncher:inference` |
+| Log dir | `/var/log/llauncher`, `2750 llauncher:inference` |
+| Agent bind | `0.0.0.0:8765`, `X-Api-Key` token auth |
+| Token | `/var/lib/llauncher/agent.token`, `0640 root:inference` (group-readable) |
+| Env file | `/var/lib/llauncher/agent.env`, `0640 root:inference` |
+| Code-side knob | #197 `LAUNCHER_STATE_DIR` — **merged** |
+| Installer | #198 `install.sh --system` — **merged** |
+
+The old `~/.llauncher` (operator home) was **copied, never moved**, so
+single-user state is intact for rollback. It is now legacy; see Open
+Items.
+
+---
+
+## 3. Host provisioning (cross-linked, not vendored here)
+
+The privileged host setup is **owned by harness-tools** and applied as
+root. It is *not* copied into this repo — these are pointers. The
+in-repo `--system` installer depends on this provisioning already being
+in place and fails loudly if it is missing.
+
+Absolute paths on the host (`claude/host-config/` in harness-tools):
+
+| Concern | Script |
+|---------|--------|
+| Create `inference` group, `llauncher` svc account, `/var/lib/llauncher` + `/var/log/llauncher` + setgid/default ACLs, exec ACLs, optional polkit | `.../host-config/setup-inference-lane.sh` |
+| One-shot cutover: migrate state, seed env, carry token, repoint `LLAMA_SERVER_PATH`, stop the `--user` agent, run `install.sh --system`, verify | `.../host-config/cutover-llauncher-system.sh` |
+| System-wide state-dir export for *interactive* local accounts | `.../host-config/etc/profile.d/llauncher.sh` |
+| Companion record: moving the orchestrator front-end to run as user `claude` | `.../host-config/claude-as-user-migration.md` |
+
+Full paths:
+
+- `/srv/dev/shanevcantwell/harness-tools/claude/host-config/setup-inference-lane.sh`
+- `/srv/dev/shanevcantwell/harness-tools/claude/host-config/cutover-llauncher-system.sh`
+- `/srv/dev/shanevcantwell/harness-tools/claude/host-config/etc/profile.d/llauncher.sh`
+- `/srv/dev/shanevcantwell/harness-tools/claude/host-config/claude-as-user-migration.md`
+
+### The two access lanes (advisor principle)
+
+Provisioning keeps "who edits the source" separate from "what drives the
+runtime":
+
+| Group / account | Purpose | Members |
+|---|---|---|
+| `assistant` *(exists)* | edit `/srv/dev` source | shane, claude |
+| `inference` *(new)* | drive + observe the model runtime | shane, claude, `llauncher` |
+| `llauncher` *(new svc acct, nologin)* | run the daemon | (member of `inference`) |
+
+Access model:
+
+- `/var/lib/llauncher` and `/var/log/llauncher` = `2770`/`2750`
+  `llauncher:inference`, **setgid + default ACL** so anything the daemon
+  writes inherits group `inference`. The group gets `rwX` (not `r-x`):
+  the `claude` agent drives via its own in-process MCP server and must
+  **write** lockfiles/registry edits as itself — a read-only grant would
+  fail those writes.
+- **Secrets are clamped back to group-read.** The installer writes
+  `agent.token` / `agent.env` at `0640`, tightening the ACL mask to `r--`
+  on those files specifically, so in-group consumers (the UI, remote HTTP
+  clients) can read the token in place with no secret copied into a
+  second home.
+- **Exec code is read-only to the daemon.** `llauncher` gets
+  `u:llauncher:rX` (read + traverse, never write) on `/srv/dev/llama.cpp`
+  and `/srv/dev/shanevcantwell/llauncher`, plus the `--x` search bit on
+  the `/srv/dev` parents so a `WorkingDirectory` chdir succeeds. A
+  buggy/compromised daemon can run the code but cannot rewrite its own
+  source.
+- **polkit (optional):** an `inference`-group member may
+  start/stop/restart/reload exactly `llauncher-agent.service` with no
+  sudo — safe **only because** the unit runs as the unprivileged
+  `llauncher` account.
+
+### System-wide state-dir config for interactive accounts
+
+The systemd unit gets `LAUNCHER_STATE_DIR=/var/lib/llauncher` from its own
+`Environment=` line. *Interactive* sessions of human/operator accounts
+(the `llauncher` CLI, the Streamlit UI, the local MCP server) need the
+same pointer so their tooling sees the same live state. This is what
+`etc/profile.d/llauncher.sh` provides:
+
+```sh
+export LAUNCHER_STATE_DIR=/var/lib/llauncher
+```
+
+Install (root):
+
+```bash
+sudo install -m 0644 \
+  /srv/dev/shanevcantwell/harness-tools/claude/host-config/etc/profile.d/llauncher.sh \
+  /etc/profile.d/llauncher.sh
+```
+
+**Read precondition:** because `/var/lib/llauncher` is `2770
+llauncher:inference`, a consuming account must be in the `inference`
+group:
+
+```bash
+sudo usermod -aG inference <user>   # then re-login / `newgrp inference`
+```
+
+(For non-login / service contexts, the broader alternative is
+`LAUNCHER_STATE_DIR=/var/lib/llauncher` in `/etc/environment`.)
+
+---
+
+## 4. Cutover flow
+
+Run **as root**, in order. Both host scripts are idempotent and support
+`DRY_RUN=1 sudo -E bash <script>` to preview.
+
+1. **Provision the runtime lane** —
+   `sudo bash setup-inference-lane.sh`. Creates the `llauncher` account,
+   `inference` group + memberships, `/var/lib/llauncher` and
+   `/var/log/llauncher` with setgid + default ACLs, exec ACLs on the code
+   tree, and (if `LLAUNCHER_UNIT` is set) the polkit rule.
+2. **Operator/agents pick up the new group** — log out/in or
+   `newgrp inference`. Group membership is fixed at login; pre-existing
+   sessions won't carry `inference` until refreshed.
+3. **Cutover** — `sudo bash cutover-llauncher-system.sh`. This does the
+   host-specific glue the in-repo installer deliberately does not:
+   - migrate durable state `~/.llauncher → /var/lib/llauncher` (copy,
+     no-clobber; lockfiles skipped, `run/` recreated);
+   - seed `/var/lib/llauncher/agent.env` (`0640 root:inference`) —
+     carrying the existing token if found, else generating one;
+   - set `LLAMA_SERVER_PATH` to the relocated binary under
+     `/srv/dev/llama.cpp` and `LD_LIBRARY_PATH` to its sibling `.so`
+     directory (the binary's baked RUNPATH points at the dead
+     pre-migration path, so the loader needs this or the spawned server
+     dies on startup);
+   - stop + disable the `--user` agent (frees `:8765`);
+   - run `install.sh --system` (renders
+     `/etc/systemd/system/llauncher-agent.service`, mirrors the token to
+     `agent.token`, daemon-reload + enable + start);
+   - verify: unit active, `/health` reachable, operator **and** `claude`
+     can read the token and **write** state.
+4. **Bring up model servers** — none are started by the cutover; drive
+   them via the agent / MCP once the system agent owns the runtime.
+
+### Rollback
+
+The old `~/.llauncher` was copied, never moved, so single-user state is
+intact:
+
+```bash
+sudo systemctl disable --now llauncher-agent.service
+sudo -u <operator> XDG_RUNTIME_DIR=/run/user/<uid> \
+  systemctl --user enable --now llauncher-agent.service
+```
+
+Once confident in the system unit, archive the old `~/.llauncher` (see
+Open Items).
+
+---
+
+## 5. Operate (system mode)
+
+```bash
+systemctl status llauncher-agent          # system unit (no --user)
+sudo systemctl restart llauncher-agent    # or, for inference-group + polkit: no sudo
+journalctl -u llauncher-agent -f          # manager log is journald
+
+$EDITOR /var/lib/llauncher/agent.env      # EnvironmentFile read at start
+sudo systemctl restart llauncher-agent    # pick up env edits
+```
+
+Token rotation in system mode: edit `LLAUNCHER_AGENT_TOKEN` in
+`/var/lib/llauncher/agent.env`, restart the unit, update clients. See
+[`run-as-a-service.md`](run-as-a-service.md#token-rotation) and
+[`../auth.md`](../auth.md).
+
+---
+
+## 6. Open Items
+
+- **Group-scheme ratification.** The `assistant` / `inference` /
+  `llauncher` scheme in §3 was proposed and is now applied on the host,
+  but the *design* was filed as "pending operator ratification" in the
+  2026-06-25 handoff. Confirm the scheme is the intended durable model
+  (vs. setgid-everywhere or a single combined group) and record the
+  ratification.
+- **Agent-token rotation.** The `agent.token` / `node_tokens.json` briefly
+  sat world-readable (`0777`) in a transient `/srv/dev` copy during the
+  migration session. Rotate the agent token to be clean: regenerate in
+  `agent.env`, restart the unit, update clients. The token guards `:8765`
+  on `0.0.0.0`.
+- **Legacy `~/.llauncher` cleanup.** The operator's old `~/.llauncher`
+  (and `~/.config/llauncher/agent.env`) were copied, not moved, and remain
+  as the rollback source. Once the system unit is trusted, archive/remove
+  them so there is one source of truth.
+- **Backup-scheme gap.** Host-local secrets/state under
+  `/var/lib/llauncher` are not captured by any backup yet — parked for a
+  separate context, noted here so it is not lost.
+
+---
+
+## Related documents
+
+- [ADR-018 — llauncher as a System Service](../adrs/accepted/018-llauncher-system-service.md)
+  — the decision and its supersession of ADR-009's deployment posture.
+- [`run-as-a-service.md`](run-as-a-service.md) — install/operate surface
+  for both `--user` and `--system` modes.
+- [`../auth.md`](../auth.md) — the two-plane token/auth model; why a
+  second local user needs shared state, not a token.
+- Session handoffs (now tracked in `../handoffs/`):
+  [HANDOFF_2026-06-25](../handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md),
+  [BUGFIX_ROADMAP_2026-06-25](../handoffs/BUGFIX_ROADMAP_2026-06-25.md).
+- Host-layer provisioning (harness-tools, not in this repo):
+  `setup-inference-lane.sh`, `cutover-llauncher-system.sh`,
+  `etc/profile.d/llauncher.sh`, `claude-as-user-migration.md`.

--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -1,5 +1,13 @@
 # Running `llauncher-agent` as a Service
 
+> **Multiuser / `--system` mode lives in its own runbook.** This doc is
+> the general install/operate surface (single-user `--user` on Linux,
+> NSSM on Windows). For the live multiuser host migration — the dedicated
+> `llauncher` service account, `/var/lib/llauncher` state, the `inference`
+> group, host provisioning, and the cutover/rollback flow — see
+> [`multiuser-migration-runbook.md`](multiuser-migration-runbook.md).
+> That runbook supersedes the `--system` notes scattered here.
+
 The agent is the daemon piece of llauncher; the UI is interactive and is
 not service-managed. This doc covers persistent installs on:
 


### PR DESCRIPTION
## What this consolidates

`auto:draft` docs-only consolidation of the multiuser / systemd migration. Distills the two loose top-level files (`HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md`, `BUGFIX_ROADMAP_2026-06-25.md`) plus the scattered dated handoffs into **one durable runbook**, and checks the loose files into the repo so they are tracked. No code, no script moves.

## New runbook — `docs/operations/multiuser-migration-runbook.md`

Section outline:

1. **The decision (Option B1)** — system unit + dedicated `llauncher` svc account; supersedes ADR-009's deployment posture; why state-locality (not the token) was the blocker; installer-vs-host-provisioning ownership split.
2. **Live ground truth (verified 2026-06-26)** — service active, `User=llauncher`, `/var/lib/llauncher` (`2770 llauncher:inference`), `:8765`, group-readable token; #197 + #198 merged.
3. **Host provisioning (cross-linked, not vendored)** — the two access lanes (`assistant`/`inference`/`llauncher`), ACL/exec/polkit access model, system-wide state-dir config (`/etc/profile.d/llauncher.sh`) + `inference` group membership.
4. **Cutover flow** — `setup-inference-lane.sh` → group pickup → `cutover-llauncher-system.sh` → bring up servers; plus **rollback**.
5. **Operate (system mode)** — `systemctl` (no `--user`), journald, env-file edits, token rotation.
6. **Open Items** — group-scheme ratification, agent-token rotation, legacy `~/.llauncher` cleanup, backup-scheme gap.

Cross-links: ADR-018, `run-as-a-service.md`, `auth.md`.

## Host-layer docs: cross-linked, NOT moved

These stay in **harness-tools** (`claude/host-config/`) and are referenced by absolute path only — privileged, one-time host setup belongs there, not in this repo:

- `setup-inference-lane.sh`
- `cutover-llauncher-system.sh`
- `etc/profile.d/llauncher.sh`
- `claude-as-user-migration.md`

## Other changes

- `docs/handoffs/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md` and `docs/handoffs/BUGFIX_ROADMAP_2026-06-25.md` — the two loose top-level files, now tracked in-repo (verbatim copies).
- `docs/operations/run-as-a-service.md` — pointer added at top directing `--system`/multiuser readers to the new runbook (rather than rewriting the doc).

## Loose originals for the operator to delete (NOT removed by this PR)

- `/srv/dev/shanevcantwell/HANDOFF_2026-06-25-multiuser-migration-llauncher-systemd.md`
- `/srv/dev/shanevcantwell/BUGFIX_ROADMAP_2026-06-25.md`

## Tier

`auto:draft` — do **not** merge; operator ratifies. Docs-only.