### PR TITLE
fix(config): make extra_args flag collision loud + expose batch/parallel family (#156)

### DIFF
--- a/llauncher/mcp_server/tools/config.py
+++ b/llauncher/mcp_server/tools/config.py
@@ -27,9 +27,13 @@ def get_tools() -> list[Tool]:
                             "n_gpu_layers": {"type": "integer"},
                             "ctx_size": {"type": "integer"},
                             "threads": {"type": "integer"},
+                            "threads_batch": {"type": "integer"},
+                            "ubatch_size": {"type": "integer"},
+                            "batch_size": {"type": "integer"},
+                            "parallel": {"type": "integer"},
                             "flash_attn": {"type": "string", "enum": ["on", "off", "auto"]},
                             "no_mmap": {"type": "boolean"},
-                            "extra_args": {"type": "string", "description": "Additional command-line arguments (space-separated)"},
+                            "extra_args": {"type": "string", "description": "Additional command-line arguments (space-separated). Flags llauncher emits natively (e.g. --batch-size, --ubatch-size, --parallel, --threads-batch) are rejected here — set the dedicated field instead (issue #156)."},
                         },
                     },
                 },
@@ -149,6 +153,14 @@ async def update_model_config(state: LauncherState, args: dict) -> dict:
             updated_config.ctx_size = updates["ctx_size"]
         if "threads" in updates:
             updated_config.threads = updates["threads"]
+        if "threads_batch" in updates:
+            updated_config.threads_batch = updates["threads_batch"]
+        if "ubatch_size" in updates:
+            updated_config.ubatch_size = updates["ubatch_size"]
+        if "batch_size" in updates:
+            updated_config.batch_size = updates["batch_size"]
+        if "parallel" in updates:
+            updated_config.parallel = updates["parallel"]
         if "flash_attn" in updates:
             updated_config.flash_attn = updates["flash_attn"]
         if "no_mmap" in updates:

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -253,12 +253,12 @@ class ModelConfig(BaseModel):
             if head in MANAGED_NATIVE_FLAGS:
                 field = MANAGED_NATIVE_FLAG_TO_FIELD[head]
                 msg = (
-                    f"extra_args contains {head!r}, which llauncher already "
-                    f"emits natively from the {field!r} config field. "
-                    f"llama-server argument parsing is first-wins and the "
-                    f"native flag precedes extra_args, so this occurrence is "
-                    f"silently dropped — set the {field!r} field instead. "
-                    f"See issue #156."
+                    f"extra_args contains {head!r}, which llauncher manages via "
+                    f"the {field!r} config field. When that field is set "
+                    f"llauncher emits {head!r} itself, ahead of extra_args, and "
+                    f"llama-server argument parsing is first-wins — so a "
+                    f"duplicate here is silently dropped. Set the {field!r} "
+                    f"field instead. See issue #156."
                 )
                 if loading:
                     # Pre-existing config on disk: surface loudly, keep loading.

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -7,6 +7,7 @@ is implemented in M1, vLLM follows in M6.
 """
 
 import shlex
+import warnings
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
@@ -28,6 +29,25 @@ from llauncher.core.settings import BLACKLISTED_PORTS as _ENV_BLACKLISTED_PORTS
 # caller sees only its own value (default ``False``) and the race cannot occur.
 _skip_path_validation_var: ContextVar[bool] = ContextVar(
     "llauncher_skip_path_validation", default=False
+)
+
+# Per-context flag marking "we are rehydrating a *persisted* config from disk"
+# (issue #156). It is set only inside :meth:`ModelConfig.from_dict_unvalidated`
+# — the single load entry point (``ConfigStore.load``). It exists so the
+# ``extra_args`` collision check can be **fail-loud on write but lenient-loud on
+# load**: a newly-authored config (add_model / update_model_config / direct
+# construction) that stuffs a llauncher-managed flag into ``extra_args`` is
+# *rejected*, while a config already on disk with such a flag is *warned* about
+# and still loaded. The asymmetry is required, not cosmetic: ``ConfigStore.load``
+# rehydrates every model in a single dict-comprehension that only catches
+# JSON/OS errors, so one ``ValueError`` mid-load would brick the operator's
+# *entire* registry (60+ models), not just the offending one. Warn-on-load keeps
+# the silent loss non-silent (the issue's core ask) without that blast radius;
+# the write-path reject stops new traps at the door. This is *not* a
+# backcompat dual-parse (PARSE-AT-THE-DOOR): one shape is parsed, the legacy
+# collision is surfaced loudly rather than trusted-and-degraded silently.
+_loading_persisted_config_var: ContextVar[bool] = ContextVar(
+    "llauncher_loading_persisted_config", default=False
 )
 
 
@@ -75,6 +95,56 @@ DENIED_EXTRA_ARG_FLAGS: frozenset[str] = frozenset({
     "--host",
     "--port",
 })
+
+
+# Flags that ``core/process.py::build_command`` emits from structured
+# ``ModelConfig`` fields. Putting any of these in ``extra_args`` is the trap
+# documented in issue #156: ``build_command`` emits the native flag *before*
+# the ``extra_args`` tokens, and ``llama-server`` argument parsing is
+# first-wins, so the ``extra_args`` occurrence is **silently dropped** — the
+# config reads as updated while the runtime keeps the field value. (Observed
+# live: the resident ``embeddinggemma`` configs carried ``--ubatch-size 2048``
+# in ``extra_args`` while the native ``ubatch_size`` field was 512; effective
+# value was 512, the 2048 silently lost.)
+#
+# Each entry maps the **emitted spelling** to the field that owns it, so the
+# error/warning can point the operator at the right field. The mapping is the
+# single source of truth for the collision check and is drift-guarded against
+# ``build_command`` by ``tests/unit/test_process.py`` (every flag the builder
+# emits must appear here or in ``DENIED_EXTRA_ARG_FLAGS``).
+#
+# Scope note (issue #156 / ADR-024): this catches each flag in the *exact
+# spelling* ``build_command`` emits. It deliberately does **not** resolve
+# llama-server short/long aliases — e.g. ``ctx_size`` is emitted as ``-c``, so
+# a literal ``-c`` in ``extra_args`` is caught but the long alias
+# ``--ctx-size`` is not. Alias-complete, table-driven config→argv rendering is
+# the job of the ADR-024 render matrix (``auto:draft``), not this narrow
+# correctness fix. What this fix guarantees is that the silent first-wins loss
+# is gone for every flag llauncher actually puts on the command line.
+MANAGED_NATIVE_FLAG_TO_FIELD: dict[str, str] = {
+    "--mmproj": "mmproj_path",
+    "--n-gpu-layers": "n_gpu_layers",
+    "-c": "ctx_size",
+    "--threads": "threads",
+    "--threads-batch": "threads_batch",
+    "--ubatch-size": "ubatch_size",
+    "--batch-size": "batch_size",
+    "--flash-attn": "flash_attn",
+    "--no-mmap": "no_mmap",
+    "--cache-type-k": "cache_type_k",
+    "--cache-type-v": "cache_type_v",
+    "--n-cpu-moe": "n_cpu_moe",
+    "--parallel": "parallel",
+    "--temp": "temperature",
+    "--top-k": "top_k",
+    "--top-p": "top_p",
+    "--min-p": "min_p",
+    "--repeat-penalty": "repeat_penalty",
+    "--reverse-prompt": "reverse_prompt",
+    "--mlock": "mlock",
+}
+
+MANAGED_NATIVE_FLAGS: frozenset[str] = frozenset(MANAGED_NATIVE_FLAG_TO_FIELD)
 
 
 class BackendKind(str, Enum):
@@ -131,16 +201,26 @@ class ModelConfig(BaseModel):
     @field_validator("extra_args", mode="before")
     @classmethod
     def extra_args_no_managed_flags(cls, v):
-        """Reject ``extra_args`` tokens that collide with llauncher-managed flags.
+        """Guard ``extra_args`` tokens that collide with llauncher-managed flags.
 
         Mirrors the runtime ``shlex.split`` at
         ``llauncher/core/process.py`` so the boundary check sees argv the
         same way the launcher will. Both bare (``--api-key foo``) and
-        equals (``--api-key=foo``) forms are rejected.
+        equals (``--api-key=foo``) forms are matched.
 
-        Implements security-hardening-plan §3 C7 (Issue #81). See
-        :data:`DENIED_EXTRA_ARG_FLAGS` for the curated deny-list and the
-        rationale for each entry.
+        Two collision classes, two postures:
+
+        * :data:`DENIED_EXTRA_ARG_FLAGS` — security/runtime-owned flags
+          (security-hardening-plan §3 C7, Issue #81). **Always rejected**,
+          on every path including load — a config-on-disk must not be able to
+          override the minted identity or the loopback binding.
+        * :data:`MANAGED_NATIVE_FLAGS` — value-carrying flags that
+          ``build_command`` emits from structured fields. Putting one here is
+          the silent first-wins loss of issue #156. **Rejected on write**
+          (construction / assignment / ``from_dict``) so new configs can't lay
+          the trap; **warned but tolerated on load** (``from_dict_unvalidated``)
+          so a pre-existing collision is surfaced loudly without bricking the
+          whole-registry load (see :data:`_loading_persisted_config_var`).
         """
         if v is None or v == "":
             return v
@@ -158,6 +238,7 @@ class ModelConfig(BaseModel):
                 # subprocess construction blow up at start time.
                 raise ValueError(f"extra_args is not a valid shell token string: {e}")
 
+        loading = _loading_persisted_config_var.get()
         for token in tokens:
             # Match both bare flag and ``--flag=value`` form. We compare
             # the head before ``=`` so ``--api-key=foo`` is rejected
@@ -169,6 +250,22 @@ class ModelConfig(BaseModel):
                     f"{head!r} — set it via the dedicated ModelConfig "
                     f"field or remove it. See security-hardening-plan §3 C7."
                 )
+            if head in MANAGED_NATIVE_FLAGS:
+                field = MANAGED_NATIVE_FLAG_TO_FIELD[head]
+                msg = (
+                    f"extra_args contains {head!r}, which llauncher already "
+                    f"emits natively from the {field!r} config field. "
+                    f"llama-server argument parsing is first-wins and the "
+                    f"native flag precedes extra_args, so this occurrence is "
+                    f"silently dropped — set the {field!r} field instead. "
+                    f"See issue #156."
+                )
+                if loading:
+                    # Pre-existing config on disk: surface loudly, keep loading.
+                    # Raising here would fail the whole-registry load.
+                    warnings.warn(msg, stacklevel=2)
+                else:
+                    raise ValueError(msg)
         return v
 
     @field_validator("model_path", mode="before")
@@ -208,8 +305,17 @@ class ModelConfig(BaseModel):
         # Migrate extra_args from list[str] to str (legacy v1 shape).
         if "extra_args" in data and isinstance(data["extra_args"], list):
             data["extra_args"] = " ".join(data["extra_args"])
-        with _skip_path_validation():
-            return cls.model_validate(data)
+        # Mark load mode so the extra_args collision check warns-but-tolerates
+        # a pre-existing managed-flag collision instead of raising (issue #156;
+        # see :data:`_loading_persisted_config_var`). The DENIED_EXTRA_ARG_FLAGS
+        # security check still raises on this path — load tolerance applies only
+        # to the silent-loss class, never to identity/binding overrides.
+        loading_token = _loading_persisted_config_var.set(True)
+        try:
+            with _skip_path_validation():
+                return cls.model_validate(data)
+        finally:
+            _loading_persisted_config_var.reset(loading_token)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""

--- a/tests/unit/mcp/test_config_tools.py
+++ b/tests/unit/mcp/test_config_tools.py
@@ -65,6 +65,78 @@ class TestUpdateModelConfig:
             assert result["success"] is True
             mock_config_store.update_model.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_update_model_config_sets_batch_parallel_family(self, mock_state):
+        """Issue #156: batch_size / ubatch_size / parallel / threads_batch are
+
+        now writable through the tool contract (previously readable-only),
+        removing the need for the silently-lossy extra_args workaround.
+        """
+        with patch("llauncher.core.config.ConfigStore"):
+            result = await update_model_config(
+                mock_state,
+                {
+                    "name": "existing-model",
+                    "config": {
+                        "batch_size": 4096,
+                        "ubatch_size": 4096,
+                        "parallel": 4,
+                        "threads_batch": 16,
+                    },
+                },
+            )
+
+        assert result["success"] is True
+        updated = mock_state.models["existing-model"]
+        assert updated.batch_size == 4096
+        assert updated.ubatch_size == 4096
+        assert updated.parallel == 4
+        assert updated.threads_batch == 16
+
+    @pytest.mark.asyncio
+    async def test_update_model_config_sets_remaining_native_fields(self, mock_state):
+        """Cover the threads / flash_attn / no_mmap apply branches so the
+
+        whole update_model_config field-apply block is exercised.
+        """
+        with patch("llauncher.core.config.ConfigStore"):
+            result = await update_model_config(
+                mock_state,
+                {
+                    "name": "existing-model",
+                    "config": {
+                        "threads": 12,
+                        "flash_attn": "off",
+                        "no_mmap": True,
+                    },
+                },
+            )
+
+        assert result["success"] is True
+        updated = mock_state.models["existing-model"]
+        assert updated.threads == 12
+        assert updated.flash_attn == "off"
+        assert updated.no_mmap is True
+
+    @pytest.mark.asyncio
+    async def test_update_model_config_rejects_colliding_extra_args(self, mock_state):
+        """Issue #156: stuffing a natively-emitted flag into extra_args via the
+
+        tool is rejected (not silently first-wins-dropped) — the operator is
+        steered to the dedicated field.
+        """
+        with patch("llauncher.core.config.ConfigStore"):
+            result = await update_model_config(
+                mock_state,
+                {
+                    "name": "existing-model",
+                    "config": {"extra_args": "--ubatch-size 4096"},
+                },
+            )
+
+        assert result["success"] is False
+        assert "issue #156" in result["error"].lower()
+
 
 class TestUpdateModelConfigValidation:
     """Tests for update_model_config edge cases and validation errors (#34-G)."""
@@ -356,3 +428,13 @@ class TestGetTools:
         assert "validate_config" in tool_names
         assert "add_model" in tool_names
         assert "delete_model" in tool_names
+
+    def test_update_model_config_schema_exposes_batch_family(self):
+        """Issue #156: the batch/parallel family must be advertised as
+
+        writable in the update_model_config input schema, not just readable.
+        """
+        tools = {t.name: t for t in get_tools()}
+        props = tools["update_model_config"].inputSchema["properties"]["config"]["properties"]
+        for field in ("batch_size", "ubatch_size", "parallel", "threads_batch"):
+            assert field in props, field

--- a/tests/unit/test_models_config_extra_args.py
+++ b/tests/unit/test_models_config_extra_args.py
@@ -16,6 +16,8 @@ import pytest
 
 from llauncher.models.config import (
     DENIED_EXTRA_ARG_FLAGS,
+    MANAGED_NATIVE_FLAG_TO_FIELD,
+    MANAGED_NATIVE_FLAGS,
     ModelConfig,
 )
 
@@ -211,10 +213,15 @@ class TestPostConstructionAssignment:
             cfg.extra_args = "--alias=evil"
 
     def test_assignment_of_benign_args_succeeds(self, model_file: str) -> None:
-        """Sanity: legitimate post-construction updates still work."""
+        """Sanity: legitimate post-construction updates still work.
+
+        Uses ``--log-disable``/``--verbose`` — flags llauncher does not emit
+        natively — so the update is genuinely benign. ``--temp`` would now be
+        rejected by the issue #156 managed-flag collision guard.
+        """
         cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
-        cfg.extra_args = "--ctx-size 4096 --temp 0.7"
-        assert "--ctx-size" in cfg.extra_args
+        cfg.extra_args = "--log-disable --verbose"
+        assert "--log-disable" in cfg.extra_args
 
 
 class TestDenyListContents:
@@ -239,3 +246,140 @@ class TestDenyListContents:
     def test_deny_list_is_frozen(self) -> None:
         """Frozenset guards against accidental mutation at import time."""
         assert isinstance(DENIED_EXTRA_ARG_FLAGS, frozenset)
+
+
+class TestManagedNativeFlagCollision:
+    """Issue #156: a flag llauncher emits natively from a structured field
+
+    must not silently first-wins-lose when also placed in ``extra_args``.
+    Write paths reject it; the load path warns but tolerates it.
+    """
+
+    # ---- write path: construction rejects --------------------------------
+
+    @pytest.mark.parametrize("flag", sorted(MANAGED_NATIVE_FLAGS))
+    def test_construction_rejects_each_managed_native_flag(
+        self, model_file: str, flag: str
+    ) -> None:
+        with pytest.raises(ValueError, match="issue #156"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args=f"{flag} sentinel-value",
+            )
+
+    def test_error_names_the_owning_field(self, model_file: str) -> None:
+        """The reject message points the operator at the dedicated field."""
+        with pytest.raises(ValueError, match="ubatch_size"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--ubatch-size 4096",
+            )
+
+    def test_construction_rejects_equals_form(self, model_file: str) -> None:
+        with pytest.raises(ValueError, match="issue #156"):
+            ModelConfig(
+                name="m",
+                model_path=model_file,
+                extra_args="--parallel=4",
+            )
+
+    def test_assignment_rejects_managed_native_flag(self, model_file: str) -> None:
+        """validate_assignment enforces the guard post-construction too."""
+        cfg = ModelConfig(name="m", model_path=model_file, extra_args="")
+        with pytest.raises(ValueError, match="--batch-size"):
+            cfg.extra_args = "--batch-size 4096"
+
+    def test_from_dict_rejects_managed_native_flag(self, model_file: str) -> None:
+        """The public dict constructor (UI/CLI write path) rejects too."""
+        with pytest.raises(ValueError, match="issue #156"):
+            ModelConfig.from_dict({
+                "name": "m",
+                "model_path": model_file,
+                "extra_args": "--threads-batch 16",
+            })
+
+    # ---- the batch/parallel family the issue names by hand ---------------
+
+    @pytest.mark.parametrize(
+        "flag", ["--batch-size", "--ubatch-size", "--parallel", "--threads-batch"]
+    )
+    def test_issue_156_named_family_is_guarded(
+        self, model_file: str, flag: str
+    ) -> None:
+        assert flag in MANAGED_NATIVE_FLAGS
+        with pytest.raises(ValueError, match="issue #156"):
+            ModelConfig(
+                name="m", model_path=model_file, extra_args=f"{flag} 4"
+            )
+
+    # ---- load path: warn but tolerate ------------------------------------
+
+    def test_load_warns_but_tolerates_collision(self) -> None:
+        """A pre-existing config on disk with a managed flag in extra_args
+
+        loads (no raise) but emits a loud warning — the silent loss is now
+        non-silent without bricking the whole-registry load.
+        """
+        with pytest.warns(UserWarning, match="issue #156"):
+            cfg = ModelConfig.from_dict_unvalidated({
+                "name": "m",
+                "model_path": "/fake/does-not-matter.gguf",
+                "extra_args": "--embeddings --ubatch-size 2048",
+            })
+        # Tolerated: the config loaded and the string round-trips unchanged.
+        assert cfg.extra_args == "--embeddings --ubatch-size 2048"
+
+    def test_load_live_embedding_repro_warns(self) -> None:
+        """Exact shape of the live resident embedding config (issue #156):
+
+        native ``ubatch_size`` default with ``--ubatch-size 2048`` in
+        extra_args. Must warn, must still load.
+        """
+        with pytest.warns(UserWarning, match="ubatch_size"):
+            cfg = ModelConfig.from_dict_unvalidated({
+                "name": "embeddinggemma-300M-F32-pooled",
+                "model_path": "/fake/emb.gguf",
+                "ubatch_size": 512,
+                "extra_args": "--embeddings --log-disable --ubatch-size 2048 --batch-size 2048",
+            })
+        assert cfg.ubatch_size == 512
+
+    def test_load_still_raises_on_security_denied_flag(self) -> None:
+        """Load tolerance applies ONLY to the silent-loss class. The
+
+        security deny-list (``--alias`` etc.) must still hard-fail on load.
+        """
+        with pytest.raises(ValueError, match="--alias"):
+            ModelConfig.from_dict_unvalidated({
+                "name": "m",
+                "model_path": "/fake/x.gguf",
+                "extra_args": "--alias sneaky",
+            })
+
+    def test_managed_native_and_denied_are_disjoint(self) -> None:
+        """The two collision classes must not overlap — a flag is either
+
+        security-owned (always reject) or value-carrying (write-reject /
+        load-warn), never both, so the validator's branch order is moot.
+        """
+        assert MANAGED_NATIVE_FLAGS.isdisjoint(DENIED_EXTRA_ARG_FLAGS)
+
+    def test_managed_native_flags_derived_from_mapping(self) -> None:
+        assert MANAGED_NATIVE_FLAGS == frozenset(MANAGED_NATIVE_FLAG_TO_FIELD)
+
+    def test_validator_handles_list_input_defensively(self) -> None:
+        """Defend-in-depth: if the validator is called directly with a
+
+        ``list[str]`` (the legacy shape is normally joined before validation),
+        it still tokenizes and applies the collision guard rather than crashing.
+        """
+        # Benign list round-trips untouched.
+        assert ModelConfig.extra_args_no_managed_flags(["--log-disable", "--verbose"]) == [
+            "--log-disable",
+            "--verbose",
+        ]
+        # A managed flag in list form is still caught on the write path.
+        with pytest.raises(ValueError, match="issue #156"):
+            ModelConfig.extra_args_no_managed_flags(["--parallel", "4"])

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -18,7 +18,11 @@ from llauncher.core.process import (
     _tail_file,
     is_port_in_use,
 )
-from llauncher.models.config import ModelConfig
+from llauncher.models.config import (
+    DENIED_EXTRA_ARG_FLAGS,
+    MANAGED_NATIVE_FLAGS,
+    ModelConfig,
+)
 
 
 # Fixtures
@@ -197,10 +201,16 @@ class TestBuildCommand:
         assert "--extra2" in cmd
 
     def test_extra_args_with_quoted_strings(self, minimal_config):
-        """extra_args properly handles quoted strings with spaces."""
-        minimal_config.extra_args = '--reverse-prompt "You are helpful"'
+        """extra_args properly handles quoted strings with spaces.
+
+        Uses ``--chat-template`` (not a llauncher-managed flag) so the test
+        exercises shlex quote handling without tripping the issue #156
+        managed-flag collision guard. ``--reverse-prompt`` would now be
+        rejected on assignment because llauncher emits it natively.
+        """
+        minimal_config.extra_args = '--chat-template "You are helpful"'
         cmd = build_command(minimal_config, port=8080)
-        assert "--reverse-prompt" in cmd
+        assert "--chat-template" in cmd
         assert "You are helpful" in cmd
 
     def test_custom_host(self, minimal_config):
@@ -1078,3 +1088,65 @@ class TestStartServerLogsLifecycle:
         # New live log contains only the banner (no previous content).
         assert "X" not in log_file.read_text(encoding="utf-8")
         assert "=== started at" in log_file.read_text(encoding="utf-8")
+
+
+class TestBuildCommandManagedFlagDriftGuard:
+    """Issue #156: keep ``MANAGED_NATIVE_FLAGS`` (the collision deny-set) in
+
+    sync with what ``build_command`` actually emits. If a future change adds a
+    native flag to ``build_command`` without registering it in
+    ``MANAGED_NATIVE_FLAGS`` / ``DENIED_EXTRA_ARG_FLAGS``, the silent
+    first-wins-loss trap would reopen for that flag — this test fails loudly
+    instead.
+    """
+
+    @staticmethod
+    def _is_flag(token: str) -> bool:
+        # A flag token starts with '-' and is not a (possibly negative) number.
+        if not token.startswith("-"):
+            return False
+        try:
+            float(token)
+        except ValueError:
+            return True
+        return False
+
+    def test_every_emitted_flag_is_registered(self) -> None:
+        # Exercise every conditional branch in build_command so all native
+        # flags are emitted. extra_args is empty so only native flags appear.
+        cfg = ModelConfig.from_dict_unvalidated({
+            "name": "drift-model",
+            "model_path": "/fake/model.gguf",
+            "mmproj_path": "/fake/mmproj.gguf",
+            "n_gpu_layers": 10,
+            "ctx_size": 4096,
+            "threads": 4,
+            "threads_batch": 8,
+            "ubatch_size": 512,
+            "batch_size": 2048,
+            "flash_attn": "on",
+            "no_mmap": True,
+            "cache_type_k": "q8_0",
+            "cache_type_v": "q8_0",
+            "n_cpu_moe": 2,
+            "parallel": 4,
+            "temperature": 0.7,
+            "top_k": 40,
+            "top_p": 0.9,
+            "min_p": 0.05,
+            "repeat_penalty": 1.1,
+            "reverse_prompt": "STOP",
+            "mlock": True,
+            "extra_args": "",
+        })
+        cmd = build_command(cfg, port=8080, host="0.0.0.0")
+
+        emitted_flags = {t for t in cmd if self._is_flag(t)}
+        registered = MANAGED_NATIVE_FLAGS | DENIED_EXTRA_ARG_FLAGS
+
+        unregistered = emitted_flags - registered
+        assert not unregistered, (
+            "build_command emits flags not registered in MANAGED_NATIVE_FLAGS "
+            f"or DENIED_EXTRA_ARG_FLAGS: {sorted(unregistered)}. Register them "
+            "so the issue #156 collision guard covers them."
+        )


### PR DESCRIPTION
Closes #156.

## The bug

`get_model_config` exposes `batch_size` / `ubatch_size` / `parallel` /
`threads_batch`, but `update_model_config` could not **write** them — they were
readable-only through the tool contract. The obvious workaround (put
`--batch-size 4096 --ubatch-size 4096 --parallel 4` into `extra_args`) is a
**silent trap**: `build_command` emits the native flag *before* `extra_args`,
and `llama-server` argument parsing is **first-wins**, so the `extra_args`
occurrence is silently dropped. The config *reads* as updated while the runtime
keeps the field value — the config lies.

This is live, not hypothetical: the resident `embeddinggemma` configs on `:8082`
carry `--ubatch-size 2048` in `extra_args` while their native `ubatch_size`
field is `512`. Effective value is `512`; the operator's `2048` is silently
lost. (Probed during this fix: all 61 live models, exactly these 2 collide.)

## The narrow fix

**Part (a) — writable family.** `update_model_config` now accepts `batch_size`,
`ubatch_size`, `parallel`, `threads_batch` (schema + apply block), so the
correct flags can be set on their owning fields instead of `extra_args`.

**Part (b) — silent loss made loud.** New `MANAGED_NATIVE_FLAGS` deny-set (flag
→ owning field) covers every flag `build_command` emits from a structured
field, checked in the `extra_args` validator with two postures, per
`PARSE-AT-THE-DOOR`:

| Path | Posture | Why |
|---|---|---|
| **write** — construction / assignment / `from_dict` / `add_model` / `update_model_config` | **reject** (`ValueError`) | new configs can't lay the trap |
| **load** — `from_dict_unvalidated` (`ConfigStore.load`) | **warn but tolerate** | a pre-existing collision is surfaced loudly *without* bricking the registry |

The load asymmetry is **required, not cosmetic**: `ConfigStore.load` rehydrates
every model in one dict-comprehension that catches only JSON/OS errors, so a
single `ValueError` mid-load would brick the operator's *entire* 60+ model
registry, not just the offending one. Warn-on-load keeps the silent loss
non-silent (the issue's core ask) without that blast radius. Verified: all 61
live models load; the 2 colliding embedding configs warn.

The security `DENIED_EXTRA_ARG_FLAGS` set (`--alias`, `--api-key`, `-m`,
`--host`, …) still **hard-rejects on every path**, load included — load
tolerance applies only to the silent-loss class, never to identity/binding
overrides.

A **drift-guard test** drives `build_command` through every conditional branch
and asserts each emitted flag is registered in `MANAGED_NATIVE_FLAGS` or
`DENIED_EXTRA_ARG_FLAGS`, so the trap cannot silently reopen when a new native
flag is added.

## Relationship to ADR-024 (deliberately NOT implemented)

The broad structural fix — an alias-complete, table-driven config→argv **render
matrix** — is ADR-024 (`auto:draft`), out of scope here. This narrow fix catches
each flag in the **exact spelling** `build_command` emits. Alias divergence
(e.g. `ctx_size` is emitted as `-c`, so a literal `-c` in `extra_args` is caught
but the long alias `--ctx-size` is not) remains ADR-024's job and is documented
inline. What this fix guarantees: the silent first-wins loss is gone for **every
flag llauncher actually puts on the command line**. The fix is coherent and
shippable without ADR-024 — no bounce.

Issue #156's optional item 3 (a `validate_config` lint for `ubatch_size >
batch_size`) is **not** included: it is a clamp-warning, not a flag collision,
and a hard reject would break the live embedding config (`ubatch_size=4096`,
`batch_size=2048`). Left for a follow-up.

## Tests / gates

- Full suite: **1249 passed**, 12 skipped. Non-UI coverage **95.50%** (≥93 floor).
- Changed files `models/config.py` and `mcp_server/tools/config.py`: **100%**.
- New coverage: write-path reject (each managed flag, bare + equals + list +
  assignment + `from_dict`), load-path warn-but-tolerate (incl. the live
  embedding repro), DENIED-still-raises-on-load, disjointness of the two sets,
  the drift guard, and the newly-writable family through the tool.
- The one environmental flake (`test_cli.py::test_config_path_printed`, a
  terminal-width line-wrap artifact) fails identically on clean `main` and
  passes at `COLUMNS=200`; unrelated to this change.
