### PR TITLE
test(core): close CORE-MISC coverage (config/agent_token/model_health/lockfile)

### DIFF
--- a/llauncher/core/lockfile.py
+++ b/llauncher/core/lockfile.py
@@ -101,7 +101,7 @@ def write_lockfile(
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(lf.to_dict(), f, indent=2)
-    except Exception:
+    except Exception:  # pragma: no cover - best-effort cleanup of a partial write after the O_EXCL fd is open; the inner FileNotFoundError guards a cleanup race where the just-created file already vanished. Exercising it would require injecting a mid-fdopen failure, which buys no real coverage of behavior.
         # Best-effort cleanup of a partial write so reconciliation isn't
         # poisoned by an empty/corrupt lockfile.
         try:

--- a/llauncher/core/model_health.py
+++ b/llauncher/core/model_health.py
@@ -90,7 +90,7 @@ def check_model_health(model_path: str) -> ModelHealthResult:
             stat = path.stat()
             result.size_bytes = stat.st_size
             result.last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
-        except OSError:
+        except OSError:  # pragma: no cover - stat() edge (e.g. race after is_file); size/mtime stay None and we continue to the readability check, which is the load-bearing gate
             pass  # May fail on edge cases; continue to readability check
 
         # Check readability by attempting an open + close.

--- a/llauncher/core/model_health.py
+++ b/llauncher/core/model_health.py
@@ -90,7 +90,7 @@ def check_model_health(model_path: str) -> ModelHealthResult:
             stat = path.stat()
             result.size_bytes = stat.st_size
             result.last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
-        except OSError:  # pragma: no cover - stat() edge (e.g. race after is_file); size/mtime stay None and we continue to the readability check, which is the load-bearing gate
+        except OSError:
             pass  # May fail on edge cases; continue to readability check
 
         # Check readability by attempting an open + close.

--- a/tests/unit/test_agent_token_generate.py
+++ b/tests/unit/test_agent_token_generate.py
@@ -1,0 +1,44 @@
+"""Unit tests for ``llauncher.core.agent_token._generate_and_persist_token``.
+
+Covers the chmod-OSError best-effort fallbacks (security hardening §3 C1):
+on filesystems where ``chmod`` is a no-op or fails (e.g. NTFS via WSL), the
+parent-dir 0700 and file 0600 hardening steps must degrade silently rather
+than abort token materialization. The file write itself is the load-bearing
+step and must still succeed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from llauncher.core.agent_token import _generate_and_persist_token
+
+
+def test_generate_token_survives_chmod_oserror(tmp_path: Path) -> None:
+    """Both ``chmod`` calls raising ``OSError`` still yields a written token.
+
+    Patching ``Path.chmod`` to always raise exercises the parent-dir branch
+    (lines 110-114) on the first call and the file branch (lines 122-123) on
+    the second; the token is generated, persisted, and returned regardless.
+    """
+    target = tmp_path / "state" / "agent.token"
+
+    with patch.object(Path, "chmod", side_effect=OSError("chmod unsupported")):
+        token = _generate_and_persist_token(target)
+
+    assert token
+    assert target.exists()
+    # File content is the token plus the trailing newline the writer appends.
+    assert target.read_text(encoding="utf-8").strip() == token
+
+
+def test_generate_token_chmods_when_supported(tmp_path: Path) -> None:
+    """Happy path: chmod succeeds, token persisted (no fallback taken)."""
+    target = tmp_path / "state" / "agent.token"
+
+    token = _generate_and_persist_token(target)
+
+    assert token
+    assert target.exists()
+    assert target.read_text(encoding="utf-8").strip() == token

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,6 +42,33 @@ def test_config_store_load_nonexistent(mock_config_store):
     assert models == {}
 
 
+def test_config_store_load_corrupt_returns_empty(
+    mock_config_store, tmp_config_dir, capsys
+):
+    """A corrupt (non-JSON) config file recovers to an empty dict (lines 45-47).
+
+    ``load()`` catches ``JSONDecodeError``/``OSError``, prints a diagnostic,
+    and returns ``{}`` so a damaged config never crashes a read path.
+    """
+    tmp_config_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_config_dir / "config.json").write_text("{ this is not valid json")
+
+    models = ConfigStore.load()
+
+    assert models == {}
+    assert "Error loading config" in capsys.readouterr().out
+
+
+def test_update_missing_model_raises_keyerror(
+    mock_config_store, sample_model_config
+):
+    """Updating a model that was never added raises ``KeyError`` (line 107)."""
+    # Name matches config.name so we pass the mismatch guard and reach the
+    # membership check; the store is empty, so the model is "not found".
+    with pytest.raises(KeyError, match="Model not found"):
+        ConfigStore.update_model(sample_model_config.name, sample_model_config)
+
+
 def test_config_store_update_model(mock_config_store, sample_model_config):
     """Test updating an existing model."""
     ConfigStore.add_model(sample_model_config)

--- a/tests/unit/test_model_health.py
+++ b/tests/unit/test_model_health.py
@@ -133,6 +133,41 @@ def test_last_modified_populated_for_valid():
     assert isinstance(result.model_dump()["last_modified"], str) or hasattr(result, "last_modified")
 
 
+def test_stat_oserror_continues_to_readability_check():
+    """An explicit ``stat()`` ``OSError`` is swallowed (lines 93-94).
+
+    The existence gate uses ``is_file()``; the *separate* ``path.stat()`` for
+    size/mtime can still fail on edge cases (e.g. a vanish-after-is_file race).
+    When it does, size/mtime stay unset and control falls through to the
+    readability check rather than aborting. With ``size_bytes`` left ``None``
+    the downstream size heuristic then reports ``too small`` — the visible
+    consequence of the swallowed edge.
+
+    ``is_file`` is forced True so the explicit ``stat()`` at line 90 (not
+    ``is_file``'s own internal stat, which swallows ``OSError`` to False) is
+    the one that raises — isolating exactly the branch under test.
+    """
+    from pathlib import Path as _Path
+
+    with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False, mode="wb") as f:
+        f.write(b"x" * (1024 * 1024 + 1))
+        path = Path(f.name).resolve()
+
+    with patch.object(_Path, "is_file", return_value=True), patch.object(
+        _Path, "stat", side_effect=OSError("stat unavailable")
+    ):
+        result = check_model_health(str(path))
+
+    # Readability check still ran (file is openable via builtin open), so the
+    # unreadable path was NOT taken.
+    assert result.readable is True
+    assert result.size_bytes is None
+    assert result.last_modified is None
+    # size_bytes None -> heuristic treats as 0 -> "too small".
+    assert result.valid is False
+    assert (result.reason or "").lower() == "too small"
+
+
 def test_resolution_failure_recovers_with_reason():
     """An unexpected exception during resolution is caught (lines 106-109).
 

--- a/tests/unit/test_model_health.py
+++ b/tests/unit/test_model_health.py
@@ -10,6 +10,7 @@ import os
 import stat
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -130,6 +131,24 @@ def test_last_modified_populated_for_valid():
 
     result = check_model_health(str(path))
     assert isinstance(result.model_dump()["last_modified"], str) or hasattr(result, "last_modified")
+
+
+def test_resolution_failure_recovers_with_reason():
+    """An unexpected exception during resolution is caught (lines 106-109).
+
+    If ``Path.resolve()`` raises something other than the inner-handled
+    ``OSError`` (e.g. a ``RuntimeError`` from a pathological path), the outer
+    ``except Exception`` records the message as ``reason`` and returns an
+    invalid result instead of propagating.
+    """
+    from pathlib import Path as _Path
+
+    with patch.object(_Path, "resolve", side_effect=RuntimeError("boom-resolve")):
+        result = check_model_health("/some/path/that/will/blow/up.gguf")
+
+    assert result.valid is False
+    assert result.reason is not None
+    assert "boom-resolve" in result.reason
 
 
 def test_cache_invalidation():


### PR DESCRIPTION
## Cluster CORE-MISC coverage close-out

Principle: every owned uncovered line is now **covered by a genuine test** or
carries an explicit **`# pragma: no cover` + reason**. No production behavior
changed — tests and one pragma annotation only.

### Covered (genuine tests)

| Module | Lines | Path exercised |
| --- | --- | --- |
| `core/config.py` | 45-47 | corrupted-config load recovery — `load()` catches `JSONDecodeError`/`OSError`, prints diagnostic, returns `{}` |
| `core/config.py` | 107 | `update_model` raises `KeyError("Model not found")` when the model was never added |
| `core/agent_token.py` | 110-114, 122-123 | `_generate_and_persist_token` chmod-`OSError` best-effort fallbacks (parent 0700, file 0600) — token still materializes |
| `core/model_health.py` | 93-94 | explicit `stat()` `OSError` edge swallowed — size/mtime stay `None`, control reaches the readability check, size heuristic then reports `too small` |
| `core/model_health.py` | 106-109 | outer `except Exception` resolution-failure recovery — records `reason`, returns invalid result |

### Excluded (`# pragma: no cover` + reason)

| Module | Lines | Justification |
| --- | --- | --- |
| `core/lockfile.py` | 104-111 | best-effort cleanup of a partial write after the `O_EXCL` fd is open, with an inner `FileNotFoundError` guarding a cleanup race; injecting a mid-`fdopen` failure buys no real behavioral coverage |

### Review note
Reviewer flagged `model_health.py` 93-94 as cheaply testable rather than
defensible; it was converted from a pragma to a genuine test (force
`is_file()`→True, patch the explicit `path.stat()` to raise — isolating
line 90's stat from `is_file`'s own OSError-swallowing internal stat).

### Gates
- Full pytest: **1256 passed, 12 skipped**
- Non-UI coverage: **96.08%** (floor 93)
- Targeted lines: all resolved (covered or excluded), confirmed via `--cov-report=term-missing`

Remaining misses in these modules (`agent_token` 54-56/67-73/164-180, `model_health` 76/135) are outside the CORE-MISC ownership for this cluster.
