### PR TITLE
feat(systemd): add system CLI installer

### DIFF
--- a/scripts/systemd/install-cli.sh
+++ b/scripts/systemd/install-cli.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-cli.sh — system install of the llauncher CLI from public origin/main.
+# ----------------------------------------------------------------------------
+# Installs `llauncher` (+ llauncher-mcp, llauncher-ui) onto the system PATH for
+# ALL accounts, pulled from the PUBLIC GitHub repo — decoupled from any dev
+# checkout and from any dev .venv. A dedicated venv lives at /opt/llauncher/venv
+# (its own Python, NOT added to PATH); only the console-script entry points are
+# symlinked into /usr/local/bin (already on every account's PATH). No venv bin
+# directory is ever placed on PATH.
+#
+# Usage (root):
+#   sudo bash scripts/systemd/install-cli.sh                 # install/refresh from main
+#   sudo REF=v0.4.0-alpha bash scripts/systemd/install-cli.sh  # pin a tag/branch/SHA
+#   sudo bash scripts/systemd/install-cli.sh --uninstall
+#
+# Re-runnable: re-running refreshes the install to the current REF.
+#
+# Pairs with a system-wide state dir so the CLI sees live system state:
+#   echo 'LAUNCHER_STATE_DIR=/var/lib/llauncher' | sudo tee /etc/profile.d/llauncher.sh
+#   sudo usermod -aG inference <user>   # read access to /var/lib/llauncher
+# ----------------------------------------------------------------------------
+set -euo pipefail
+
+REPO_URL="https://github.com/shanevcantwell/llauncher.git"
+REF="${REF:-main}"
+PREFIX="/opt/llauncher"
+VENV="$PREFIX/venv"
+BINDIR="/usr/local/bin"
+SCRIPTS=(llauncher llauncher-mcp llauncher-ui)
+
+[ "$(id -u)" -eq 0 ] || { echo "FATAL: run as root (sudo bash $0)"; exit 1; }
+
+if [ "${1:-}" = "--uninstall" ]; then
+    for s in "${SCRIPTS[@]}"; do rm -f "$BINDIR/$s" && echo "removed $BINDIR/$s"; done
+    rm -rf "$PREFIX" && echo "removed $PREFIX"
+    echo "Uninstalled."
+    exit 0
+fi
+
+command -v python3 >/dev/null || { echo "FATAL: python3 not found"; exit 1; }
+command -v git     >/dev/null || { echo "FATAL: git not found (needed for the git+https install)"; exit 1; }
+
+echo "==> dedicated venv at $VENV (own Python; independent of any dev .venv; not on PATH)"
+mkdir -p "$PREFIX"
+[ -x "$VENV/bin/python" ] || python3 -m venv "$VENV"
+"$VENV/bin/pip" install --quiet --upgrade pip
+
+echo "==> installing llauncher[ui] from public $REPO_URL @ $REF"
+"$VENV/bin/pip" install --quiet --upgrade "llauncher[ui] @ git+$REPO_URL@$REF"
+
+echo "==> symlinking console scripts into $BINDIR (venv bin stays off PATH)"
+for s in "${SCRIPTS[@]}"; do
+    ln -sfn "$VENV/bin/$s" "$BINDIR/$s"
+    echo "    $BINDIR/$s -> $VENV/bin/$s"
+done
+
+# world-readable/executable so every account can run the shared install
+chmod -R a+rX "$PREFIX"
+
+echo "==> verify"
+"$VENV/bin/python" -c "import llauncher; print('    installed llauncher', llauncher.__version__)"
+for s in "${SCRIPTS[@]}"; do command -v "$s" >/dev/null && echo "    ok: $s resolves on PATH"; done
+echo "Done — 'llauncher' is available to all accounts via $BINDIR (from public $REF), with no dev-.venv dependency."


### PR DESCRIPTION
## Summary

- Adds `scripts/systemd/install-cli.sh`, a standalone root-run installer that clones from the public `origin/main` into a dedicated `/opt/llauncher` venv and drops symlinks under `/usr/local/bin`
- Intentionally decoupled from the dev `.venv` — system-wide install survives dev tree changes
- Pairs with the existing `profile.d` state-dir config and `inference` group setup; no new systemd units introduced here
- Supports `--uninstall` to cleanly remove the venv and symlinks, and a `REF` env-var override for pinning to a specific commit or branch

## No code/tests changed

This is a purely additive standalone shell script. No Python source, no test suite, no coverage impact.

## Test plan

- [ ] Run `sudo REF=main bash scripts/systemd/install-cli.sh` on the host and verify `llauncher --version` resolves from `/usr/local/bin`
- [ ] Confirm the install venv at `/opt/llauncher` is isolated from the dev `.venv`
- [ ] Run `sudo bash scripts/systemd/install-cli.sh --uninstall` and verify symlinks and venv are removed
- [ ] Optionally: `REF=<sha> sudo bash scripts/systemd/install-cli.sh` to confirm pinned-ref install