### PR TITLE
fix(preflight): guard unknown-VRAM branch instead of silently passing (#150)

### DIFF
--- a/llauncher/operations/preflight.py
+++ b/llauncher/operations/preflight.py
@@ -21,6 +21,7 @@ slice-2 wiring.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from collections.abc import Callable
 
@@ -58,6 +59,45 @@ def run_preflight_check(
         logger.exception("%s pre-flight check raised; treating as failure", label)
         return False, f"{label} check raised: {exc}"
     return ok, reason
+
+
+# Behavior when VRAM headroom cannot be verified — a GPU backend is present
+# but reports no device numbers (e.g. a transient ``nvidia-smi`` hiccup or a
+# malformed device query). Governed by the ``LLAUNCHER_VRAM_PREFLIGHT`` env
+# var (issue #150):
+#
+#   ``strict`` — fail closed: reject with "cannot verify VRAM headroom".
+#   ``warn``   — proceed but log a structured WARNING (the default).
+#   ``off``    — proceed silently, matching the legacy no-op behavior.
+#
+# Default is ``warn`` rather than ``strict`` because the companion
+# device-query defect makes the unknown-VRAM branch fire constantly;
+# defaulting to strict would block every swap. ``warn`` restores a visible
+# guard rail without regressing swap availability. The "no backend at all"
+# branch (genuinely CPU-only host) is unaffected and always passes.
+VRAM_PREFLIGHT_ENV = "LLAUNCHER_VRAM_PREFLIGHT"
+VRAM_PREFLIGHT_DEFAULT = "warn"
+VRAM_PREFLIGHT_MODES = ("strict", "warn", "off")
+
+
+def _vram_unknown_mode() -> str:
+    """Resolve the configured behavior for the unknown-VRAM branch.
+
+    Reads :data:`VRAM_PREFLIGHT_ENV` at call time (so the runtime env, and
+    test monkeypatching, take effect without re-import). An unrecognized
+    value logs a WARNING and falls back to :data:`VRAM_PREFLIGHT_DEFAULT`.
+    """
+    raw = os.environ.get(VRAM_PREFLIGHT_ENV, VRAM_PREFLIGHT_DEFAULT).strip().lower()
+    if raw not in VRAM_PREFLIGHT_MODES:
+        logger.warning(
+            "%s=%r is not one of %s; falling back to %r",
+            VRAM_PREFLIGHT_ENV,
+            raw,
+            VRAM_PREFLIGHT_MODES,
+            VRAM_PREFLIGHT_DEFAULT,
+        )
+        return VRAM_PREFLIGHT_DEFAULT
+    return raw
 
 
 # Heuristic constant: VRAM (MiB) per billion parameters at ~Q4_K_M quantization.
@@ -129,6 +169,11 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
       state. If no GPU backend is detected, treat the check as a no-op
       pass — the process will fail naturally if the host can't run the
       model. This matches the agent-routing behavior.
+    - If a backend *is* detected but reports no device numbers, VRAM
+      headroom is unknown. Per issue #150 this is governed by
+      :data:`VRAM_PREFLIGHT_ENV` (``strict`` rejects, ``warn`` passes with
+      a logged warning, ``off`` passes silently) — never a silent no-op,
+      which would let a blind swap OOM.
     - Compute :func:`estimate_vram_mb` for ``config``.
     - Pass if **any** device reports ``free_vram_mb >= required``. We pick
       the most-free device rather than enforcing an exact placement; the
@@ -147,6 +192,18 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
 
     devices = health.get("devices") or []
     if not devices:
+        # Backend present but no device numbers — VRAM headroom is unknown.
+        # Issue #150: this is the dangerous branch (a blind swap can OOM), so
+        # govern it explicitly instead of silently passing.
+        mode = _vram_unknown_mode()
+        reason = (
+            "cannot verify VRAM headroom: GPU backend "
+            f"{backends!r} present but reported no device data"
+        )
+        if mode == "strict":
+            return False, reason
+        if mode == "warn":
+            logger.warning("VRAM pre-flight: %s; proceeding (mode=warn)", reason)
         return True, ""
 
     required_mb = estimate_vram_mb(config)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -138,11 +138,69 @@ def test_default_vram_check_no_backend_passes() -> None:
     assert reason == ""
 
 
-def test_default_vram_check_backend_with_no_devices_passes() -> None:
+def test_default_vram_check_backend_with_no_devices_warns_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #150: default mode is ``warn`` — pass but log a structured warning."""
+    monkeypatch.delenv(pf.VRAM_PREFLIGHT_ENV, raising=False)
+    cfg = _config()
+    with caplog.at_level("WARNING", logger="llauncher.operations.preflight"):
+        with _patch_gpu({"backends": ["nvidia"], "devices": []}):
+            ok, reason = pf.default_vram_check(cfg)
+    assert ok is True
+    assert reason == ""
+    assert any("cannot verify VRAM headroom" in rec.message for rec in caplog.records)
+
+
+def test_default_vram_check_backend_with_no_devices_strict_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #150: ``strict`` fails closed when VRAM headroom is unknown."""
+    monkeypatch.setenv(pf.VRAM_PREFLIGHT_ENV, "strict")
     cfg = _config()
     with _patch_gpu({"backends": ["nvidia"], "devices": []}):
         ok, reason = pf.default_vram_check(cfg)
+    assert ok is False
+    assert "cannot verify vram headroom" in reason.lower()
+    assert "nvidia" in reason
+
+
+def test_default_vram_check_backend_with_no_devices_off_passes_silently(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #150: ``off`` restores the legacy no-op — pass with no warning."""
+    monkeypatch.setenv(pf.VRAM_PREFLIGHT_ENV, "off")
+    cfg = _config()
+    with caplog.at_level("WARNING", logger="llauncher.operations.preflight"):
+        with _patch_gpu({"backends": ["nvidia"], "devices": []}):
+            ok, reason = pf.default_vram_check(cfg)
     assert ok is True
+    assert reason == ""
+    assert not any("VRAM pre-flight" in rec.message for rec in caplog.records)
+
+
+def test_default_vram_check_unknown_mode_falls_back_to_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognized mode logs a warning and defaults to ``warn`` (pass)."""
+    monkeypatch.setenv(pf.VRAM_PREFLIGHT_ENV, "bogus")
+    cfg = _config()
+    with caplog.at_level("WARNING", logger="llauncher.operations.preflight"):
+        with _patch_gpu({"backends": ["nvidia"], "devices": []}):
+            ok, reason = pf.default_vram_check(cfg)
+    assert ok is True
+    assert reason == ""
+    assert any("falling back to" in rec.message for rec in caplog.records)
+
+
+def test_vram_unknown_mode_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(pf.VRAM_PREFLIGHT_ENV, "  STRICT  ")
+    assert pf._vram_unknown_mode() == "strict"
 
 
 def test_default_vram_check_sufficient_passes() -> None:


### PR DESCRIPTION
Closes #150.

## Problem
When `GPUHealthCollector` reports a GPU backend but no device numbers,
`default_vram_check` passed unconditionally — VRAM headroom is *unknown*,
yet a swap/start proceeded blind and could OOM. The check became a no-op
exactly when something was wrong (a malformed device query — companion
issue — or any transient `nvidia-smi` hiccup).

## Fix (smallest correct, scoped to the unknown-VRAM branch)
Govern the "backend present, no device data" branch via a new env var,
`LLAUNCHER_VRAM_PREFLIGHT`:

- `strict` — fail closed with `cannot verify VRAM headroom: ...`.
- `warn` — **default**: proceed but emit a structured `logger.warning`.
- `off` — proceed silently (the legacy no-op).

Default is `warn`, not `strict`, on purpose: the companion device-query
defect makes this branch fire constantly today, so a strict default would
block *every* swap. `warn` restores a visible guard rail without
regressing swap availability. Unrecognized values log a warning and fall
back to `warn`.

The "no backend at all" branch (genuinely CPU-only host) is unchanged and
always passes, per the issue's stated scope.

The env var is read at call time (matching the `LLAUNCHER_GPU_SIMULATE`
pattern in `core/gpu.py`) so runtime env and test monkeypatching take
effect without re-import.

## Tests
Added profiled cases over the changed branch in
`tests/unit/test_preflight.py`: default-warn (asserts pass + logged
warning), strict-fails, off-passes-silently, unknown-mode-falls-back, and
case-insensitive mode parsing.

## Gates
- Full suite: 1184 passed, 11 skipped.
- Coverage 95.35% (>= 93); `operations/preflight.py` now 100%.

No backwards-compat shim (single new env knob, default chosen to avoid
regression). Per `CODE_CONSTITUTION` `PARSE-AT-THE-DOOR`: unknown env
values fail soft to the default with a loud warning rather than dual-parse.