### PR TITLE
test(remote): coverage close-out for node/state/registry cluster

### DIFF
--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -60,7 +60,7 @@ class NodeRegistry:
                     timeout=node_data.get("timeout", 5.0),
                     api_key=raw_key,
                 )
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError):  # pragma: no cover - defensive recovery from a corrupted/partial nodes.json; start fresh rather than crash UI startup
             # Corrupted file, start fresh
             self._nodes.clear()
 
@@ -142,7 +142,7 @@ class NodeRegistry:
         """
         tokens = self._load_node_tokens()
         for name, token in tokens.items():
-            if name == "local":
+            if name == "local":  # pragma: no cover - C10 security guard: 'local' token is never sourced from the sidecar (canonical source is agent.token); skip to prevent credential confusion
                 continue
             node = self._nodes.get(name)
             if node is not None and not node.api_key:
@@ -233,7 +233,7 @@ class NodeRegistry:
         NODES_FILE.parent.mkdir(parents=True, exist_ok=True)
         try:
             NODES_FILE.parent.chmod(0o700)
-        except OSError:
+        except OSError:  # pragma: no cover - best-effort dir chmod; no-op/failure on exotic FS (WSL-on-NTFS, some cloud mounts) is swallowed, the 0600 on the file is the load-bearing protection
             # Best-effort; chmod is a no-op on some filesystems (e.g.
             # WSL-on-NTFS). The 0600 on the file itself is the
             # load-bearing protection.
@@ -253,7 +253,7 @@ class NodeRegistry:
 
         try:
             os.chmod(NODES_FILE, 0o600)
-        except OSError as e:
+        except OSError as e:  # pragma: no cover - best-effort re-tighten; chmod failure on exotic FS (WSL-on-NTFS, cloud mounts) is logged-and-swallowed, not fatal
             logger.warning(f"Could not set restrictive permissions on {NODES_FILE}: {e}")
 
         # Sidecar tokens file (issue #132). Wrapped so a token-write
@@ -261,7 +261,7 @@ class NodeRegistry:
         # succeeded — the two files are independent on purpose.
         try:
             self._save_node_tokens()
-        except Exception as e:  # noqa: BLE001 — defensive isolation
+        except Exception as e:  # noqa: BLE001 — defensive isolation  # pragma: no cover - isolates a sidecar token-write failure from the just-succeeded nodes.json write (#132); the two files are independent on purpose
             logger.warning(f"Could not write {NODE_TOKENS_FILE}: {e}")
 
     def add_node(

--- a/tests/unit/test_remote_node_extended.py
+++ b/tests/unit/test_remote_node_extended.py
@@ -206,3 +206,146 @@ class TestStopAndLogsErrorPaths:
         n = _node()
         assert n.get_logs(8081) is None
         assert n.status == NodeStatus.OFFLINE
+
+
+# ---------------------------------------------------------------------------
+# start_server error/transport fallback — symmetry with swap_server /
+# delete_model (TestVerbDetailSurfacing already covers those). Covers the
+# bare-except on malformed-JSON ``detail`` (node.py 336-337), the
+# non-dict/HTTP fallback return (340-343), and the transport-error → OFFLINE
+# branch (344-346).
+# ---------------------------------------------------------------------------
+
+class TestStartServerErrorPaths:
+    @patch("httpx.Client")
+    def test_start_server_detail_missing_falls_back(self, mock_cls):
+        """Non-200 whose body is not JSON → bare-except swallows, then the
+        ``HTTP {code}`` fallback envelope is returned (336-337, 340-343)."""
+        resp = MagicMock(status_code=500)
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+        mock_cls.return_value = _http_client_mock(response=resp)
+        out = _node().start_server("modelX", 8081)
+        assert out["success"] is False
+        assert "HTTP 500" in out["error"]
+
+    @patch("httpx.Client")
+    def test_start_server_detail_non_dict_falls_back(self, mock_cls):
+        """A ``detail`` that is a bare string (not a dict) takes the same
+        fallback path, surfacing the string as the error (340-343)."""
+        resp = MagicMock(status_code=503)
+        resp.json = MagicMock(return_value={"detail": "service unavailable"})
+        mock_cls.return_value = _http_client_mock(response=resp)
+        out = _node().start_server("modelX", 8081)
+        assert out["success"] is False
+        assert out["error"] == "service unavailable"
+
+    @patch("httpx.Client")
+    def test_start_server_request_error_marks_offline(self, mock_cls):
+        """Transport error → OFFLINE + error envelope (344-346)."""
+        mock_cls.side_effect = httpx.RequestError("down")
+        n = _node()
+        out = n.start_server("modelX", 8081)
+        assert out["success"] is False
+        assert n.status == NodeStatus.OFFLINE
+
+
+# ---------------------------------------------------------------------------
+# swap_server HTTP success path (node.py 364-366) — the detail/error/
+# transport branches are covered in TestVerbDetailSurfacing; the 200 path
+# was the remaining gap.
+# ---------------------------------------------------------------------------
+
+class TestSwapServerSuccess:
+    @patch("httpx.Client")
+    def test_swap_server_success_returns_json_and_online(self, mock_cls):
+        resp = MagicMock(status_code=200)
+        resp.json = MagicMock(return_value={"success": True, "action": "swapped"})
+        mock_cls.return_value = _http_client_mock(response=resp)
+        n = _node()
+        out = n.swap_server("modelX", 8081)
+        assert out == {"success": True, "action": "swapped"}
+        assert n.status == NodeStatus.ONLINE
+
+
+# ---------------------------------------------------------------------------
+# read_audit ``result_filter`` — self-loop (node.py 516) and HTTP (523).
+# The existing suite exercises ``action_filter`` on both branches but not
+# ``result_filter``.
+# ---------------------------------------------------------------------------
+
+class TestReadAuditResultFilter:
+    def test_self_loop_applies_result_filter(self, tmp_path, monkeypatch):
+        """In-process branch filters on ``AuditResult`` value (516)."""
+        from llauncher.core import audit_log
+
+        audit_path = tmp_path / "audit.jsonl"
+        monkeypatch.setattr(
+            "llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path
+        )
+        audit_log.record(
+            audit_log.AuditAction.STARTED, audit_log.AuditResult.SUCCESS, caller="t"
+        )
+        audit_log.record(
+            audit_log.AuditAction.STARTED, audit_log.AuditResult.ERROR, caller="t"
+        )
+
+        monkeypatch.setenv("LLAUNCHER_IS_AGENT_PROCESS", "1")
+        node = RemoteNode("local", "127.0.0.1", port=8765)
+        with patch("httpx.Client") as mock_client_class:
+            entries = node.read_audit(result_filter="error")
+            mock_client_class.assert_not_called()
+
+        assert len(entries) == 1
+        assert entries[0]["result"] == "error"
+
+    @patch("httpx.Client")
+    def test_http_passes_result_filter_param(self, mock_cls):
+        """HTTP branch forwards ``result_filter`` as the ``result`` query
+        param (523)."""
+        resp = MagicMock(status_code=200)
+        resp.json = MagicMock(return_value=[])
+        client = _http_client_mock(response=resp)
+        mock_cls.return_value = client
+        out = _node().read_audit(limit=20, result_filter="success")
+        assert out == []
+        params = client.get.call_args.kwargs["params"]
+        assert params["result"] == "success"
+        assert params["limit"] == 20
+
+
+# ---------------------------------------------------------------------------
+# local_agent_node() factory (node.py 572-576).
+# ---------------------------------------------------------------------------
+
+class TestLocalAgentNodeFactory:
+    def test_builds_local_target_with_resolved_token(self, monkeypatch):
+        from llauncher.remote.node import local_agent_node
+
+        monkeypatch.setattr("llauncher.core.settings.AGENT_PORT", 9999)
+        monkeypatch.setattr(
+            "llauncher.core.agent_token.resolve_agent_token",
+            lambda allow_generate=False: "resolved-token",
+        )
+
+        node = local_agent_node()
+
+        assert node.name == "local"
+        assert node.host == "127.0.0.1"
+        assert node.port == 9999
+        assert node.api_key == "resolved-token"
+
+    def test_builds_local_target_with_no_token(self, monkeypatch):
+        """``allow_generate=False`` resolver returning None → api_key None."""
+        from llauncher.remote.node import local_agent_node
+
+        monkeypatch.setattr("llauncher.core.settings.AGENT_PORT", 8765)
+        monkeypatch.setattr(
+            "llauncher.core.agent_token.resolve_agent_token",
+            lambda allow_generate=False: None,
+        )
+
+        node = local_agent_node()
+
+        assert node.name == "local"
+        assert node.port == 8765
+        assert node.api_key is None

--- a/tests/unit/test_remote_state_extended.py
+++ b/tests/unit/test_remote_state_extended.py
@@ -149,6 +149,90 @@ class TestGetModelsByName:
             assert "node2" not in model2_nodes
 
 
+    def test_get_models_by_name_skips_offline_node(self):
+        """A node returning ``None`` (offline) is skipped, not crashed on
+        (state.py 112 — the ``continue`` guard)."""
+        registry = NodeRegistry()
+        registry.add_node("online-node", "localhost", 8765)
+        registry.add_node("offline-node", "localhost", 8766)
+
+        aggregator = RemoteAggregator(registry)
+
+        def mock_get_models(self):
+            if self.name == "online-node":
+                return [{"name": "model1", "model_path": "/p/model1"}]
+            return None  # offline → triggers the continue
+
+        with patch.object(RemoteNode, "get_models", mock_get_models):
+            models_by_name = aggregator.get_models_by_name()
+
+        assert "model1" in models_by_name
+        # Only the online node contributed; the offline node was skipped.
+        assert [n for n, _ in models_by_name["model1"]] == ["online-node"]
+
+
+class TestSwapOnNode:
+    """Tests for RemoteAggregator.swap_on_node method (state.py 151-155)."""
+
+    def test_swap_on_node_not_found(self):
+        registry = NodeRegistry()
+        aggregator = RemoteAggregator(registry)
+
+        result = aggregator.swap_on_node("nonexistent", "test-model", 8081)
+
+        assert result is not None
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    def test_swap_on_node_success(self):
+        registry = NodeRegistry()
+        registry.add_node("test-node", "localhost", 8765)
+        aggregator = RemoteAggregator(registry)
+
+        captured: dict = {}
+
+        def mock_swap_server(self, model_name, port):
+            captured["args"] = (model_name, port)
+            return {"success": True, "port": port}
+
+        with patch.object(RemoteNode, "swap_server", mock_swap_server):
+            result = aggregator.swap_on_node("test-node", "test-model", 8081)
+
+        assert result["success"] is True
+        assert captured["args"] == ("test-model", 8081)
+
+
+class TestDeleteModelOnNode:
+    """Tests for RemoteAggregator.delete_model_on_node (state.py 163-167)."""
+
+    def test_delete_model_on_node_not_found(self):
+        registry = NodeRegistry()
+        aggregator = RemoteAggregator(registry)
+
+        result = aggregator.delete_model_on_node("nonexistent", "test-model")
+
+        assert result is not None
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    def test_delete_model_on_node_success(self):
+        registry = NodeRegistry()
+        registry.add_node("test-node", "localhost", 8765)
+        aggregator = RemoteAggregator(registry)
+
+        captured: dict = {}
+
+        def mock_delete_model(self, model_name):
+            captured["arg"] = model_name
+            return {"success": True}
+
+        with patch.object(RemoteNode, "delete_model", mock_delete_model):
+            result = aggregator.delete_model_on_node("test-node", "test-model")
+
+        assert result["success"] is True
+        assert captured["arg"] == "test-model"
+
+
 class TestStartOnNode:
     """Tests for RemoteAggregator.start_on_node method."""
 


### PR DESCRIPTION
Coverage close-out for the **remote cluster** (`llauncher/remote/node.py`, `state.py`, `registry.py`). Principle: every uncovered line is either covered by a genuine test or excluded with an explicit `# pragma: no cover` + one-line reason. All three modules now report **100%** under the targeted measurement; full non-UI coverage **96.46%** (floor 93).

## Covered (genuine tests)

**`llauncher/remote/node.py`**
- `364-366` — `swap_server` HTTP 200 success path (`TestSwapServerSuccess`).
- `516` & `523` — `read_audit(result_filter=…)` on both the self-loop and HTTP branches (`TestReadAuditResultFilter`). The existing suite exercised `action_filter` on both branches but not `result_filter`.
- `572-576` — `local_agent_node()` factory, resolved-token and no-token cases (`TestLocalAgentNodeFactory`).
- `336-346` — `start_server` error/transport fallback: malformed-JSON bare-except (336-337), non-dict/HTTP fallback envelope (340-343), transport→OFFLINE (344-346) (`TestStartServerErrorPaths`).
  - **Note:** the cluster triage listed these as *defensible → pragma*. I **covered** them instead because the byte-for-byte identical paths in `swap_server` and `delete_model` are already tested (`TestVerbDetailSurfacing`); pragma-ing only `start_server`'s copy would be an in-file asymmetry, and the two extra tests are cheap. Flagging the deviation explicitly per the bounce/visibility discipline.

**`llauncher/remote/state.py`**
- `112` — `get_models_by_name` offline-node `continue` guard.
- `151-155` — `swap_on_node` not-found + success delegation.
- `163-167` — `delete_model_on_node` not-found + success delegation.

## Excluded (`# pragma: no cover` + reason)

**`llauncher/remote/registry.py`** — all genuinely defensive:
- `63-65` — corrupted `nodes.json` recovery (`JSONDecodeError`/`KeyError` → start fresh rather than crash UI startup).
- `146` — C10 security guard: the `local` token is never sourced from `node_tokens.json` (canonical source is `agent.token`); the `continue` prevents credential confusion. Pragma + reason makes the intent visibly intentional.
- `236-240` — best-effort parent-dir `chmod(0o700)`; no-op/failure on exotic FS (WSL-on-NTFS, some cloud mounts) is swallowed — the `0600` on the file is the load-bearing protection.
- `256-257` — best-effort `nodes.json` `chmod(0o600)` re-tighten; failure logged-and-swallowed.
- `264-265` — isolates a sidecar token-write failure from the just-succeeded `nodes.json` write (#132); the two files are independent on purpose.

## Gate
- `pytest tests/` → **1263 passed, 12 skipped**.
- Non-UI coverage **96.46%** (`--cov-fail-under=93`).
- Targeted modules `node.py` / `state.py` / `registry.py` → **100%**.

No production behavior changed (test additions + pragma comments only).