### PR TITLE
docs(remote): make manual token-copy provisioning discoverable (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+### Added
+
+- **Remote-node provisioning is now discoverable (#134).** The README's
+  Multi-Node section gained an *Adding a remote node* walkthrough naming the
+  token file on each platform (`~/.llauncher/agent.token` on Linux,
+  `%USERPROFILE%\.llauncher\agent.token` on Windows) and the SSH/RDP →
+  read → copy → paste steps. The UI's Add Node form gained an info banner and
+  platform-specific API-key help text. A new `llauncher-agent print-token`
+  subcommand resolves and prints the local agent token to stdout, so
+  `ssh <box> llauncher-agent print-token` replaces file-archaeology. UI auth
+  is restored end-to-end after the security-hardening cohort
+  (#131, #132, #134). The manual copy itself is eliminated by session-token
+  issuance in a later phase (#137).
+
 ### Breaking changes
 
 - **Agent env-var family renamed (#138).** The four service-facing agent

--- a/README.md
+++ b/README.md
@@ -454,8 +454,48 @@ In the dashboard:
    - **Node Name**: Friendly name (e.g., `linux-box`, `windows-server`)
    - **Host**: IP address or hostname (e.g., `192.168.1.100`)
    - **Port**: Agent port (default: `8765`)
+   - **API Key**: the remote agent's token (see *Adding a remote node* below)
 4. Click **🔍 Test Connection** to verify
 5. Click **➕ Add Node** to register
+
+##### Adding a remote node (token walkthrough)
+
+A remote agent **always** enforces a token (auth is never off, even on
+loopback). To pair the head with a remote node you copy that token by hand —
+it currently is **not** issued automatically (session-token issuance is
+tracked under #137). Each platform keeps the token in a known file:
+
+| Platform | Token file | Mirrored from | By |
+| --- | --- | --- | --- |
+| Linux | `~/.llauncher/agent.token` | `~/.config/llauncher/agent.env` | `scripts/systemd/install.sh` |
+| Windows | `%USERPROFILE%\.llauncher\agent.token` | `agent.env` | `scripts/windows/install.ps1` |
+
+Step by step:
+
+1. **Get on the remote box.** SSH to a Linux node, or RDP to a Windows node.
+2. **Read the token.** The portable way is the agent's own subcommand, which
+   resolves the token from env / stdin / the token file and prints it to
+   stdout:
+   ```bash
+   llauncher-agent print-token
+   ```
+   If you prefer to read the file directly:
+   ```bash
+   # Linux
+   cat ~/.llauncher/agent.token
+   ```
+   ```powershell
+   # Windows (PowerShell)
+   Get-Content $env:USERPROFILE\.llauncher\agent.token
+   ```
+   Over SSH you can do both in one shot: `ssh windows-box llauncher-agent print-token`.
+3. **Copy the value.** It is a single `secrets.token_urlsafe(32)` string on
+   one line.
+4. **Paste it into the head's UI.** Back on the head machine, paste the value
+   into the **API Key** field of the **Add New Node** form (step 3 above).
+
+The token is stored on the head at `~/.llauncher/node_tokens.json` (mode 0600);
+the `local` node is excluded because its token already lives in `agent.token`.
 
 ### Network Configuration
 

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -411,7 +411,37 @@ def main() -> None:
         action="store_true",
         help="Stop any running agent and exit",
     )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["print-token"],
+        help=(
+            "Optional subcommand. 'print-token' resolves this node's agent "
+            "token (env > stdin > ~/.llauncher/agent.token) and prints it to "
+            "stdout, then exits — so an operator can copy it into the head's "
+            "Add Node form without file-archaeology (issue #134)."
+        ),
+    )
     args = parser.parse_args()
+
+    # Handle print-token subcommand: resolve and print the local token, then
+    # exit. Never auto-generates — printing a freshly minted token from a
+    # read-only command would diverge the on-disk secret; a missing token is
+    # a fail-loud config error, not a trigger to mint one.
+    if args.command == "print-token":
+        env_token = os.environ.get("LLAUNCHER_AGENT_TOKEN")
+        token = resolve_agent_token(env_value=env_token, allow_generate=False)
+        if token is None:
+            sys.stderr.write(
+                "[llauncher-agent] ERROR: no agent token found. Start the "
+                "agent once on loopback to generate ~/.llauncher/agent.token, "
+                "or set LLAUNCHER_AGENT_TOKEN.\n"
+            )
+            sys.exit(1)
+            return
+        print(token)
+        sys.exit(0)
+        return
 
     # Handle --stop flag
     if args.stop:

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -187,6 +187,14 @@ def render_add_node_form(registry: NodeRegistry) -> None:
     Args:
         registry: NodeRegistry instance.
     """
+    st.info(
+        "Adding a remote node currently requires copying the remote agent's "
+        "API token by hand. See the README section **Adding a remote node** "
+        "for the step-by-step walkthrough. Automatic session-token issuance "
+        "(#137) will eliminate this manual step in a future release.",
+        icon="🔑",
+    )
+
     with st.form("add_node_form", clear_on_submit=True):
         node_name = st.text_input(
             "Node Name",
@@ -218,9 +226,12 @@ def render_add_node_form(registry: NodeRegistry) -> None:
             "API Key",
             type="password",
             help=(
-                "Token from the remote agent's LLAUNCHER_AGENT_TOKEN / "
-                "agent.token. Required for non-loopback agents (per ADR-003). "
-                "Leave blank for unauthenticated loopback agents."
+                "On the remote box, run `llauncher-agent print-token` (or "
+                "`cat ~/.llauncher/agent.token` on Linux / "
+                "`Get-Content $env:USERPROFILE\\.llauncher\\agent.token` on "
+                "Windows) and paste the value here. Required for non-loopback "
+                "agents (per ADR-003); leave blank only for unauthenticated "
+                "loopback agents."
             ),
         )
 

--- a/tests/ui/test_nodes_tab.py
+++ b/tests/ui/test_nodes_tab.py
@@ -6,18 +6,10 @@ Two things live here:
    ``AppTest``-driven smoke that the ``#134`` salvage stopgap
    (``salvage/134-nodes-tab-test``) explicitly pointed forward to ("a real
    rendered-output smoke is deferred to the Streamlit AppTest harness (#69)").
-   It asserts the form renders its fields with the help text that *actually
-   ships* today (ADR-003 / ``LLAUNCHER_AGENT_TOKEN``).
-
-   Note on the salvage: that stopgap also pinned a manual-token-copy ``st.info``
-   banner and platform-specific (``cat`` / ``Get-Content``) API-Key help keyed
-   to issue ``#135``. That copy was never merged into ``render_add_node_form``
-   on ``main`` — it remains terser. Re-implementing those exact assertions would
-   require *adding speculative UI copy that references unshipped #135 work*,
-   which is a product decision, not a test salvage. So this file preserves the
-   salvage's intent (a rendered smoke of the Add Node form) against the shipped
-   copy and surfaces the stranded banner copy in the PR rather than fabricating
-   it.
+   It asserts the form renders its fields with the Phase 0 (#134) operability
+   copy that ships on ``main`` today: the manual-token-copy ``st.info`` banner
+   and the platform-specific (``print-token`` / ``cat`` / ``Get-Content``)
+   API-Key help, alongside the ADR-003 auth reference.
 
 2. **Behavioral remote-I/O test** — drives the tab with ``remote/`` mocked and
    asserts the UI reaches the node *only* through the ``RemoteNode`` facade
@@ -70,7 +62,8 @@ class TestNodesTabRender:
 class TestAddNodeFormSmoke:
     """Rendered-output smoke of the Add Node form (salvage #134 → #69 intent).
 
-    Pins the *shipped* operability copy, not the never-merged #134 banner.
+    Pins the shipped Phase 0 (#134) operability copy: the manual-token-copy
+    banner and the platform-specific API-Key help.
     """
 
     def test_add_node_form_fields_render(
@@ -90,19 +83,34 @@ class TestAddNodeFormSmoke:
         assert "➕ Add Node" in button_labels
         assert "🔍 Test Connection" in button_labels
 
+    def test_manual_token_copy_banner_renders(
+        self, tab_harness, mock_registry, mock_aggregator
+    ):
+        """An info banner surfaces the manual flow and its README pointer."""
+        at = tab_harness(render_nodes_tab, mock_registry, mock_aggregator)
+
+        assert not at.exception
+        banner = next(
+            el.value for el in at.info if "API token by hand" in el.value
+        )
+        assert "Adding a remote node" in banner  # README section pointer
+        assert "#137" in banner  # roadmap issue tracking the successor
+
     def test_api_key_help_documents_token_source_and_adr(
         self, tab_harness, mock_registry, mock_aggregator
     ):
         """First-contact help tells the operator what the API Key field wants.
 
-        Asserts the copy that ships on ``main`` today — the agent-token source
-        and the ADR-003 auth reference — rather than the stranded #134 banner.
+        Asserts the Phase 0 (#134) copy that ships on ``main`` today: the
+        platform-specific token-retrieval commands and the ADR-003 auth
+        reference.
         """
         at = tab_harness(render_nodes_tab, mock_registry, mock_aggregator)
 
         help_text = _input_by_label(at, "API Key").help
-        assert "LLAUNCHER_AGENT_TOKEN" in help_text
-        assert "agent.token" in help_text
+        assert "llauncher-agent print-token" in help_text
+        assert "cat ~/.llauncher/agent.token" in help_text
+        assert "Get-Content $env:USERPROFILE\\.llauncher\\agent.token" in help_text
         assert "ADR-003" in help_text
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1033,6 +1033,87 @@ class TestUtilityFunctions:
         assert exited_with == 1
         assert "test error" in error_msg
 
+    def test_main_print_token_from_env(self, monkeypatch, capsys):
+        """print-token resolves the env token, prints it, and exits 0 (#134)."""
+        from llauncher.agent.server import main
+        import sys
+
+        monkeypatch.setattr("sys.argv", ["llauncher-agent", "print-token"])
+        monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "sekret-from-env")
+
+        exited_with = None
+
+        def mock_exit(code):
+            nonlocal exited_with
+            exited_with = code
+
+        monkeypatch.setattr(sys, "exit", mock_exit)
+
+        main()
+
+        out = capsys.readouterr().out
+        assert out.strip() == "sekret-from-env"
+        assert exited_with == 0
+
+    def test_main_print_token_from_file(self, monkeypatch, capsys, tmp_path):
+        """print-token falls back to the on-disk token file (#134)."""
+        from llauncher.agent.server import main
+        import sys
+
+        monkeypatch.setattr("sys.argv", ["llauncher-agent", "print-token"])
+        monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+        token_file = tmp_path / "agent.token"
+        token_file.write_text("sekret-from-file\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "llauncher.core.agent_token.default_token_path",
+            lambda: token_file,
+        )
+
+        exited_with = None
+
+        def mock_exit(code):
+            nonlocal exited_with
+            exited_with = code
+
+        monkeypatch.setattr(sys, "exit", mock_exit)
+
+        main()
+
+        out = capsys.readouterr().out
+        assert out.strip() == "sekret-from-file"
+        assert exited_with == 0
+
+    def test_main_print_token_missing_fails_loud(self, monkeypatch, capsys, tmp_path):
+        """print-token exits 1 with a clear stderr message when no token exists (#134)."""
+        from llauncher.agent.server import main
+        import sys
+
+        monkeypatch.setattr("sys.argv", ["llauncher-agent", "print-token"])
+        monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+        # Point at a non-existent token file so resolution returns None
+        # (allow_generate=False is enforced by the subcommand).
+        monkeypatch.setattr(
+            "llauncher.core.agent_token.default_token_path",
+            lambda: tmp_path / "does-not-exist.token",
+        )
+
+        exited_with = None
+
+        def mock_exit(code):
+            nonlocal exited_with
+            exited_with = code
+
+        monkeypatch.setattr(sys, "exit", mock_exit)
+
+        main()
+
+        captured = capsys.readouterr()
+        assert exited_with == 1
+        assert captured.out == ""  # token never printed
+        assert "no agent token found" in captured.err
+
     def test_main_entry_point(self):
         """Test the if __name__ == "__main__" block."""
         # We can't easily test the actual block without importing the module as main

--- a/tests/unit/test_nodes_tab.py
+++ b/tests/unit/test_nodes_tab.py
@@ -1,0 +1,60 @@
+"""Smoke tests for the Nodes tab Add Node form copy (#134, Phase 0).
+
+These pin the operability strings shipped by the Phase 0 provisioning
+docs (issue #134 / roadmap #137): the manual-token-copy info banner and
+the platform-specific API Key help text. They use the same mock-``st``
+pattern as ``test_models_tab.py`` — a real rendered-output smoke is
+deferred to the Streamlit AppTest harness (#69).
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestAddNodeFormProvisioningCopy:
+    """Phase 0 (#134) banner + help-text strings on the Add Node form."""
+
+    def _patch_st(self, mock_st):
+        """Wire up the Streamlit mocks the form needs."""
+
+        def mock_columns(n):
+            count = len(n) if isinstance(n, list) else n
+            return [MagicMock() for _ in range(count)]
+
+        mock_st.columns.side_effect = mock_columns
+        # Neither Test Connection nor Add Node is clicked.
+        mock_st.form_submit_button.return_value = False
+        return mock_st
+
+    def _render(self, mock_st):
+        from llauncher.ui.tabs.nodes import render_add_node_form
+
+        self._patch_st(mock_st)
+        render_add_node_form(MagicMock())
+
+    def test_manual_token_copy_banner_renders(self):
+        """An info banner surfaces the manual flow and its successor."""
+        with patch("llauncher.ui.tabs.nodes.st") as mock_st:
+            self._render(mock_st)
+
+        mock_st.info.assert_called_once()
+        banner = mock_st.info.call_args.args[0]
+        assert "API token by hand" in banner
+        assert "Adding a remote node" in banner  # README section pointer
+        assert "#137" in banner  # roadmap issue tracking the successor
+
+    def test_api_key_help_names_both_platform_commands(self):
+        """First-contact help tells you what the field wants, per platform."""
+        with patch("llauncher.ui.tabs.nodes.st") as mock_st:
+            self._render(mock_st)
+
+        api_key_calls = [
+            call
+            for call in mock_st.text_input.call_args_list
+            if call.args and call.args[0] == "API Key"
+        ]
+        assert len(api_key_calls) == 1
+        help_text = api_key_calls[0].kwargs["help"]
+        assert "llauncher-agent print-token" in help_text
+        assert "cat ~/.llauncher/agent.token" in help_text
+        assert "Get-Content $env:USERPROFILE\\.llauncher\\agent.token" in help_text
+        assert "ADR-003" in help_text


### PR DESCRIPTION
Closes #134 (Phase 0, v0.3.1: operability docs for the current manual-token-copy provisioning flow). No design change — narrative + UI copy + one small CLI affordance.

## What changed

1. **README — *Adding a remote node* walkthrough.** New subsection in the Multi-Node section naming the token file on each platform (`~/.llauncher/agent.token` on Linux, `%USERPROFILE%\.llauncher\agent.token` on Windows), the mirror source/installer per platform, and the SSH/RDP → read → copy → paste steps.
2. **Add Node form help text.** Rewrote the generic API-key help into platform-specific guidance: `llauncher-agent print-token`, or `cat` (Linux) / `Get-Content` (Windows).
3. **Info banner above the Add Node form.** `st.info` block surfacing the manual nature of the flow and pointing at the README; references #137 for the future session-token issuance that eliminates the step.
4. **CLI affordance (the optional scope-call, taken).** `llauncher-agent print-token` resolves the local agent token (env > stdin > `agent.token`) and prints it to stdout. **No auto-generate** — printing a freshly minted token from a read-only command would diverge the on-disk secret, so a missing token is a fail-loud `exit(1)` with a clear stderr message. Mirrors the existing `--stop` arg-parse pattern; ~25 LOC.
5. **CHANGELOG.** Release-notes line: UI auth restored end-to-end after the security cohort (#131, #132, #134).

Took the optional CLI affordance because it is the only non-UI testable surface in the issue and makes the manual flow a one-liner (`ssh <box> llauncher-agent print-token`); README + UI copy alone carry no profiled-test surface (ui/tabs is omitted from the coverage floor).

## Exit criteria
- Operator can pair two boxes from the README alone — walkthrough names every file path and step.
- Form first-contact help tells you what the API Key field wants.
- v0.3.1 release-notes line landed in CHANGELOG.

Deferred to Phase 1 (#137), unchanged: eliminating the manual copy, token rotation on the remote, first-time provisioning before the operator has touched the remote.

## Gates
- Full pytest: **1183 passed, 11 skipped** (3 new profiled cases on `print-token`: env, file, missing-fails-loud).
- Coverage: **95.34%** (floor 93%). New `print-token` branch covered.

Do NOT merge — review first.