### PR TITLE
fix(scripts): make run.sh install honest; surface global install in help (#154)

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -25,32 +25,38 @@ print_info() {
     echo -e "${YELLOW}ℹ${NC} $1"
 }
 
-# Check if virtual environment exists
-if [ ! -d "$PROJECT_DIR/.venv" ]; then
-    print_info "Virtual environment not found. Creating one..."
-    cd "$PROJECT_DIR"
-    python3 -m venv .venv
-    print_status "Virtual environment created"
-fi
-
-# Activate virtual environment
-source "$PROJECT_DIR/.venv/bin/activate"
+# Ensure + activate the repo-local virtual environment. Only the commands
+# that actually run code need this — `install` (disabled) and the help text
+# must not bootstrap a ~498 MB venv as a side effect (issue #154).
+ensure_venv() {
+    if [ ! -d "$PROJECT_DIR/.venv" ]; then
+        print_info "Virtual environment not found. Creating one..."
+        cd "$PROJECT_DIR"
+        python3 -m venv .venv
+        print_status "Virtual environment created"
+    fi
+    # shellcheck disable=SC1091
+    source "$PROJECT_DIR/.venv/bin/activate"
+}
 
 case "${1:-}" in
     install)
-        # Disabled: this installed into the repo-local .venv (activated above),
-        # disconnected from the operator's global commands — the "complete"
-        # banner implied a global readiness it never delivered. See issue #154.
+        # Disabled: this installed into the repo-local .venv, disconnected
+        # from the operator's global commands — the "complete" banner implied
+        # a global readiness it never delivered. See issue #154.
         print_error "run.sh install is disabled: it installed into a repo-local .venv,"
-        print_error "disconnected from your global commands. For a global install:"
+        print_error "disconnected from your global commands. For a global install"
+        print_error "(puts llauncher / llauncher-ui on your PATH):"
         echo "    pip install --user -e \".[ui]\"   # from this repo, with no venv active"
         exit 1
         ;;
     mcp)
+        ensure_venv
         print_info "Starting MCP server..."
         python -m llauncher.mcp.server
         ;;
     ui)
+        ensure_venv
         print_info "Starting Streamlit UI..."
         # Bind to loopback by default. The dashboard has no built-in auth;
         # see README "Streamlit UI" + docs/plans/security-hardening-plan.md
@@ -60,16 +66,19 @@ case "${1:-}" in
             --server.address "${LAUNCHER_UI_HOST:-127.0.0.1}"
         ;;
     agent)
+        ensure_venv
         print_info "Starting remote management agent..."
         print_info "Agent will listen on 0.0.0.0:8765"
         print_info "Set LLAUNCHER_AGENT_PORT and LLAUNCHER_AGENT_NODE_NAME to customize"
         llauncher-agent
         ;;
     stop)
+        ensure_venv
         print_info "Stopping remote management agent..."
         llauncher-agent --stop
         ;;
     discover)
+        ensure_venv
         print_info "Discovering launch scripts..."
         python -m llauncher discover
         ;;
@@ -90,7 +99,7 @@ case "${1:-}" in
         echo "  LLAUNCHER_AGENT_PORT     Port to listen on (default: 8765)"
         echo "  LLAUNCHER_AGENT_NODE_NAME Friendly name for this node"
         echo ""
-        echo "First time setup:"
-        echo "  $0 install"
+        echo "First time setup (puts llauncher / llauncher-ui on your PATH):"
+        echo "  pip install --user -e \".[ui]\"   # from this repo, with no venv active"
         ;;
 esac

--- a/tests/unit/test_run_sh_install_honesty.py
+++ b/tests/unit/test_run_sh_install_honesty.py
@@ -1,0 +1,146 @@
+"""Regression guards for ``scripts/run.sh`` install honesty (issue #154).
+
+Background
+----------
+``run.sh install`` used to ``pip install`` into the repo-local ``.venv``
+while printing ``✓ Installation complete`` plus a list of ``./run.sh``
+commands — implying a *global* readiness it never delivered. The console
+scripts landed in ``.venv/bin`` and were invisible to the operator's
+global shell (``llauncher-ui`` → ``command not found``).
+
+Worse, the venv bootstrap ran *unconditionally* before the command
+dispatch, so even the now-disabled ``install`` — and a bare help
+invocation — would re-create the ~498 MB venv as a side effect.
+
+Issue #154's acceptance criteria (both pinned here):
+
+  1. ``run.sh install`` no longer implies a global readiness it didn't
+     deliver — it is disabled and points at the real global path.
+  2. The documented global launch path
+     (``pip install --user -e ".[ui]"``) is discoverable from the
+     script's own output / help.
+
+This module drives the real ``scripts/run.sh`` in a hermetic temp
+``PROJECT_DIR`` (so a stray bootstrap would land in ``tmp_path``, never
+the repo) and asserts both criteria plus the no-side-effect-venv
+guarantee for the non-runtime commands.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+GLOBAL_INSTALL_CMD = 'pip install --user -e ".[ui]"'
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until a ``.git`` entry is found."""
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+@pytest.fixture
+def run_sh(tmp_path: Path) -> Path:
+    """Copy the real ``run.sh`` into a hermetic ``PROJECT_DIR/scripts``.
+
+    ``run.sh`` derives ``PROJECT_DIR`` as the parent of its own
+    ``scripts`` dir, so any accidental ``.venv`` bootstrap lands under
+    ``tmp_path`` and is easy to assert on — the real repo is never
+    touched.
+    """
+    src = _repo_root() / "scripts" / "run.sh"
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    dest = scripts_dir / "run.sh"
+    shutil.copy2(src, dest)
+    return dest
+
+
+def _invoke(run_sh: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(run_sh), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ─────────── Criterion 1: install is honest, no global implication ──
+
+
+def test_install_is_disabled_and_nonzero(run_sh: Path):
+    """``run.sh install`` must fail loudly, not pretend success."""
+    result = _invoke(run_sh, "install")
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "disabled" in combined.lower()
+    # It must NOT claim completion / global readiness.
+    assert "Installation complete" not in combined
+    assert "complete" not in combined.lower()
+
+
+def test_install_points_at_global_path(run_sh: Path):
+    """The disabled-install message surfaces the real global command."""
+    result = _invoke(run_sh, "install")
+
+    combined = result.stdout + result.stderr
+    assert GLOBAL_INSTALL_CMD in combined
+
+
+def test_install_does_not_bootstrap_venv(run_sh: Path, tmp_path: Path):
+    """The disabled install must not create the venv it disavows.
+
+    Pre-#154 the bootstrap ran before dispatch, so ``install`` built a
+    ~498 MB venv before printing its banner. The fix moves bootstrap
+    into the runtime commands only.
+    """
+    _invoke(run_sh, "install")
+
+    assert not (tmp_path / ".venv").exists()
+
+
+# ─────────── Criterion 2: global path discoverable from help ────────
+
+
+@pytest.mark.parametrize("args", [(), ("help",), ("bogus-cmd",)])
+def test_help_surfaces_global_install_path(run_sh: Path, args: tuple[str, ...]):
+    """A bare / unknown invocation prints the global install command."""
+    result = _invoke(run_sh, *args)
+
+    combined = result.stdout + result.stderr
+    assert GLOBAL_INSTALL_CMD in combined
+
+
+def test_help_does_not_route_setup_to_disabled_install(run_sh: Path):
+    """Help must not send first-time users to the disabled ``install``.
+
+    The old help block said ``First time setup:  ./run.sh install`` —
+    a dead end now that install is disabled. The setup line must point
+    at the global pip path instead.
+    """
+    result = _invoke(run_sh)
+
+    combined = result.stdout + result.stderr
+    # The "first time setup" guidance must not name the install subcommand.
+    setup_lines = [
+        line for line in combined.splitlines() if "first time setup" in line.lower()
+    ]
+    assert setup_lines, "help should still have a first-time-setup section"
+    for line in setup_lines:
+        assert "install" not in line.lower() or "pip install" in line.lower()
+
+
+def test_help_does_not_bootstrap_venv(run_sh: Path, tmp_path: Path):
+    """Printing help must have no venv side effect."""
+    _invoke(run_sh)
+
+    assert not (tmp_path / ".venv").exists()


### PR DESCRIPTION
Closes #154.

## Problem
`run.sh install` previously installed into the repo-local `.venv` while printing a "complete" banner implying a global readiness it never delivered (console scripts landed in `.venv/bin`, invisible to the operator's PATH). Even after the prior disable of `install`, the venv bootstrap ran *unconditionally before dispatch* — so the disabled `install`, and a bare help invocation, would still re-create the ~498 MB venv as a side effect.

## Fix (smallest correct, completing the maintainer's option-1 disable honestly)
- Move the venv bootstrap into an `ensure_venv` helper called only by the runtime commands (`mcp`/`ui`/`agent`/`stop`/`discover`). `install` (disabled) and the help text no longer bootstrap a venv as a side effect.
- The disabled-`install` message now names what the global path puts on PATH (`llauncher` / `llauncher-ui`).
- Help's "First time setup" no longer routes to the now-disabled `install`; it surfaces the real global path `pip install --user -e ".[ui]"` directly.

## Acceptance (issue #154)
- `run.sh install` no longer implies global readiness — disabled, fails loud, points at the global command. ✓
- The global launch path (`pip install --user -e ".[ui]"`) is discoverable from the script's own help output. ✓

## Tests
New `tests/unit/test_run_sh_install_honesty.py` drives the real `run.sh` in a hermetic temp `PROJECT_DIR`: install is disabled/non-zero and points at the global path; help (bare/`help`/unknown) surfaces the global command and does not route setup to `install`; neither install nor help bootstraps a `.venv`.

Scope note: `run.bat` (Windows quartet) left untouched per the parked Windows-deployment posture.

Gates: full suite 1188 passed / 11 skipped; non-UI coverage 95.33% (>=93).
