### PR TITLE
test(interface): coverage close-out for CLI/MCP/agent INTERFACE cluster

### DIFF
--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -405,12 +405,7 @@ def node_status(
     for node_name in list(registry._nodes.keys()):
         try:
             registry.get_node(node_name).ping()
-        except Exception:  # pragma: no cover - defensive: a transient ping
-            # failure (transport hiccup, slow node) must not abort the
-            # status render; we deliberately swallow it and keep the node's
-            # prior status. Exercising every transport failure mode here
-            # would test ``RemoteNode.ping``'s own error handling, not this
-            # render loop, so the swallow is left uncovered by intent.
+        except Exception:
             pass  # keep current status if ping fails completely
 
     if as_json:

--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -405,7 +405,12 @@ def node_status(
     for node_name in list(registry._nodes.keys()):
         try:
             registry.get_node(node_name).ping()
-        except Exception:
+        except Exception:  # pragma: no cover - defensive: a transient ping
+            # failure (transport hiccup, slow node) must not abort the
+            # status render; we deliberately swallow it and keep the node's
+            # prior status. Exercising every transport failure mode here
+            # would test ``RemoteNode.ping``'s own error handling, not this
+            # render loop, so the swallow is left uncovered by intent.
             pass  # keep current status if ping fails completely
 
     if as_json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ omit = [
     # CLI entry-point shim for ``python -m llauncher.agent``; covered
     # indirectly through integration runs of the agent, not unit tests.
     "llauncher/agent/__main__.py",
+    # ``python -m llauncher.mcp_server`` entry shim — a 2-line passthrough
+    # to ``mcp_server.server:main`` that runs ``_main()`` at import time, so
+    # it cannot be unit-imported without launching the stdio server. Omitted
+    # for parity with ``agent/__main__.py`` above (same entry-shim category);
+    # ``server.main`` / ``server.main_async`` themselves are unit-covered.
+    "llauncher/mcp_server/__main__.py",
 ]
 
 [tool.coverage.report]

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -230,3 +230,82 @@ class TestMainFunctions:
     def test_main_entry_point(self):
         """Test the if __name__ == '__main__' block."""
         assert callable(main)
+
+
+class TestInterfaceCloseout:
+    """INTERFACE coverage close-out for the MCP dispatch + handler wiring."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_tool_cancel_server(self):
+        """Dispatch to cancel_server — stateless verb, bypasses the singleton.
+
+        Covers server.py:83 — the ``cancel_server`` arm of ``_dispatch_tool``
+        in the stateless verb group (ADR-010/ADR-014), reached before
+        ``get_mcp_state``.
+        """
+        with patch("llauncher.mcp_server.server.get_mcp_state") as mock_get:
+            with patch(
+                "llauncher.mcp_server.server.servers_tools.cancel_server",
+                return_value="cancel_server_result",
+            ):
+                result = await _dispatch_tool("cancel_server", {"port": 8080})
+                assert result == "cancel_server_result"
+                # Stateless verb must not touch the lazy LauncherState singleton.
+                mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_main_async_registered_handlers_invoke_dispatch(self):
+        """The decorated ``list_tools``/``call_tool`` callbacks delegate to the handlers.
+
+        Covers server.py:120 and :124 — the existing ``main_async`` test
+        registers the handlers but never *invokes* the inner decorated
+        functions, so their one-line bodies stayed uncovered. Here we capture
+        what ``@server.list_tools()`` / ``@server.call_tool()`` register and
+        then call them, confirming each delegates to its module-level handler.
+        """
+        captured: dict = {}
+
+        def list_tools_decorator():
+            def register(fn):
+                captured["list_tools"] = fn
+                return fn
+            return register
+
+        def call_tool_decorator():
+            def register(fn):
+                captured["call_tool"] = fn
+                return fn
+            return register
+
+        with patch("llauncher.mcp_server.server.Server") as mock_server_class:
+            mock_server = MagicMock()
+            mock_server_class.return_value = mock_server
+            mock_server.list_tools = MagicMock(side_effect=list_tools_decorator)
+            mock_server.call_tool = MagicMock(side_effect=call_tool_decorator)
+
+            async def mock_run(*args, **kwargs):
+                pass
+            mock_server.run.return_value = mock_run()
+
+            with patch("llauncher.mcp_server.server.stdio_server") as mock_stdio:
+                mock_stdio.return_value.__aenter__.return_value = (
+                    MagicMock(),
+                    MagicMock(),
+                )
+                with patch(
+                    "llauncher.mcp_server.server.list_tools_handler",
+                    new=AsyncMock(return_value=["a-tool"]),
+                ) as mock_lt, patch(
+                    "llauncher.mcp_server.server.call_tool_handler",
+                    new=AsyncMock(return_value=["a-result"]),
+                ) as mock_ct:
+                    await main_async()
+
+                    # Invoke the captured decorated callbacks (server.py:120, :124).
+                    assert await captured["list_tools"]() == ["a-tool"]
+                    assert await captured["call_tool"]("some_tool", {"k": "v"}) == [
+                        "a-result"
+                    ]
+
+                    mock_lt.assert_awaited_once()
+                    mock_ct.assert_awaited_once_with("some_tool", {"k": "v"})

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -283,9 +283,9 @@ class TestInterfaceCloseout:
             mock_server.list_tools = MagicMock(side_effect=list_tools_decorator)
             mock_server.call_tool = MagicMock(side_effect=call_tool_decorator)
 
-            async def mock_run(*args, **kwargs):
-                pass
-            mock_server.run.return_value = mock_run()
+            # AsyncMock so ``server.run`` is awaitable on every call — avoids
+            # the single-use coroutine footgun of a pre-created coroutine.
+            mock_server.run = AsyncMock()
 
             with patch("llauncher.mcp_server.server.stdio_server") as mock_stdio:
                 mock_stdio.return_value.__aenter__.return_value = (

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -216,6 +216,47 @@ class TestStatusEndpoint:
         assert server["model_config"] is None
 
 
+class TestStatusGpuBranches:
+    """/status GPU-health branch coverage (routing.py:190-195)."""
+
+    def test_status_gpu_no_backends_reports_not_degraded(self, client, monkeypatch):
+        """A collector that reports no backends yields a non-degraded GPU block.
+
+        Covers routing.py:193 — the ``else`` arm when ``get_health()`` returns
+        a payload with a falsy ``backends`` entry (no GPU backend present).
+        """
+        import llauncher.core.gpu as gpu_mod
+
+        class FakeCollector:
+            def get_health(self):
+                return {"backends": []}  # falsy → not-degraded else branch
+
+        monkeypatch.setattr(gpu_mod, "GPUHealthCollector", FakeCollector)
+
+        response = client.get("/status")
+        assert response.status_code == 200
+        assert response.json()["gpu"] == {"degraded": False, "error": None}
+
+    def test_status_gpu_collector_exception_reports_degraded(self, client, monkeypatch):
+        """A collector that raises degrades the GPU block instead of 500-ing.
+
+        Covers routing.py:194-195 — any exception from the GPU collector is
+        caught and surfaced as ``{"degraded": True, "error": <ExcType>}`` so
+        the status poll stays healthy.
+        """
+        import llauncher.core.gpu as gpu_mod
+
+        class BoomCollector:
+            def __init__(self):
+                raise RuntimeError("no gpu backend")
+
+        monkeypatch.setattr(gpu_mod, "GPUHealthCollector", BoomCollector)
+
+        response = client.get("/status")
+        assert response.status_code == 200
+        assert response.json()["gpu"] == {"degraded": True, "error": "RuntimeError"}
+
+
 class TestModelsEndpoint:
     """Tests for the /models endpoint."""
 
@@ -846,6 +887,62 @@ class TestUtilityFunctions:
 
         assert result is False
         assert "Error stopping agent: test" in error_msg
+
+    def test_stop_agent_psutil_race_returns_false(self, monkeypatch):
+        """psutil fallback: a NoSuchProcess/AccessDenied race is swallowed.
+
+        Covers server.py:117-124 — ``find_process_on_port`` returns None so
+        we enter the psutil fallback, find a LISTEN connection on the port,
+        but ``psutil.Process``/``terminate`` loses a race against the process
+        exiting (NoSuchProcess). The ``except`` ``continue``s, the loop
+        exhausts, and the function logs the warning and returns False.
+        """
+        from llauncher.agent.server import stop_agent
+        import psutil
+        from unittest.mock import MagicMock
+
+        class MockResponse:
+            status_code = 200
+
+        monkeypatch.setattr("httpx.get", lambda url, timeout: MockResponse())
+        # Not found via /proc → drop into the psutil fallback loop.
+        monkeypatch.setattr(
+            "llauncher.agent.server.find_process_on_port", lambda port: None
+        )
+
+        mock_conn = MagicMock()
+        mock_conn.laddr.port = 8080
+        mock_conn.status = "LISTEN"
+        mock_conn.pid = 5678
+        monkeypatch.setattr("psutil.net_connections", lambda kind: [mock_conn])
+
+        def raise_nosuch(proc):
+            raise psutil.NoSuchProcess(proc)
+
+        monkeypatch.setattr("psutil.Process", raise_nosuch)
+
+        result = stop_agent(8080)
+
+        # The race was swallowed (continue), the loop found nothing live to
+        # terminate, and the function reported failure.
+        assert result is False
+
+    def test_stop_agent_non_200_health_returns_false(self, monkeypatch):
+        """A non-200 health response means no live agent → False.
+
+        Covers server.py:123-124 — the ``else`` arm when the health probe
+        answers with a non-200 status (something is on the port but it is
+        not a healthy llauncher agent), so we do not attempt a kill.
+        """
+        from llauncher.agent.server import stop_agent
+
+        class MockResponse:
+            status_code = 503
+
+        monkeypatch.setattr("httpx.get", lambda url, timeout: MockResponse())
+
+        result = stop_agent(8080)
+        assert result is False
 
     def test_run_agent(self, monkeypatch):
         """Test run_agent calls uvicorn.run with correct parameters."""

--- a/tests/unit/test_agent_middleware.py
+++ b/tests/unit/test_agent_middleware.py
@@ -87,7 +87,124 @@ def test_with_empty_api_key_returns_403():
 def test_health_exempt_with_empty_key(self=None):
     """/health remains accessible even when a wrong/empty key is sent (exempt path)."""
     app, client = _make_app(token="secret")
-    
+
     # Exempt paths bypass auth entirely — empty or wrong key doesn't matter
     response = client.get("/health", headers={"X-Api-Key": ""})
     assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# BodySizeLimitMiddleware — ASGI-level edge branches (INTERFACE close-out)
+# ---------------------------------------------------------------------------
+import pytest  # noqa: E402
+
+from llauncher.agent.middleware import BodySizeLimitMiddleware  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_limited_receive_forwards_non_request_message():
+    """``limited_receive`` forwards non-``http.request`` messages verbatim.
+
+    Covers middleware.py:141: a downstream app that keeps draining
+    ``receive`` past the body will eventually get a non-request message
+    (e.g. ``http.disconnect``); the wrapper must return it unchanged
+    without touching the byte accumulator.
+    """
+    seen: list[str] = []
+
+    async def inner_app(scope, receive, send):
+        # Drain until the disconnect — this pulls the non-request message
+        # through ``limited_receive`` (middleware.py:140-141).
+        while True:
+            msg = await receive()
+            seen.append(msg["type"])
+            if msg["type"] == "http.disconnect":
+                return
+
+    mw = BodySizeLimitMiddleware(inner_app, max_bytes=1024)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/x",
+        "headers": [],  # no content-length → streaming path
+    }
+
+    messages = iter(
+        [
+            {"type": "http.request", "body": b"hi", "more_body": False},
+            {"type": "http.disconnect"},
+        ]
+    )
+
+    async def receive():
+        try:
+            return next(messages)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+
+    async def send(message):
+        pass
+
+    await mw(scope, receive, send)
+
+    # The under-cap request flowed through, and the non-request disconnect
+    # was forwarded to the downstream app (the line-141 branch).
+    assert "http.request" in seen
+    assert "http.disconnect" in seen
+
+
+@pytest.mark.asyncio
+async def test_guarded_send_suppresses_late_response_after_rejection():
+    """A send attempted *after* the cap trips is suppressed.
+
+    Covers middleware.py:159: once ``rejected`` is set (body exceeded the
+    cap, surfaced to the app as a sentinel ``http.disconnect``), a
+    downstream app that still tries to emit a response has those messages
+    swallowed by ``guarded_send`` — only the middleware's own 413 reaches
+    the wire.
+    """
+
+    async def inner_app(scope, receive, send):
+        # Consume until the cap-trip sentinel, then (mis)behave by emitting
+        # a 200 anyway — guarded_send must drop it.
+        while True:
+            msg = await receive()
+            if msg["type"] == "http.disconnect":
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"late"})
+
+    mw = BodySizeLimitMiddleware(inner_app, max_bytes=1024)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/x",
+        "headers": [(b"content-type", b"application/json")],  # streaming path
+    }
+
+    chunks = iter(
+        [
+            {"type": "http.request", "body": b"a" * 2048, "more_body": False},
+        ]
+    )
+
+    async def receive():
+        try:
+            return next(chunks)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+
+    # The downstream 200 was suppressed; the only response.start on the wire
+    # is the middleware's 413.
+    starts = [m for m in sent if m["type"] == "http.response.start"]
+    assert len(starts) == 1
+    assert starts[0]["status"] == 413

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -602,3 +602,181 @@ def test_invalid_subcommand():
     """Unknown subcommand should produce a helpful error."""
     result = runner.invoke(app, ["bogus"])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# INTERFACE coverage close-out (issue: coverage close-out, INTERFACE cluster)
+# ---------------------------------------------------------------------------
+
+
+def test_print_table_colours_status_keywords():
+    """``_print_table`` styles ``online``/``serving`` and ``stopped`` cells.
+
+    Exercises the per-cell status-keyword branches (cli.py:75-80): a value
+    of ``online`` (or ``running``/``serving``) takes the green branch and a
+    value of ``stopped`` takes the yellow branch. We render directly rather
+    than through a command so every status keyword is hit deterministically
+    regardless of live node/server state.
+    """
+    # No assertion on ANSI styling itself (Rich owns that); reaching the
+    # branches without raising is the coverage target. ``serving`` and
+    # ``online`` both flow through the first branch (cli.py:76); ``stopped``
+    # through the second (cli.py:78); ``offline`` through the third.
+    cli._print_table(
+        ["STATUS"],
+        [["online"], ["serving"], ["running"], ["stopped"], ["offline"], ["other"]],
+        title="Styling",
+    )
+
+
+def test_server_status_json_with_running_server(mock_config_store):
+    """``server status --json`` exports each running server via ``to_dict``.
+
+    Covers the JSON export loop body (cli.py:270): with at least one entry
+    in ``state.running`` the command serializes ``srv.to_dict()`` keyed by
+    port string.
+    """
+    _dir, _path = mock_config_store
+
+    srv = MagicMock()
+    srv.to_dict.return_value = {"port": 8080, "config_name": "m", "pid": 7}
+
+    with patch("llauncher.cli.LauncherState") as MockState:
+        instance = MagicMock()
+        instance.running = {8080: srv}
+        MockState.return_value = instance
+
+        result = runner.invoke(app, ["server", "status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == {"8080": {"port": 8080, "config_name": "m", "pid": 7}}
+
+
+def test_server_status_table_uptime_boundaries(mock_config_store):
+    """``server status`` table renders hour/minute/second uptime formats.
+
+    Covers the uptime-formatting boundaries (cli.py:283 hours branch, 285
+    minutes branch; the sub-minute branch is already covered elsewhere). We
+    seed three running servers whose ``uptime_seconds`` land in each band.
+    """
+    _dir, _path = mock_config_store
+
+    def _srv(name, pid, secs):
+        s = MagicMock()
+        s.config_name = name
+        s.pid = pid
+        s.uptime_seconds.return_value = secs
+        return s
+
+    running = {
+        8001: _srv("hours", 11, 7265),    # >= 3600 → "2h 1m"  (line 283)
+        8002: _srv("minutes", 12, 125),   # >= 60   → "2m 5s"  (line 285)
+        8003: _srv("seconds", 13, 42),    # < 60    → "42s"
+    }
+
+    with patch("llauncher.cli.LauncherState") as MockState:
+        instance = MagicMock()
+        instance.running = running
+        MockState.return_value = instance
+
+        result = runner.invoke(app, ["server", "status"])
+        assert result.exit_code == 0
+        # Rich may wrap the table, but the model names anchor the rows.
+        assert "hours" in result.stdout
+        assert "minutes" in result.stdout
+        assert "seconds" in result.stdout
+
+
+def test_list_nodes_json(node_config_file):
+    """``node list --json`` emits ``registry.to_dict()`` (cli.py:371-372)."""
+    with patch("llauncher.cli.NodeRegistry") as MockReg:
+        reg_instance = MagicMock()
+        reg_instance.to_dict.return_value = {"nodeA": {"host": "1.2.3.4", "port": 8765}}
+        MockReg.return_value = reg_instance
+
+        result = runner.invoke(app, ["node", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data == {"nodeA": {"host": "1.2.3.4", "port": 8765}}
+        reg_instance.to_dict.assert_called_once()
+
+
+def _mock_node(host, port, status_value):
+    node = MagicMock()
+    node.host = host
+    node.port = port
+    node.status.value = status_value
+    return node
+
+
+def test_node_status_table_online_only(node_config_file):
+    """``node status`` (no ``--all``) renders only online nodes (cli.py:427-433,439)."""
+    online = _mock_node("10.0.0.1", 8765, "online")
+    offline = _mock_node("10.0.0.2", 8765, "offline")
+
+    with patch("llauncher.cli.NodeRegistry") as MockReg:
+        reg_instance = MagicMock()
+        reg_instance._nodes = {"up": online, "down": offline}
+        # get_node(...).ping() is a no-op MagicMock — the ping loop's try
+        # branch runs without raising.
+        MockReg.return_value = reg_instance
+
+        result = runner.invoke(app, ["node", "status"])
+        assert result.exit_code == 0
+        assert "up" in result.stdout
+        # Offline node filtered out of the default (online-only) view.
+        assert "down" not in result.stdout
+
+
+def test_node_status_table_all_includes_offline(node_config_file):
+    """``node status --all`` includes offline/error nodes (cli.py:427 True branch)."""
+    online = _mock_node("10.0.0.1", 8765, "online")
+    offline = _mock_node("10.0.0.2", 8765, "offline")
+
+    with patch("llauncher.cli.NodeRegistry") as MockReg:
+        reg_instance = MagicMock()
+        reg_instance._nodes = {"up": online, "down": offline}
+        MockReg.return_value = reg_instance
+
+        result = runner.invoke(app, ["node", "status", "--all"])
+        assert result.exit_code == 0
+        assert "up" in result.stdout
+        assert "down" in result.stdout
+
+
+def test_node_status_table_empty_roster(node_config_file):
+    """``node status`` with no registered nodes prints the empty notice (cli.py:435-436)."""
+    with patch("llauncher.cli.NodeRegistry") as MockReg:
+        reg_instance = MagicMock()
+        reg_instance._nodes = {}
+        MockReg.return_value = reg_instance
+
+        result = runner.invoke(app, ["node", "status"])
+        assert result.exit_code == 0
+        assert "no nodes registered" in result.stdout.lower()
+
+
+def test_config_validate_schema_exception(mock_config_store):
+    """``config validate`` reports a schema failure on the exception path.
+
+    Covers cli.py:472-474: ``get_model`` returns a config (so we pass the
+    not-found guard) but the re-validation via ``ModelConfig.model_validate``
+    raises, taking the ``except`` branch that prints the failure and exits 1.
+    """
+    _dir, _path = mock_config_store
+
+    cfg = ModelConfig.from_dict_unvalidated({
+        "name": "broken-model",
+        "model_path": "/fake/path/model.gguf",
+    })
+
+    with patch("llauncher.cli.ConfigStore.get_model", return_value=cfg):
+        with patch(
+            "llauncher.cli.ModelConfig.model_validate",
+            side_effect=ValueError("schema boom"),
+        ):
+            result = runner.invoke(app, ["config", "validate", "broken-model"])
+
+    assert result.exit_code == 1
+    assert "validation failed" in result.stdout.lower()
+    assert "schema boom" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -610,23 +610,54 @@ def test_invalid_subcommand():
 
 
 def test_print_table_colours_status_keywords():
-    """``_print_table`` styles ``online``/``serving`` and ``stopped`` cells.
+    """``_print_table`` routes status keywords through ``_color``, others through ``Text``.
 
-    Exercises the per-cell status-keyword branches (cli.py:75-80): a value
-    of ``online`` (or ``running``/``serving``) takes the green branch and a
-    value of ``stopped`` takes the yellow branch. We render directly rather
-    than through a command so every status keyword is hit deterministically
-    regardless of live node/server state.
+    Exercises the per-cell status-keyword branches (cli.py:75-80) *and*
+    asserts the routing so a branch swap or a misspelled keyword would fail:
+    every recognised status (``online``/``serving``/``running`` → green
+    branch line 76; ``stopped`` → yellow branch line 78; ``offline`` → line
+    79-80) must be handed to ``_color`` with its lowercased status, while a
+    non-status value must NOT be (it falls to the plain-``Text`` else arm).
     """
-    # No assertion on ANSI styling itself (Rich owns that); reaching the
-    # branches without raising is the coverage target. ``serving`` and
-    # ``online`` both flow through the first branch (cli.py:76); ``stopped``
-    # through the second (cli.py:78); ``offline`` through the third.
-    cli._print_table(
-        ["STATUS"],
-        [["online"], ["serving"], ["running"], ["stopped"], ["offline"], ["other"]],
-        title="Styling",
-    )
+    from unittest.mock import patch as _patch
+
+    rows = [["online"], ["serving"], ["running"], ["stopped"], ["offline"], ["other"]]
+    with _patch("llauncher.cli._color", wraps=cli._color) as color_spy:
+        cli._print_table(["STATUS"], rows, title="Styling")
+
+    routed = {call.args for call in color_spy.call_args_list}
+    # Each recognised keyword reached its colour branch with (value, status).
+    for kw in ("online", "serving", "running", "stopped", "offline"):
+        assert (kw, kw) in routed, f"{kw} did not route through _color"
+    # The non-status value took the plain-Text else branch, never _color.
+    assert all(
+        call.args[0] != "other" for call in color_spy.call_args_list
+    ), "non-status value should not be colourised"
+
+
+def test_node_status_ping_failure_is_swallowed(node_config_file):
+    """A node whose ``ping()`` raises does not abort the status render (cli.py:407-409).
+
+    The ping refresh loop swallows a transient failure and keeps the node's
+    prior status so one flaky node cannot blank the whole status table.
+    """
+    node = _mock_node("10.0.0.9", 8765, "online")
+
+    with patch("llauncher.cli.NodeRegistry") as MockReg:
+        reg_instance = MagicMock()
+        reg_instance._nodes = {"flaky": node}
+        pinger = MagicMock()
+        pinger.ping.side_effect = RuntimeError("transient transport hiccup")
+        reg_instance.get_node.return_value = pinger
+        MockReg.return_value = reg_instance
+
+        result = runner.invoke(app, ["node", "status"])
+
+    # The swallow kept the loop alive; the node still renders from its prior
+    # (online) status rather than the command aborting.
+    assert result.exit_code == 0
+    assert "flaky" in result.stdout
+    pinger.ping.assert_called_once()
 
 
 def test_server_status_json_with_running_server(mock_config_store):


### PR DESCRIPTION
## Coverage close-out — INTERFACE cluster

Every targeted uncovered line in the INTERFACE cluster is now **covered** or carries an **explicit justification**. Branched off `main` @ `af5f0f7`; source verified unchanged before writing tests. Gates: full pytest green (1267 passed, 12 skipped); non-UI coverage **96.61%** (≥93 floor). All five targeted modules at **100%**.

### Covered (genuine tests)

**`llauncher/cli.py`** — now 100%, no exclusions
- 76 & 78 — `_print_table` status-cell styling; the test asserts each recognised keyword (online/serving/running → green, stopped → yellow, offline → red) routes through `_color` and the non-status value does not, so a branch swap or misspelling fails
- 270 — `server status --json` export loop (`srv.to_dict()` keyed by port)
- 283 & 285 — uptime formatting hour / minute boundaries
- 371-372 — `node list --json` (`registry.to_dict()`)
- 407-409 — node-ping refresh loop swallows a transient `ping()` failure and keeps prior status (covered directly via a raising mock — see "review" note below)
- 427-439 — `node status` filtering/rendering: online-only default, `--all` (offline included), empty-roster notice
- 472-474 — `config validate` schema-exception path (re-validation raises → exit 1)

**`llauncher/mcp_server/server.py`**
- 83 — `cancel_server` dispatch arm (stateless verb; asserts singleton untouched)
- 120 & 124 — the decorated `list_tools` / `call_tool` callbacks registered in `main_async`, captured and invoked so their bodies delegate to the handlers

**`llauncher/agent/middleware.py`**
- 141 — `limited_receive` forwards a non-`http.request` message verbatim
- 159 — `guarded_send` suppresses a late downstream response after the body cap trips

**`llauncher/agent/routing.py`**
- 193-195 — `/status` GPU branches: no-backends → `{degraded: False}`; collector raises → `{degraded: True, error: <ExcType>}`

**`llauncher/agent/server.py`**
- 117-124 — `stop_agent` psutil fallback: `NoSuchProcess` race swallowed → False; plus the non-200 health-response `else` branch

### Excluded (defensible)

- **`llauncher/mcp_server/__main__.py`** — added to `[tool.coverage.run].omit` for parity with the already-omitted `agent/__main__.py`: a 2-line `python -m` entry shim that runs `_main()` at import time (cannot be unit-imported without launching the stdio server). `server.main` / `server.main_async` themselves are unit-covered.

> The originally-planned `# pragma: no cover` on cli.py:408-409 was **dropped after review** — the node-ping swallow is genuinely testable via a raising mock, so it is now covered by a real test rather than excluded. No defensible-exclude pragmas remain in this diff.

### Review
Dispatched a `harness-tools:reviewer` pass. Findings addressed: (1) `_print_table` test gained a behavioral assertion (was assertion-free); (2) the cli.py:408-409 pragma justification was inaccurate — covered the line instead and removed the pragma; (3) `mock_server.run` switched to `AsyncMock` to avoid a single-use-coroutine footgun. All other new tests confirmed mechanically sound (mocks correctly targeted at lazily-imported names, assertions regression-catching, no uncleaned global state).

### Verification
```
llauncher/agent/middleware.py     66   0   100%
llauncher/agent/routing.py       162   0   100%
llauncher/agent/server.py        151   0   100%
llauncher/cli.py                 228   0   100%
llauncher/mcp_server/server.py    72   0   100%
```
