### PR TITLE
fix(audit-tab): forward filter selection to remote read_audit (#118)

### DIFF
--- a/llauncher/ui/tabs/audit.py
+++ b/llauncher/ui/tabs/audit.py
@@ -150,7 +150,20 @@ def render_audit_tab(
                 f"or add it on the Nodes tab."
             )
             return
-        remote_entries = node.read_audit(limit=int(limit))
+        # Forward the filter selection to the remote read so the wire
+        # payload shrinks when the user has a tight filter (issue #118).
+        # The endpoint / ``read_audit`` accept a single value each, so we
+        # can only push a selection of exactly one option down the wire;
+        # for empty or multi-value selections we fetch unfiltered and rely
+        # on the in-memory post-filter below (which also covers the
+        # single-value case, keeping behavior identical either way).
+        remote_action = selected_actions[0] if len(selected_actions) == 1 else None
+        remote_result = selected_results[0] if len(selected_results) == 1 else None
+        remote_entries = node.read_audit(
+            limit=int(limit),
+            action_filter=remote_action,
+            result_filter=remote_result,
+        )
         if remote_entries is None:
             st.error(
                 f"Could not read audit log from node '{target}' "

--- a/tests/unit/test_audit_tab.py
+++ b/tests/unit/test_audit_tab.py
@@ -172,11 +172,69 @@ class TestRemoteDispatch:
             render_audit_tab("remote-1", mock_registry)
 
             mock_registry.get_node.assert_called_once_with("remote-1")
-            mock_node.read_audit.assert_called_once_with(limit=200)
+            mock_node.read_audit.assert_called_once_with(
+                limit=200, action_filter=None, result_filter=None
+            )
             mock_local_read.assert_not_called()
             mock_st.dataframe.assert_called_once()
             df = mock_st.dataframe.call_args[0][0]
             assert df.iloc[0]["model"] == "remote-model"
+
+    def test_remote_single_filter_selection_forwarded_to_read_audit(self):
+        """A single action/result selection is pushed down to the remote
+        read so the wire payload shrinks (issue #118)."""
+        from llauncher.ui.tabs.audit import render_audit_tab
+
+        mock_node = MagicMock()
+        mock_node.read_audit.return_value = []
+        mock_registry = MagicMock()
+        mock_registry.get_node.return_value = mock_node
+
+        with _patched_st() as mock_st, patch(
+            "llauncher.ui.tabs.audit.audit_log.read_entries"
+        ):
+            mock_st.number_input.return_value = 200
+            # First multiselect call = action filter, second = result filter.
+            mock_st.multiselect.side_effect = [["started"], ["success"]]
+
+            render_audit_tab("remote-1", mock_registry)
+
+            mock_node.read_audit.assert_called_once_with(
+                limit=200, action_filter="started", result_filter="success"
+            )
+
+    def test_remote_multi_filter_selection_not_forwarded(self):
+        """A multi-value selection can't be expressed as a single query
+        param, so it is NOT pushed down; the in-memory post-filter still
+        narrows the rows, keeping behavior identical (issue #118)."""
+        from llauncher.ui.tabs.audit import render_audit_tab
+
+        remote_entries = [
+            {"action": "started", "result": "success", "model": "a", "message": ""},
+            {"action": "stopped", "result": "success", "model": "b", "message": ""},
+            {"action": "swapped", "result": "success", "model": "c", "message": ""},
+        ]
+
+        mock_node = MagicMock()
+        mock_node.read_audit.return_value = remote_entries
+        mock_registry = MagicMock()
+        mock_registry.get_node.return_value = mock_node
+
+        with _patched_st() as mock_st, patch(
+            "llauncher.ui.tabs.audit.audit_log.read_entries"
+        ):
+            mock_st.number_input.return_value = 200
+            mock_st.multiselect.side_effect = [["started", "stopped"], []]
+
+            render_audit_tab("remote-1", mock_registry)
+
+            # Two actions selected -> not forwarded (None), fetched unfiltered.
+            mock_node.read_audit.assert_called_once_with(
+                limit=200, action_filter=None, result_filter=None
+            )
+            # In-memory post-filter still narrows to the selected actions.
+            df = mock_st.dataframe.call_args[0][0]
+            assert set(df["action"].tolist()) == {"started", "stopped"}
 
     def test_remote_target_unreachable_renders_error(self):
         """``read_audit`` returning ``None`` (offline) surfaces an error."""


### PR DESCRIPTION
Closes #118.

## Problem
The audit tab dispatched remote reads via `node.read_audit(limit=int(limit))` and applied action/result filters in-memory post-read. The `GET /audit` endpoint and `RemoteNode.read_audit()` both expose `action_filter`/`result_filter`, but the UI never used them — the HTTP round-trip always fetched `limit` unfiltered entries (silent-rot risk on an end-to-end capability).

## Fix
In `llauncher/ui/tabs/audit.py`, the remote branch now forwards the user's filter selection to `read_audit`. The endpoint/method accept a single value each, while the UI uses `multiselect` (lists), so:
- A selection of exactly one action/result is pushed down the wire (smaller payload when the filter is tight).
- Empty or multi-value selections fetch unfiltered and rely on the existing in-memory post-filter.

Either way the in-memory post-filter still runs, so the rendered rows are identical — no user-visible behavior change, just a smaller wire payload in the common single-filter case.

The local-node branch is untouched (still filters in-memory off the on-disk read).

## Tests
`TestRemoteDispatch` updated:
- Existing dispatch test asserts the new `action_filter=None, result_filter=None` kwargs.
- New `test_remote_single_filter_selection_forwarded_to_read_audit` — single selection pushed down.
- New `test_remote_multi_filter_selection_not_forwarded` — multi-value not forwarded, in-memory filter still narrows rows.

## Gates
- Full suite: 1182 passed, 11 skipped.
- Coverage: 95.33% (>= 93%).