### PR TITLE
feat(systemd): UI under operator-scoped systemd --user control (ADR-022)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,7 +6,7 @@ state of the decision**, not the maturity of the ADR document itself.
 | Folder | Meaning | Count |
 |--------|---------|-------|
 | [`completed/`](./completed/) | Accepted; implementation done; no open issues tracking gaps against the ADR | 10 |
-| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 6 |
+| [`accepted/`](./accepted/) | Accepted; known partial implementation tracked as open issues, or scope explicitly deferred in the ADR's own §Deferred Work | 7 |
 | [`superseded/`](./superseded/) | Replaced by a later ADR; preserved as historical record | 2 |
 | [`draft/`](./draft/) | Not yet ratified | 1 |
 
@@ -38,6 +38,7 @@ Folder placement and in-document Status are kept in sync.
 - [ADR-015 — Orphan Policy (Annotation and Listing)](./accepted/015-orphan-policy.md) — `adopt` verb deferred per §Deferred Work
 - [ADR-018 — llauncher as a System Service](./accepted/018-llauncher-system-service.md) — `--system` install mode landed (#194); host provisioning (#196) and `LAUNCHER_STATE_DIR` Python support (#197) tracked separately; supersedes ADR-009's deployment posture
 - [ADR-LLNCH-019 — Server-Metrics Surface (Live In-Server Inference Telemetry)](./accepted/adr-llnch-019-server-metrics-surface.md) — ratified; implementation not yet begun; deferred scope tracked #174/#175/#176
+- [ADR-022 — llauncher UI under Operator-Scoped `systemd --user` Control](./accepted/022-llauncher-ui-user-service.md) — per-operator user unit (`scripts/systemd/llauncher-ui.service.user.in` + `install-ui.sh`); narrows ADR-018's UI posture; `/usr/local/bin` symlink (`install-cli.sh`, root) and `inference`-group membership are operator/host steps (#223)
 
 ### Draft
 

--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -1,6 +1,6 @@
 # Running `llauncher-agent` as a Service
 
-The agent is the daemon piece of llauncher. The UI's service posture is governed by [ADR-022](../adrs/accepted/022-llauncher-ui-user-service.md): it is **decided** to run as a per-operator systemd --user unit, with **implementation pending**. Until that lands, the UI is still hand-launched (below). This doc covers persistent installs on:
+The agent is the daemon piece of llauncher. The UI's service posture is governed by [ADR-022](../adrs/accepted/022-llauncher-ui-user-service.md): it runs as a per-operator `systemd --user` unit, installed via [`scripts/systemd/install-ui.sh`](#ubuntu--linux-ui-systemd-user-unit) (see the UI section below). Two operator/host steps sit outside that installer: the `/usr/local/bin/llauncher-ui` symlink (placed by `install-cli.sh`, as root) and the caller's `inference`-group membership (host provisioning). This doc covers persistent installs on:
 
 - Linux (systemd, user-mode)
 - Windows (NSSM-wrapped service)
@@ -92,6 +92,83 @@ systemctl --user restart llauncher-agent
 
 The env file is left in place; remove it manually if you want a fully
 clean state.
+
+---
+
+## Ubuntu / Linux (UI systemd --user unit)
+
+The Streamlit UI is a per-operator front-end, not machine infrastructure
+(loopback-only, no built-in auth, matters only while an operator is
+watching). [ADR-022](../adrs/accepted/022-llauncher-ui-user-service.md)
+runs it as a `systemd --user` unit owned by your login session — never a
+system unit, never root.
+
+### Operator/host preconditions (NOT done by the installer)
+
+1. **The `/usr/local/bin/llauncher-ui` symlink** the unit's `ExecStart`
+   points at. Place it once, as root:
+
+   ```bash
+   sudo bash scripts/systemd/install-cli.sh
+   ```
+
+   This installs `llauncher` (+ `llauncher-mcp`, `llauncher-ui`) into a
+   dedicated `/opt/llauncher/venv` and symlinks the console scripts into
+   `/usr/local/bin`.
+
+2. **`inference`-group membership** for your account. The UI reads the
+   system agent's token (`/var/lib/llauncher/agent.token`, mode `0640`
+   `root:inference`) in place via group membership — no copy. Group
+   provisioning is a host step (harness-tools
+   `setup-inference-lane.sh`):
+
+   ```bash
+   sudo usermod -aG inference "$USER"   # then re-login
+   ```
+
+`install-ui.sh` *warns* (does not block) if either is missing, so the
+unit can be rendered now and becomes functional once provisioning lands.
+
+### Install
+
+```bash
+./scripts/systemd/install-ui.sh
+```
+
+The installer (as your own account, NOT root):
+
+- Copies the fixed unit template to
+  `~/.config/systemd/user/llauncher-ui.service`. The template hardcodes
+  `Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher` — the one line that
+  makes the UI read the system agent's token instead of `~/.llauncher`;
+  it is **not** overridable from the installer's environment.
+- Runs `systemctl --user daemon-reload`, `enable --now`.
+
+It is idempotent — re-run it to pick up a `git pull` that touches the
+template.
+
+### Autostart at boot / survive logout (optional)
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+Optional and your call — the installer prints this as guidance but never
+runs it.
+
+### Operate
+
+```bash
+systemctl --user status llauncher-ui
+systemctl --user restart llauncher-ui
+journalctl --user -u llauncher-ui -f      # live logs
+```
+
+### Uninstall
+
+```bash
+./scripts/systemd/install-ui.sh --uninstall
+```
 
 ---
 

--- a/scripts/systemd/install-cli.sh
+++ b/scripts/systemd/install-cli.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-cli.sh — system install of the llauncher CLI from public origin/main.
+# ----------------------------------------------------------------------------
+# Installs `llauncher` (+ llauncher-mcp, llauncher-ui) onto the system PATH for
+# ALL accounts, pulled from the PUBLIC GitHub repo — decoupled from any dev
+# checkout and from any dev .venv. A dedicated venv lives at /opt/llauncher/venv
+# (its own Python, NOT added to PATH); only the console-script entry points are
+# symlinked into /usr/local/bin (already on every account's PATH). No venv bin
+# directory is ever placed on PATH.
+#
+# Usage (root):
+#   sudo bash scripts/systemd/install-cli.sh                 # install/refresh from main
+#   sudo REF=v0.4.0-alpha bash scripts/systemd/install-cli.sh  # pin a tag/branch/SHA
+#   sudo bash scripts/systemd/install-cli.sh --uninstall
+#
+# Re-runnable: re-running refreshes the install to the current REF.
+#
+# Pairs with a system-wide state dir so the CLI sees live system state:
+#   echo 'LAUNCHER_STATE_DIR=/var/lib/llauncher' | sudo tee /etc/profile.d/llauncher.sh
+#   sudo usermod -aG inference <user>   # read access to /var/lib/llauncher
+# ----------------------------------------------------------------------------
+set -euo pipefail
+
+REPO_URL="https://github.com/shanevcantwell/llauncher.git"
+REF="${REF:-main}"
+PREFIX="/opt/llauncher"
+VENV="$PREFIX/venv"
+BINDIR="/usr/local/bin"
+SCRIPTS=(llauncher llauncher-mcp llauncher-ui)
+
+[ "$(id -u)" -eq 0 ] || { echo "FATAL: run as root (sudo bash $0)"; exit 1; }
+
+if [ "${1:-}" = "--uninstall" ]; then
+    for s in "${SCRIPTS[@]}"; do rm -f "$BINDIR/$s" && echo "removed $BINDIR/$s"; done
+    rm -rf "$PREFIX" && echo "removed $PREFIX"
+    echo "Uninstalled."
+    exit 0
+fi
+
+command -v python3 >/dev/null || { echo "FATAL: python3 not found"; exit 1; }
+command -v git     >/dev/null || { echo "FATAL: git not found (needed for the git+https install)"; exit 1; }
+
+echo "==> dedicated venv at $VENV (own Python; independent of any dev .venv; not on PATH)"
+mkdir -p "$PREFIX"
+[ -x "$VENV/bin/python" ] || python3 -m venv "$VENV"
+"$VENV/bin/pip" install --quiet --upgrade pip
+
+echo "==> installing llauncher[ui] from public $REPO_URL @ $REF"
+"$VENV/bin/pip" install --quiet --upgrade "llauncher[ui] @ git+$REPO_URL@$REF"
+
+echo "==> symlinking console scripts into $BINDIR (venv bin stays off PATH)"
+for s in "${SCRIPTS[@]}"; do
+    ln -sfn "$VENV/bin/$s" "$BINDIR/$s"
+    echo "    $BINDIR/$s -> $VENV/bin/$s"
+done
+
+# world-readable/executable so every account can run the shared install
+chmod -R a+rX "$PREFIX"
+
+echo "==> verify"
+"$VENV/bin/python" -c "import llauncher; print('    installed llauncher', llauncher.__version__)"
+for s in "${SCRIPTS[@]}"; do command -v "$s" >/dev/null && echo "    ok: $s resolves on PATH"; done
+echo "Done — 'llauncher' is available to all accounts via $BINDIR (from public $REF), with no dev-.venv dependency."

--- a/scripts/systemd/install-ui.sh
+++ b/scripts/systemd/install-ui.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# install-ui.sh — install / refresh the llauncher UI as a systemd --user unit.
+#
+# Per-operator, unprivileged, session-managed. Renders
+# llauncher-ui.service.user.in into ~/.config/systemd/user/ and runs
+# `systemctl --user enable --now`. See ADR-022 (narrows ADR-018's UI posture):
+# the agent is a system service; the UI is a per-operator `systemd --user` unit.
+#
+# Run as your OWN operator account — NOT root. The token-read path works in
+# place via your `inference`-group membership (host provisioning); the
+# /usr/local/bin/llauncher-ui symlink is placed by install-cli.sh (root).
+# Neither is this installer's job — it only warns if they are missing.
+#
+# LAUNCHER_STATE_DIR comes from the template (fixed at /var/lib/llauncher); it
+# is intentionally NOT overridable from this installer's caller environment.
+#
+# Idempotent: safe to re-run after a `git pull` to pick up unit changes.
+#
+# Usage:
+#   ./scripts/systemd/install-ui.sh             # render + enable + start
+#   ./scripts/systemd/install-ui.sh --uninstall # disable + remove unit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/llauncher-ui.service.user.in"
+UI_BIN="/usr/local/bin/llauncher-ui"
+
+UNIT_NAME="llauncher-ui.service"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT_PATH="$UNIT_DIR/$UNIT_NAME"
+
+# Colors
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+say()  { echo -e "${GREEN}✓${NC} $1"; }
+info() { echo -e "${YELLOW}ℹ${NC} $1"; }
+err()  { echo -e "${RED}✗${NC} $1" >&2; }
+
+# --- Argument parsing --------------------------------------------------
+DO_UNINSTALL=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall) DO_UNINSTALL=1 ;;
+        *)           err "Unknown argument: $1"; exit 2 ;;
+    esac
+    shift
+done
+
+if [ "$(id -u)" -eq 0 ]; then
+    err "Run as your own operator account, NOT root."
+    err "This is a 'systemctl --user' unit owned by your login session (ADR-022)."
+    exit 1
+fi
+
+if ! command -v systemctl >/dev/null; then
+    err "systemctl not found — this installer targets systemd hosts only."
+    exit 1
+fi
+
+uninstall() {
+    info "Stopping and disabling $UNIT_NAME..."
+    systemctl --user disable --now "$UNIT_NAME" 2>/dev/null || true
+    if [ -f "$UNIT_PATH" ]; then
+        rm -f "$UNIT_PATH"
+        say "Removed $UNIT_PATH"
+    fi
+    systemctl --user daemon-reload
+    say "Uninstalled."
+    exit 0
+}
+
+[ "$DO_UNINSTALL" -eq 1 ] && uninstall
+
+# --- Preflight (warn, do NOT block) ------------------------------------
+# Both conditions are operator/host provisioning, out of this installer's
+# scope (ADR-022 §installer-vs-host-provisioning). Warn loudly so the cause
+# of a later failure is legible, but proceed — the unit can be rendered and
+# enabled now; it will become functional once provisioning is in place.
+if [ ! -x "$UI_BIN" ]; then
+    info "[user:gate] $UI_BIN is absent. The unit's ExecStart points there."
+    info "  Run the CLI installer as root first:"
+    info "    sudo bash $SCRIPT_DIR/install-cli.sh"
+    info "  Until then the service will fail to start."
+fi
+
+if ! getent group inference >/dev/null 2>&1; then
+    info "Group 'inference' does not exist on this host. The UI reads the system"
+    info "  agent's token (/var/lib/llauncher/agent.token, 0640 root:inference) via"
+    info "  group membership; token reads will fail until the group is provisioned"
+    info "  (host provisioning, out of installer scope)."
+elif ! id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx inference; then
+    info "$USER is not a member of group 'inference'. The UI reads the system"
+    info "  agent's token (/var/lib/llauncher/agent.token, 0640 root:inference) via"
+    info "  group membership; token reads will fail until you are added"
+    info "    sudo usermod -aG inference $USER   # host provisioning, then re-login"
+fi
+
+# --- Render ------------------------------------------------------------
+# LAUNCHER_STATE_DIR is fixed in the template; this is a straight copy (no sed,
+# no placeholders), so the caller's environment cannot override it.
+mkdir -p "$UNIT_DIR"
+cp "$TEMPLATE" "$UNIT_PATH"
+say "Rendered unit to $UNIT_PATH"
+
+# --- Activate ----------------------------------------------------------
+systemctl --user daemon-reload
+systemctl --user enable --now "$UNIT_NAME"
+say "Enabled and started $UNIT_NAME"
+
+cat <<EOF
+
+Next steps:
+  systemctl --user status llauncher-ui
+  journalctl --user -u llauncher-ui -f
+
+Optional — autostart at boot / survive logout (run once, your call):
+  loginctl enable-linger "$USER"
+
+To uninstall:
+  $SCRIPT_DIR/install-ui.sh --uninstall
+EOF

--- a/scripts/systemd/llauncher-ui.service.user.in
+++ b/scripts/systemd/llauncher-ui.service.user.in
@@ -1,0 +1,51 @@
+; llauncher Streamlit UI — systemd *user* unit template.
+;
+; Do not install this file directly. Run `scripts/systemd/install-ui.sh`
+; (as your own operator account, NOT root), which copies this template to
+; ${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/llauncher-ui.service and
+; runs `systemctl --user enable --now`.
+;
+; This unit has NO @…@ placeholders: every value is fixed. The UI runs as the
+; caller's own uid (no User=/Group=/EnvironmentFile=) — it is an unprivileged,
+; loopback-only (127.0.0.1) per-operator front-end, not machine infrastructure.
+; See ADR-022 (narrows ADR-018's UI posture): the agent is a system service,
+; the UI is a per-operator `systemd --user` unit.
+;
+; The /usr/local/bin/llauncher-ui symlink is placed by
+; scripts/systemd/install-cli.sh (root). Group `inference` membership for the
+; caller is host provisioning. Neither is the installer's job.
+
+[Unit]
+Description=llauncher Streamlit UI (per-operator user service)
+Documentation=https://github.com/shanevcantwell/llauncher
+After=network-online.target
+Wants=network-online.target
+; Crash-loop guard mirrors the agent unit
+; (scripts/systemd/llauncher-agent.service.system.in): restart aggressively,
+; but if the unit fails 10 times inside a minute treat it as a config problem
+; and give up. ADR-022 §Open Questions deferred this policy to the build; the
+; UI and agent share the same supervised-process failure shape, so the agent's
+; values carry over unchanged.
+; (StartLimit* live in [Unit] since systemd 230; [Service] is deprecated.)
+StartLimitBurst=10
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+; The single non-negotiable line: without it the UI reads ~/.llauncher and
+; misses the system agent's /var/lib/llauncher/agent.token (0640 root:inference),
+; which the caller reads in place via `inference`-group membership. The value is
+; fixed at process start — exactly when systemd injects the unit env. See
+; ADR-022 §Open Questions and core/agent_token.py::default_token_path().
+Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher
+ExecStart=/usr/local/bin/llauncher-ui
+
+Restart=on-failure
+RestartSec=5
+
+; journald (per-user) captures stdout/stderr by default — view with
+;   journalctl --user -u llauncher-ui -f
+
+[Install]
+; User units want default.target, NOT multi-user.target.
+WantedBy=default.target


### PR DESCRIPTION
Implements accepted **ADR-022** (`docs/adrs/accepted/022-llauncher-ui-user-service.md`): puts the Streamlit UI under per-operator `systemd --user` control.

**Adds**
- `scripts/systemd/llauncher-ui.service.user.in` — user-scoped unit. `ExecStart=/usr/local/bin/llauncher-ui`; `Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher` (mandatory — without it the UI reads `~/.llauncher` and misses the system agent's `0640 root:inference` token); `WantedBy=default.target`; no `User=`/`EnvironmentFile=`. `Restart=on-failure` mirrors the agent unit.
- `scripts/systemd/install-ui.sh` — renders the unit into `~/.config/systemd/user/`, `systemctl --user enable --now`; preflight warns (not blocks) on missing `/usr/local/bin/llauncher-ui` symlink or missing `inference`-group membership; prints `loginctl enable-linger` guidance; idempotent; `--uninstall` path.
- Tracks `scripts/systemd/install-cli.sh` (symlinks `llauncher-ui` → `/usr/local/bin`; previously untracked, byte-identical to and superseding the inert `feat/systemd-cli-installer` branch).
- Docs: ADR index row for 022; `run-as-a-service.md` references `install-ui.sh`.

**Install boundary (`user:gate`, NOT done by merging this):** the `/usr/local/bin/llauncher-ui` symlink (root, via `install-cli.sh`) and operator ∈ `inference` group (host provisioning). `enable-linger` is optional.

**Gates:** pytest green + non-UI coverage ≥93% (no new Python; token-read path already covered); `bash -n`; `systemd-analyze verify` on the rendered unit.

Refs #223. Closes the ADR-022 build.