### PR TITLE
ADR-023 Phase A (#227): agent venv ensure-unit — guaranteed recomposition

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # llauncher - Linux/Mac runner script
-# Usage: ./run.sh [mcp|ui|agent|discover|install]
+# Usage: ./run.sh [mcp|ui|agent|discover|setup|install]
 
 set -e
 
@@ -40,6 +40,43 @@ ensure_venv() {
 }
 
 case "${1:-}" in
+    setup)
+        # Recompose the agent venv from pyproject.toml (ADR-023, issue #227).
+        #
+        # This is the single, named recompose command the system ensure unit
+        # (llauncher-agent-ensure-venv.service) calls, and the live successor
+        # to the disabled `install` pointer (issue #154). It REUSES the one
+        # venv-creation path — ensure_venv (added by #219, which only CREATES
+        # the venv) — and adds the POPULATE step on top, rather than
+        # parallel-implementing a second venv builder.
+        #
+        # OQ3 (lazy re-heal): existence-check on the entry point. If the
+        # venv already resolves `llauncher-agent`, this is a no-op — we
+        # recompose only when missing/broken, never eagerly every boot.
+        # OQ2 (minimal): rebuild from pyproject.toml `>=` floors via an
+        # editable install; no lockfile (deferred to ADR-023 Phase C).
+        if [ -x "$PROJECT_DIR/.venv/bin/llauncher-agent" ]; then
+            print_status "Agent venv already populated (llauncher-agent present) — nothing to recompose."
+            exit 0
+        fi
+        ensure_venv  # creates + activates .venv (the #219 path); do not duplicate it
+        print_info "Recomposing agent venv from $PROJECT_DIR/pyproject.toml (editable install)..."
+        # Fail-loud: a nonzero pip recompose must abort with an actionable
+        # message so the ensure unit enters `failed` and the agent (which
+        # Requires= it) never starts against a half-built venv.
+        if ! pip install -e "$PROJECT_DIR"; then
+            print_error "Recompose FAILED: 'pip install -e $PROJECT_DIR' returned nonzero."
+            print_error "The agent venv at $PROJECT_DIR/.venv is NOT usable. Resolve the error"
+            print_error "above (network down? broken pyproject.toml?) and re-run: ./scripts/run.sh setup"
+            exit 1
+        fi
+        if [ ! -x "$PROJECT_DIR/.venv/bin/llauncher-agent" ]; then
+            print_error "Recompose INCOMPLETE: the llauncher-agent entry point is still missing"
+            print_error "after 'pip install -e'. Refusing to report success (fail-loud, ADR-023)."
+            exit 1
+        fi
+        print_status "Agent venv recomposed: $PROJECT_DIR/.venv/bin/llauncher-agent present."
+        ;;
     install)
         # Disabled: this installed into the repo-local .venv, disconnected
         # from the operator's global commands — the "complete" banner implied
@@ -93,6 +130,7 @@ case "${1:-}" in
         echo "  ui        Start Streamlit UI (requires agent; start it first)"
         echo "  stop      Stop running agent"
         echo "  discover  List discovered launch scripts"
+        echo "  setup     Recompose the agent .venv from pyproject.toml (editable install)"
         echo ""
         echo "Environment variables for agent:"
         echo "  LLAUNCHER_AGENT_HOST     Host to bind to (default: 0.0.0.0)"

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -28,6 +28,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VENV_BIN="$PROJECT_DIR/.venv/bin"
 
 UNIT_NAME="llauncher-agent.service"
+# Root oneshot that guarantees the agent venv (system mode only; ADR-023/#227).
+ENSURE_UNIT_NAME="llauncher-agent-ensure-venv.service"
 ENV_EXAMPLE="$SCRIPT_DIR/llauncher-agent.env.example"
 
 # Colors
@@ -98,6 +100,14 @@ uninstall() {
         rm -f "$UNIT_PATH"
         say "Removed $UNIT_PATH"
     fi
+    # Tear down the system-scope ensure unit alongside the agent (ADR-023/#227).
+    if [ "$MODE" = "system" ]; then
+        "${SYSTEMCTL[@]}" disable --now "$ENSURE_UNIT_NAME" 2>/dev/null || true
+        if [ -f "$UNIT_DIR/$ENSURE_UNIT_NAME" ]; then
+            rm -f "$UNIT_DIR/$ENSURE_UNIT_NAME"
+            say "Removed $UNIT_DIR/$ENSURE_UNIT_NAME"
+        fi
+    fi
     "${SYSTEMCTL[@]}" daemon-reload
     info "Env file left in place at $ENV_FILE (delete manually if desired)."
     info "Token file left in place at $TOKEN_FILE (delete manually if desired)."
@@ -110,7 +120,7 @@ uninstall() {
 # --- Preflight ---------------------------------------------------------
 if [ ! -x "$VENV_BIN/llauncher-agent" ]; then
     err "Did not find $VENV_BIN/llauncher-agent."
-    err "Run './scripts/run.sh install' first to create the venv."
+    err "Run './scripts/run.sh setup' first to recompose the venv (ADR-023)."
     exit 1
 fi
 
@@ -212,7 +222,26 @@ sed \
     "$TEMPLATE" > "$UNIT_PATH"
 say "Rendered unit to $UNIT_PATH"
 
+# --- Ensure-venv unit (system scope only; ADR-023 / #227) --------------
+# The agent system unit Requires=/After= this root oneshot so the agent never
+# starts against a missing/broken venv. It is system-scoped because recompose
+# must run where the dev-tree .venv is writable (root), not as User=llauncher.
+# User mode owns its own venv via `run.sh setup` at launch, so it gets no
+# ensure unit here.
+if [ "$MODE" = "system" ]; then
+    ENSURE_TEMPLATE="$SCRIPT_DIR/llauncher-agent-ensure-venv.service.in"
+    ENSURE_UNIT_PATH="$UNIT_DIR/$ENSURE_UNIT_NAME"
+    sed \
+        -e "s|@PROJECT_DIR@|$PROJECT_DIR|g" \
+        "$ENSURE_TEMPLATE" > "$ENSURE_UNIT_PATH"
+    say "Rendered ensure unit to $ENSURE_UNIT_PATH"
+fi
+
 "${SYSTEMCTL[@]}" daemon-reload
+if [ "$MODE" = "system" ]; then
+    "${SYSTEMCTL[@]}" enable "$ENSURE_UNIT_NAME" >/dev/null
+    say "Enabled $ENSURE_UNIT_NAME"
+fi
 "${SYSTEMCTL[@]}" enable "$UNIT_NAME" >/dev/null
 say "Enabled $UNIT_NAME"
 

--- a/scripts/systemd/llauncher-agent-ensure-venv.service.in
+++ b/scripts/systemd/llauncher-agent-ensure-venv.service.in
@@ -1,0 +1,44 @@
+; llauncher agent venv-ensure — systemd *system* oneshot unit template.
+;
+; Do not install this file directly. Run `scripts/systemd/install.sh --system`
+; (as root), which substitutes the @TOKENS@ below and drops the rendered unit
+; at /etc/systemd/system/llauncher-agent-ensure-venv.service.
+;
+; ADR-023 (issue #227): the agent unit's ExecStart resolves into
+; @PROJECT_DIR@/.venv, but the operator treats venvs as non-durable (freely
+; reaped by a disk sweep). This oneshot RE-COUPLES that reference to its
+; lifecycle: it guarantees the venv exists before the agent starts, recomposing
+; it from the git-tracked pyproject.toml when missing/broken. The agent unit
+; Requires=/After= this unit, so the agent never starts against a venv that
+; isn't there (invariant VENV-OWNED-OR-GUARANTEED / PARSE-AT-THE-DOOR).
+;
+; Runs as ROOT (no User=): the agent runs as User=llauncher, which cannot be
+; relied on to own the dev tree where .venv lives. Recompose lives where the
+; venv's write permission lives — root scope for the dev tree (ADR-023).
+
+[Unit]
+Description=llauncher agent venv recomposition (guarantee .venv before agent start)
+Documentation=https://github.com/shanevcantwell/llauncher
+; Recompose is a network-bound `pip install` (editable, from the local tree);
+; gate it behind the network like the agent unit it precedes.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+; Hold `active` after exit so the agent's Requires=/After= is satisfied for the
+; whole agent lifetime, not just the instant the oneshot ran.
+RemainAfterExit=yes
+; OQ4 (ADR-023): recompose ceiling. A first-start-after-reap `pip install` can
+; run tens of seconds to minutes; 300s isolates that latency here (away from the
+; agent's own TimeoutStartSec) and treats anything slower as a failed recompose.
+TimeoutStartSec=300
+WorkingDirectory=@PROJECT_DIR@
+; The single named recompose path (run.sh setup): existence-checked (OQ3 lazy
+; re-heal — no-op when the entry point is present), fail-loud on a broken
+; recompose (nonzero -> this unit `failed` -> agent does not start). Reuses
+; run.sh's ensure_venv (issue #219) rather than a second venv builder.
+ExecStart=@PROJECT_DIR@/scripts/run.sh setup
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/llauncher-agent.service.system.in
+++ b/scripts/systemd/llauncher-agent.service.system.in
@@ -17,6 +17,13 @@ Description=llauncher remote management agent (system service)
 Documentation=https://github.com/shanevcantwell/llauncher
 After=network-online.target
 Wants=network-online.target
+; ADR-023 (issue #227): never start against a missing/broken venv. The ensure
+; oneshot recomposes @PROJECT_DIR@/.venv from pyproject.toml and fails loud if
+; it can't; Requires= propagates that failure (the agent does NOT start), After=
+; orders us strictly after the venv is guaranteed (invariant
+; VENV-OWNED-OR-GUARANTEED).
+Requires=llauncher-agent-ensure-venv.service
+After=llauncher-agent-ensure-venv.service
 ; Crash-loop guard: restart aggressively, but if the unit fails 10
 ; times inside a minute treat it as a config problem and give up.
 ; (StartLimit* live in [Unit] since systemd 230; [Service] is deprecated.)

--- a/tests/unit/test_agent_ensure_venv.py
+++ b/tests/unit/test_agent_ensure_venv.py
@@ -1,0 +1,221 @@
+"""Guards for ADR-023 Phase A — agent venv recomposition (issue #227).
+
+Two surfaces are exercised here:
+
+1. ``scripts/run.sh setup`` — the single, named recompose command the system
+   ensure unit calls. It must (a) lazily no-op when the agent entry point is
+   already present (OQ3 lazy re-heal), (b) populate the venv via an editable
+   install of ``pyproject.toml`` when missing (OQ2 minimal — no lockfile), and
+   (c) fail loud (nonzero) on a broken recompose so the ensure unit enters
+   ``failed`` and the agent never starts degraded.
+
+2. The static wiring — the ``llauncher-agent-ensure-venv.service.in`` oneshot
+   template, the agent system unit's ``Requires=``/``After=`` on it, and
+   ``install.sh``'s render+enable+uninstall mechanics.
+
+The ``run.sh`` tests drive the *real* script in a hermetic temp ``PROJECT_DIR``
+with a *fake* ``.venv`` (a stub ``activate`` + ``pip``), so no network ``pip
+install`` runs and the real repo is never touched — mirroring the fixture style
+of ``test_run_sh_install_honesty.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until a ``.git`` entry is found."""
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+SYSTEMD_DIR = _repo_root() / "scripts" / "systemd"
+ENSURE_TEMPLATE = SYSTEMD_DIR / "llauncher-agent-ensure-venv.service.in"
+AGENT_SYSTEM_UNIT = SYSTEMD_DIR / "llauncher-agent.service.system.in"
+INSTALL_SH = SYSTEMD_DIR / "install.sh"
+
+
+# ───────────────────────── run.sh setup behavior ───────────────────────
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """A hermetic PROJECT_DIR with the real ``run.sh`` and a ``pyproject``.
+
+    ``run.sh`` derives ``PROJECT_DIR`` as the parent of its own ``scripts``
+    dir, so everything stays under ``tmp_path``.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy2(_repo_root() / "scripts" / "run.sh", scripts_dir / "run.sh")
+    # A pyproject must exist so the editable-install target is plausible; the
+    # stub pip ignores its contents.
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='stub'\n")
+    return tmp_path
+
+
+def _make_fake_venv(project_dir: Path, *, pip_creates_entrypoint: bool,
+                    pip_returns: int) -> Path:
+    """Build a fake ``.venv`` with stub ``activate`` + ``pip``.
+
+    ``activate`` prepends the venv ``bin`` to PATH (so ``pip`` resolves to the
+    stub), matching what a real venv activate does. The stub ``pip`` simulates
+    an editable install: optionally drops the ``llauncher-agent`` entry point
+    and exits with ``pip_returns``.
+    """
+    venv_bin = project_dir / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+
+    (venv_bin / "activate").write_text(f'export PATH="{venv_bin}:$PATH"\n')
+
+    create = (
+        f'touch "{venv_bin}/llauncher-agent" && chmod +x "{venv_bin}/llauncher-agent"\n'
+        if pip_creates_entrypoint
+        else ""
+    )
+    pip = venv_bin / "pip"
+    pip.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = "install" ]; then\n'
+        f"  {create}"
+        f"  exit {pip_returns}\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    pip.chmod(0o755)
+    return venv_bin
+
+
+def _run_setup(project_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(project_dir / "scripts" / "run.sh"), "setup"],
+        capture_output=True,
+        text=True,
+        check=False,
+        # Drop the test venv's bin from PATH so only the stub pip is reachable.
+        env={**os.environ, "VIRTUAL_ENV": ""},
+    )
+
+
+def test_setup_lazy_noop_when_entrypoint_present(project_dir: Path):
+    """OQ3: present entry point ⇒ no recompose, clean exit."""
+    venv_bin = project_dir / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    ep = venv_bin / "llauncher-agent"
+    ep.write_text("#!/bin/sh\n")
+    ep.chmod(0o755)
+
+    result = _run_setup(project_dir)
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "already populated" in combined
+    # It must NOT have entered the recompose branch.
+    assert "Recomposing" not in combined
+
+
+def test_setup_populates_when_missing(project_dir: Path):
+    """Missing entry point ⇒ editable install runs and yields the entry point."""
+    venv_bin = _make_fake_venv(
+        project_dir, pip_creates_entrypoint=True, pip_returns=0
+    )
+
+    result = _run_setup(project_dir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "Recomposing agent venv" in combined
+    assert "recomposed" in combined
+    assert (venv_bin / "llauncher-agent").exists()
+
+
+def test_setup_fails_loud_on_pip_error(project_dir: Path):
+    """Fail-loud: nonzero pip ⇒ nonzero exit + actionable message, no success."""
+    _make_fake_venv(project_dir, pip_creates_entrypoint=False, pip_returns=1)
+
+    result = _run_setup(project_dir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "FAILED" in combined
+    assert "run.sh setup" in combined  # actionable remediation
+    assert "recomposed" not in combined
+
+
+def test_setup_fails_loud_when_entrypoint_absent_after_install(project_dir: Path):
+    """A pip that 'succeeds' but leaves no entry point must still fail loud."""
+    _make_fake_venv(project_dir, pip_creates_entrypoint=False, pip_returns=0)
+
+    result = _run_setup(project_dir)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "INCOMPLETE" in combined
+    assert "recomposed" not in combined
+
+
+def test_setup_listed_in_help(project_dir: Path):
+    """The new subcommand is discoverable from the help output."""
+    result = subprocess.run(
+        ["bash", str(project_dir / "scripts" / "run.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert "setup" in combined
+
+
+# ───────────────────────── static unit / install wiring ────────────────
+
+
+def test_ensure_unit_template_shape():
+    """The oneshot ensure template carries the ADR-023 OQ guarantees."""
+    text = ENSURE_TEMPLATE.read_text()
+    assert "Type=oneshot" in text
+    assert "RemainAfterExit=yes" in text
+    assert "TimeoutStartSec=300" in text  # OQ4
+    assert "ExecStart=@PROJECT_DIR@/scripts/run.sh setup" in text
+    # Runs as root: no active User= directive (comment lines start with ';').
+    directives = [
+        ln.strip() for ln in text.splitlines() if not ln.lstrip().startswith(";")
+    ]
+    assert not any(ln.startswith("User=") for ln in directives)
+
+
+def test_agent_system_unit_requires_ensure_unit():
+    """The agent never starts without the guaranteed venv (Requires + After)."""
+    text = AGENT_SYSTEM_UNIT.read_text()
+    assert "Requires=llauncher-agent-ensure-venv.service" in text
+    assert "After=llauncher-agent-ensure-venv.service" in text
+
+
+def test_user_agent_unit_has_no_cross_scope_dependency():
+    """The --user agent unit must NOT Requires= a system-scope ensure unit."""
+    text = (SYSTEMD_DIR / "llauncher-agent.service.in").read_text()
+    assert "ensure-venv" not in text
+
+
+def test_install_sh_wires_ensure_unit_in_system_mode():
+    """install.sh renders + enables + uninstalls the ensure unit (system only)."""
+    text = INSTALL_SH.read_text()
+    assert 'ENSURE_UNIT_NAME="llauncher-agent-ensure-venv.service"' in text
+    assert "llauncher-agent-ensure-venv.service.in" in text  # template render
+    assert 'enable "$ENSURE_UNIT_NAME"' in text
+    assert 'disable --now "$ENSURE_UNIT_NAME"' in text  # uninstall path
+
+
+def test_install_sh_dead_pointer_replaced():
+    """The disabled 'run.sh install' pointer is replaced by 'run.sh setup'."""
+    text = INSTALL_SH.read_text()
+    assert "run.sh install" not in text
+    assert "run.sh setup" in text


### PR DESCRIPTION
Implements **Phase A of ADR-023** (`VENV-OWNED-OR-GUARANTEED`): the agent system service now *guarantees* its venv's recomposition instead of assuming it. Closes #227.

## What
- **New root oneshot** `scripts/systemd/llauncher-agent-ensure-venv.service.in` — recomposes `$PROJECT_DIR/.venv` from `pyproject.toml` when missing/broken, before the agent starts.
- **`llauncher-agent.service`** gains `Requires=`/`After=` the ensure unit → never starts without a guaranteed venv.
- **New `run.sh setup`** subcommand — the single named recompose path: reuses `ensure_venv()` (from #219) for creation + adds the populate step (`pip install -e .`). The ensure unit's `ExecStart` is just `run.sh setup` — no parallel venv-creation code path (the #219 review flagged this explicitly).
- **`install.sh`** renders/enables the unit in `--system` mode; tears it down on `--uninstall`.
- **Tests:** `tests/unit/test_agent_ensure_venv.py` (10) — lazy re-heal, populate, fail-loud, and static unit/install wiring.

## Operator decisions baked in
- **OQ2 = minimal:** recompose from `pyproject.toml` `>=` floors; **no lockfile** (reproducibility deferred to a separate `auto:draft`).
- **OQ3 = lazy re-heal:** recompose only when the venv is missing/unusable.
- **OQ4 = `TimeoutStartSec=300`.**
- **Scope = system-mode only:** root oneshot (agent runs as `User=llauncher`, can't own the dev-tree venv); the `--user` agent path owns its venv via `run.sh setup` at launch. Cross-scope `Requires=` is forbidden — Phase B (#228) handles the UI/user side.

## Fail-loud (PARSE-AT-THE-DOOR)
Nonzero pip → actionable message + `exit 1`; entry point still absent after install → `exit 1`. Via `Requires=`, a failed ensure unit keeps the agent **down** rather than starting degraded.

## Gates
- `systemd-analyze verify`: clean on both rendered units.
- `bash -n`: clean.
- `pytest`: **1201 passed, 11 skipped**; non-UI coverage **95.30%** (floor 93%).

Independent review in progress — verdict will be posted as a comment. Phase B (#228) depends on this unit. Follow-up #229 (`stop`/`ensure_venv` wart) is tracked separately.