### PR TITLE
docs(versioning): state vN and 0.x are independent axes (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ llauncher includes validation rules to prevent problematic actions:
 - **Model whitelists**: Optionally restrict which models can be started
 - **Caller blacklists**: Restrict which callers (UI, MCP, etc.) can perform actions
 
+## Versioning
+
+`vN` (`v1`, `v2`, `v3` …) denotes the architecture generation; `0.x`
+(`0.4.0a0` / `v0.4.0-alpha`) denotes the semver release. They are independent
+axes and do not map to each other — see [`docs/VERSIONING.md`](docs/VERSIONING.md).
+
 ## Project Structure
 
 ```

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,25 @@
+# Versioning
+
+llauncher carries two numbering axes that are **independent**:
+
+- **Internal generation** — `v1`, `v2`, `v3` … denotes the *architecture
+  epoch* (e.g. `v2` is the `operations/` stateless-facade refactor, ADR-008+).
+- **External semver** — `0.x` (`0.4.0a0` / `v0.4.0-alpha`) denotes the
+  *release*, per `pyproject.toml`, `llauncher/__init__.py`, and the latest git
+  tag.
+
+> `vN` denotes architecture generation; `0.x` denotes semver release. They are
+> independent axes and do not map to each other.
+
+There is deliberately **no** mapping table and **no** `vN ↔ 0.(N+1)`
+correspondence. Reaching for one (e.g. "`v2` == `0.4.0-alpha`?") manufactures a
+false equivalence — the axes advance on their own schedules and are read
+separately.
+
+## Tag-namespace note
+
+Release tags live in the `v0.x.y` namespace (`v0.1.0-alpha … v0.4.0-alpha`).
+Generation labels (`v1`, `v2`, …) belong to the architecture axis and should
+not be minted as release tags. The historical `v1-final` tag is the one spot
+where the two axes physically collide; treat it as legacy, and keep generation
+labels out of the release-tag namespace going forward.


### PR DESCRIPTION
## What

Adds the single canonical statement that llauncher's two numbering axes are **independent**, resolving the conflation described in #153.

- New `docs/VERSIONING.md` — canonical home, carrying the issue's exact sentence:
  > `vN` denotes architecture generation; `0.x` denotes semver release. They are independent axes and do not map to each other.
- README gains a short **Versioning** subsection (before Project Structure) restating the independence and pointing to `docs/VERSIONING.md` for discoverability.

## Scope discipline (per #153)

- **No mapping table**, no `vN ↔ 0.(N+1)` correspondence — that's the issue's explicit non-goal; the axes stay independent.
- The optional "Aside" git-tag rename (`v1-final`) is **not** performed (tag operations need operator coordination); instead `docs/VERSIONING.md` documents the convention — generation labels stay out of the release-tag namespace, and `v1-final` is flagged as the legacy collision point.

## Gates (rebased onto current main 2026-07-04)

- Full pytest: **1348 passed, 1 failed (pre-existing baseline `test_config_path_printed`, unrelated to this docs-only change), 11 skipped**.
- Non-UI coverage: **100%** (floor 93%). Docs-only change touches no code paths.

Closes #153

DO NOT MERGE — per dispatch instruction, this PR is left open for operator review.
