### PR TITLE
fix(preflight): VRAM check fails loud when GPU device data is unavailable (#150)

### DIFF
--- a/llauncher/operations/preflight.py
+++ b/llauncher/operations/preflight.py
@@ -126,9 +126,16 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
     Strategy:
 
     - Query :class:`llauncher.core.gpu.GPUHealthCollector` for current device
-      state. If no GPU backend is detected, treat the check as a no-op
-      pass — the process will fail naturally if the host can't run the
-      model. This matches the agent-routing behavior.
+      state. If no GPU backend is detected at all (genuine CPU-only host),
+      treat the check as a no-op pass — the process will fail naturally if
+      the host can't run the model. This matches the agent-routing behavior.
+    - **Fail loud when a backend is present but exposes no device data.**
+      A detected GPU backend with an empty device list means VRAM headroom
+      cannot be verified (malformed device query, transient ``nvidia-smi``
+      hiccup, etc.). Rather than silently admitting the launch and risking a
+      blind OOM, the check refuses with a ``"cannot verify VRAM headroom"``
+      reason (#150). This is fail-closed by design: a backend that claims to
+      exist must be able to report its devices.
     - Compute :func:`estimate_vram_mb` for ``config``.
     - Pass if **any** device reports ``free_vram_mb >= required``. We pick
       the most-free device rather than enforcing an exact placement; the
@@ -147,7 +154,17 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
 
     devices = health.get("devices") or []
     if not devices:
-        return True, ""
+        # Backend present but no device numbers: VRAM headroom is unknown.
+        # Fail loud rather than admit a blind launch that can OOM (#150).
+        logger.warning(
+            "VRAM pre-flight: backend(s) %s detected but no device data; "
+            "refusing launch (cannot verify VRAM headroom)",
+            backends,
+        )
+        return False, (
+            f"cannot verify VRAM headroom: GPU backend(s) {backends} detected "
+            "but reported no device data"
+        )
 
     required_mb = estimate_vram_mb(config)
     best_free = max(int(d.get("free_vram_mb") or 0) for d in devices)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -138,11 +138,28 @@ def test_default_vram_check_no_backend_passes() -> None:
     assert reason == ""
 
 
-def test_default_vram_check_backend_with_no_devices_passes() -> None:
+def test_default_vram_check_backend_with_no_devices_fails_loud() -> None:
+    """#150: backend detected but no device data must fail loud, not silently pass.
+
+    A GPU backend that claims to exist yet reports no devices means VRAM
+    headroom is unverifiable (malformed query / nvidia-smi hiccup). The
+    check refuses the launch rather than admitting a blind, OOM-prone swap.
+    """
     cfg = _config()
     with _patch_gpu({"backends": ["nvidia"], "devices": []}):
         ok, reason = pf.default_vram_check(cfg)
-    assert ok is True
+    assert ok is False
+    assert "cannot verify vram headroom" in reason.lower()
+    assert "nvidia" in reason.lower()
+
+
+def test_default_vram_check_backend_with_missing_devices_key_fails_loud() -> None:
+    """#150: a missing ``devices`` key is treated the same as an empty list."""
+    cfg = _config()
+    with _patch_gpu({"backends": ["nvidia"]}):
+        ok, reason = pf.default_vram_check(cfg)
+    assert ok is False
+    assert "cannot verify vram headroom" in reason.lower()
 
 
 def test_default_vram_check_sufficient_passes() -> None:


### PR DESCRIPTION
Closes #150.

## Problem
`llauncher/operations/preflight.py::default_vram_check` **failed open**: when a
GPU backend was detected but `GPUHealthCollector.get_health()` returned an empty
`devices` list, the check returned `(True, "")` — admitting the launch. So a
swap/start whose VRAM telemetry was broken (malformed device query, transient
`nvidia-smi` hiccup) proceeded *blind*, exactly when something was wrong, and
could OOM the host. There was no guard rail at all on the unknown-VRAM path.

## Fix — fail-open → fail-loud
Per the operator dispatch resolving the issue's scope question to the
**fail-closed** option: a backend present with **no device data** now refuses
the launch instead of silently passing.

```text
backend(s) detected + empty devices  ->  (False, "cannot verify VRAM headroom: ...")  + WARNING log
```

Behavior change, precisely:
- **Changed:** backend present + empty/absent `devices` -> was silent pass, now
  fail-loud refusal (`"cannot verify VRAM headroom"`) with a `logger.warning`.
- **Preserved (no GPU genuinely):** no backend at all (CPU-only host) still
  passes as a no-op — this issue is specifically "backend present, device data
  missing", not "no GPU".
- **Preserved (genuine capacity):** the normal sufficient / insufficient-VRAM
  device paths are untouched; a device with enough free VRAM still passes.

This is fail-closed by design (CLAUDE.md `PARSE-AT-THE-DOOR` / fail-loud posture):
a backend that claims to exist must be able to report its devices.

## Tests
- `test_default_vram_check_backend_with_no_devices_fails_loud` — flips the stale
  test that encoded the fail-open behavior; now asserts `ok is False` and the
  `"cannot verify vram headroom"` reason.
- `test_default_vram_check_backend_with_missing_devices_key_fails_loud` — a
  missing `devices` key is treated the same as empty.
- Normal pass/fail and no-backend paths retained and still green.

## Gates
- Full suite: **1211 passed, 12 skipped**.
- Coverage: **95.33%** total (floor 93%); `operations/preflight.py` at **100%**.
- (Note: `test_cli.py::test_config_path_printed` flakes only under a narrow
  terminal width — Rich wraps the printed path with a `\n`; passes at
  `COLUMNS=200`. Pre-existing, unrelated to this change.)

## Scope note
Issue #150 calls out two companion items as **independent PRs**: the malformed
device-query fix and the quant/KV-cache-aware VRAM estimate. This PR is the
defense-in-depth guard rail only; it does not touch those.
