### PR TITLE
test(ops,gpu): coverage close-out for OPS-GPU cluster

### DIFF
--- a/llauncher/core/gpu.py
+++ b/llauncher/core/gpu.py
@@ -376,7 +376,7 @@ class GPUHealthCollector:
             gpu_index = 0
             for line in out.stdout.splitlines():
                 match = re.search(r"(\w[\w\s.]+)\s*\n.*?Chipset Model", line)
-                if match:
+                if match:  # pragma: no cover - dead branch (issue #246): the regex requires a literal '\n' but splitlines() strips it, so this never matches real system_profiler output; the block-level fallback below is the live MPS-discovery path. Bounced rather than fixed (production MPS-parse change, unverifiable on this non-Apple host).
                     name = match.group(1).strip()
                     result["devices"].append(
                         GPUDevice(index=gpu_index, name=name, total_vram_mb=_estimate_apple_unified_mem())

--- a/llauncher/operations/orphan.py
+++ b/llauncher/operations/orphan.py
@@ -70,7 +70,7 @@ def list_orphans(*, caller: str = "reconcile") -> list[OrphanInfo]:
     for process, port, unreadable in proc.find_all_llama_servers_annotated():
         try:
             pid = int(process.pid)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError):  # pragma: no cover - defensive: psutil.Process.pid is always an int, so this coercion guard is effectively unreachable; kept to fail safe rather than crash a reconcile scan on a hypothetically non-numeric pid.
             continue
 
         if unreadable or port is None:

--- a/llauncher/operations/stop.py
+++ b/llauncher/operations/stop.py
@@ -214,7 +214,7 @@ def stop_in_background(port: int, *, caller: str = "unknown") -> StopResult:
         def _run() -> None:
             try:
                 _terminate(port, existing, caller=caller)
-            except OSError as exc:
+            except OSError as exc:  # pragma: no cover - defensive: catches a filesystem error during the background thread's lockfile-removal/audit emit; psutil errors are already absorbed in core.process, and deterministically injecting an OSError into the daemon thread's durable-emit tail is not worth the threaded test scaffolding.
                 # Filesystem failure in lockfile/audit emission. psutil
                 # errors are already absorbed inside core.process. Log
                 # rather than die silently in the thread; the next

--- a/tests/unit/test_gpu_health_extended.py
+++ b/tests/unit/test_gpu_health_extended.py
@@ -443,3 +443,135 @@ class TestIsAvailableRouting:
         with patch.object(gpu_mod, "shutil_which", side_effect=fake_which):
             assert collector.is_available("rocm") is True
             assert collector.is_available("nvidia") is False
+
+
+# ---------------------------------------------------------------------------
+# _collect_devices backend fall-through (priority order)
+# ---------------------------------------------------------------------------
+
+class TestCollectDevicesBackendOrder:
+    def test_collect_devices_selects_rocm_when_nvidia_absent(self):
+        """NVIDIA fails, ROCm succeeds → backend 'rocm', return short-circuits MPS."""
+        collector = GPUHealthCollector()
+
+        def rocm_ok(result):
+            result.devices.append(GPUDevice(index=0, name="ROCm GPU 0", used_vram_mb=512))
+            return True
+
+        with patch.object(collector, "_try_NVIDIA", return_value=False), \
+             patch.object(collector, "_try_ROCM", side_effect=rocm_ok), \
+             patch.object(collector, "_try_MPS", return_value=True) as mps_probe:
+            result = collector._collect_devices()
+
+        assert result.backends == ["rocm"]
+        assert [d.name for d in result.devices] == ["ROCm GPU 0"]
+        # Priority order: MPS is never consulted once ROCm wins.
+        mps_probe.assert_not_called()
+
+    def test_collect_devices_selects_mps_when_nvidia_and_rocm_absent(self):
+        """NVIDIA and ROCm fail, MPS succeeds → backend 'mps'."""
+        collector = GPUHealthCollector()
+
+        def mps_ok(result):
+            result.devices.append(GPUDevice(index=0, name="Apple M3", total_vram_mb=16384))
+            return True
+
+        with patch.object(collector, "_try_NVIDIA", return_value=False), \
+             patch.object(collector, "_try_ROCM", return_value=False), \
+             patch.object(collector, "_try_MPS", side_effect=mps_ok):
+            result = collector._collect_devices()
+
+        assert result.backends == ["mps"]
+        assert [d.name for d in result.devices] == ["Apple M3"]
+
+
+# ---------------------------------------------------------------------------
+# _try_ROCM / _try_MPS success paths
+# ---------------------------------------------------------------------------
+
+class TestBackendProbeSuccessPaths:
+    def test_try_rocm_success_extends_devices(self):
+        """rocm-smi present + _query_ROCM yields a device → True, device added."""
+        collector = GPUHealthCollector()
+        result = GPUHealthResult()
+        with patch.object(gpu_mod, "shutil_which", return_value="/usr/bin/rocm-smi"), \
+             patch.object(
+                 collector, "_query_ROCM",
+                 return_value={"devices": [GPUDevice(index=0, name="ROCm GPU 0", used_vram_mb=999)]},
+             ):
+            assert collector._try_ROCM(result) is True
+        assert len(result.devices) == 1
+        assert result.devices[0].used_vram_mb == 999
+
+    def test_try_mps_success_extends_devices(self):
+        """Apple MPS available + _query_MPS yields a device → True, device added."""
+        collector = GPUHealthCollector()
+        result = GPUHealthResult()
+        with patch.object(gpu_mod, "is_apple_mps_available", return_value=True), \
+             patch.object(
+                 collector, "_query_MPS",
+                 return_value={"devices": [GPUDevice(index=0, name="Apple M3", total_vram_mb=16384)]},
+             ):
+            assert collector._try_MPS(result) is True
+        assert len(result.devices) == 1
+        assert result.devices[0].name == "Apple M3"
+
+    def test_query_mps_populates_via_block_fallback(self):
+        """Realistic system_profiler output → device discovered via the
+        block-level fallback matcher (the live MPS-discovery path; the
+        per-line loop body is dead, see issue #246)."""
+        sp_output = (
+            "Graphics/Displays:\n"
+            "    Apple M3 Pro:\n"
+            "      Chipset Model: Apple M3 Pro\n"
+            "      Type: GPU\n"
+        )
+        collector = GPUHealthCollector()
+        fake_run = MagicMock(return_value=SimpleNamespace(returncode=0, stdout=sp_output))
+        with patch.object(gpu_mod, "is_apple_mps_available", return_value=True), \
+             patch.object(gpu_mod.subprocess, "run", fake_run), \
+             patch.object(gpu_mod, "_estimate_apple_unified_mem", return_value=16384):
+            out = collector._query_MPS()
+        assert len(out["devices"]) == 1
+        assert out["devices"][0].total_vram_mb == 16384
+
+
+# ---------------------------------------------------------------------------
+# _query_ROCM parse-block exception handlers
+# ---------------------------------------------------------------------------
+
+class TestROCMParseExceptionHandlers:
+    def _run_with_splitlines_raising(self, exc):
+        """rocm-smi exits 0 but stdout.splitlines() raises mid-parse."""
+        bad_stdout = MagicMock()
+        bad_stdout.splitlines.side_effect = exc
+        return MagicMock(return_value=SimpleNamespace(returncode=0, stdout=bad_stdout))
+
+    def test_query_rocm_parse_filenotfound_swallowed(self):
+        collector = GPUHealthCollector()
+        fake_run = self._run_with_splitlines_raising(FileNotFoundError("vanished"))
+        with patch.object(gpu_mod.subprocess, "run", fake_run):
+            out = collector._query_ROCM()
+        assert out == {"devices": []}
+
+    def test_query_rocm_parse_timeout_swallowed(self):
+        collector = GPUHealthCollector()
+        fake_run = self._run_with_splitlines_raising(
+            subprocess.TimeoutExpired(cmd="rocm-smi", timeout=10)
+        )
+        with patch.object(gpu_mod.subprocess, "run", fake_run):
+            out = collector._query_ROCM()
+        assert out == {"devices": []}
+
+
+# ---------------------------------------------------------------------------
+# _csv_rows blank-line skip
+# ---------------------------------------------------------------------------
+
+class TestCSVRowsBlankSkip:
+    def test_csv_rows_skips_blank_lines(self):
+        from llauncher.core.gpu import _csv_rows
+
+        rows = _csv_rows("0, A100\n\n   \n1, H100\n")
+        # Blank and whitespace-only lines are dropped; data rows survive.
+        assert rows == [["0", "A100"], ["1", "H100"]]

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -1815,3 +1815,122 @@ def test_swap_cancel_after_success_is_no_op_with_advisory(
     written = lf.read_lockfile(8081, run_dir=run_dir)
     assert written is not None
     assert written.model == "new-model"
+
+
+def test_start_cancel_after_preflight_returns_cancelled(
+    run_dir: Path, audit_path: Path, sample_config: ModelConfig, mock_popen: MagicMock
+) -> None:
+    """Cancel at the *post-preflight* checkpoint (ADR-014) yields no state change.
+
+    ``is_cancelled`` returns False at the pre-preflight checkpoint and True
+    at the post-preflight one, exercising the second cancel gate in
+    ``operations.start`` (``stage="post-preflight"``). The launch must never
+    be reached and no lockfile may be written.
+    """
+    calls = {"n": 0}
+
+    def is_cancelled_side(*_args, **_kwargs):
+        calls["n"] += 1
+        return calls["n"] >= 2  # False pre-preflight, True post-preflight
+
+    with patch("llauncher.operations.ConfigStore.get_model", return_value=sample_config), \
+         patch("llauncher.operations.proc.start_server", return_value=mock_popen) as start_proc, \
+         patch("llauncher.operations.start.mk.is_cancelled", side_effect=is_cancelled_side):
+        result = ops.start("mistral-7b", 8081, caller="test", model_health_check=None)
+
+    assert result.success is False
+    assert result.action == "cancelled"
+    assert "post-preflight" in result.message
+    # Cancel caught before the spawn — launch never attempted.
+    start_proc.assert_not_called()
+    assert lf.read_lockfile(8081, run_dir=run_dir) is None
+    # Marker released by the surrounding finally.
+    assert (run_dir / "8081.swap").exists() is False
+
+    entries = al.read_entries(path=audit_path)
+    assert any(
+        e.action == AuditAction.STARTED and e.result == AuditResult.CANCELLED
+        for e in entries
+    )
+
+
+def test_swap_same_model_in_flight_marker_rejects(
+    run_dir: Path, marker_run_dir: Path, audit_path: Path
+) -> None:
+    """Same-model swap while a marker is already held → ``rejected_in_progress``.
+
+    The 1b same-model short-circuit still takes the marker for concurrency
+    safety (ADR-011); when ``take_marker`` raises ``FileExistsError`` because
+    another op already holds it, ``swap`` returns the in-progress result
+    rather than the idempotent ``already_running``. Exercises the
+    ``except FileExistsError`` branch in the same-model path.
+    """
+    import os
+    from llauncher.core import marker as mk
+
+    lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+    # A live marker (current pid as holder) simulates an op already in flight.
+    mk.take_marker(
+        8081, caller="other", from_model="mistral-7b", to_model="mistral-7b"
+    )
+
+    result = ops.swap("mistral-7b", 8081, caller="test")
+
+    assert result.success is False
+    assert result.action == "rejected_in_progress"
+    assert result.port_state == "unchanged"
+    assert result.previous_model == "mistral-7b"
+    # The pre-existing live marker is left in place — we don't own it.
+    assert (run_dir / "8081.swap").exists() is True
+
+    entries = al.read_entries(path=audit_path)
+    assert any(
+        e.action == AuditAction.SWAPPED
+        and e.result == AuditResult.REJECTED_IN_PROGRESS
+        for e in entries
+    )
+
+
+def test_launch_and_await_ready_lockfile_race_terminate_oserror(caplog) -> None:
+    """Lockfile race during launch + terminate raises OSError → logged, race returned.
+
+    Covers the OSError cleanup branch in ``_launch_and_await_ready``: the new
+    model's atomic lockfile write loses a race, so we tear down the process we
+    just spawned — but ``terminate`` raises ``OSError`` because the process
+    already exited (ESRCH). The exception is logged (not swallowed silently,
+    per issue #61) and the race tuple is returned. Parallels the start-side
+    ``test_start_lockfile_race_terminate_oserror_does_not_mask_error``.
+    """
+    import importlib
+    import logging
+
+    # ``operations.swap`` the attribute is the verb function (the package
+    # re-exports it), so reach the module via importlib — same gotcha the
+    # background-stop reap test documents.
+    swap_mod = importlib.import_module("llauncher.operations.swap")
+
+    racing_popen = MagicMock()
+    racing_popen.pid = 88888
+    racing_popen.terminate.side_effect = OSError("process already exited (ESRCH)")
+    cfg = _make_config("new-model")
+
+    with patch(
+        "llauncher.operations.swap.proc.start_server", return_value=racing_popen
+    ), patch(
+        "llauncher.operations.swap.lf.write_lockfile",
+        side_effect=FileExistsError("raced"),
+    ):
+        with caplog.at_level(logging.ERROR, logger="llauncher.operations.swap"):
+            ready, pid, logs, err = swap_mod._launch_and_await_ready(
+                cfg, 8081, server_bin=None, readiness_timeout=1
+            )
+
+    assert ready is False
+    assert pid == 88888
+    assert logs == []
+    assert "lockfile race" in err
+    assert any("Failed to terminate raced-launch" in r.message for r in caplog.records)
+    assert any(
+        isinstance(r.exc_info, tuple) and r.exc_info[0] is OSError
+        for r in caplog.records
+    )


### PR DESCRIPTION
Coverage close-out for the OPS-GPU cluster: every uncovered line in the owned
modules is now **covered** or carries an **explicit, reasoned justification**.
Owned modules go to 100%; non-UI aggregate 95.50% → 96.22%.

Constitutions: `CODE_CONSTITUTION.md` (every line covered-or-justified),
`.claude/architecture.md` (no cross-module edges added — comment/test-only).

## Covered (genuine tests)

| Module | Line(s) | What |
|---|---|---|
| `operations/start.py` | 199 | post-preflight cancel checkpoint (ADR-014) |
| `operations/swap.py` | 290-291 | same-model swap with an in-flight marker → `rejected_in_progress` |
| `operations/swap.py` | 121-122 | lockfile-race-during-launch; `terminate` OSError logged, not swallowed (issue #61) |
| `core/gpu.py` | 136-140 | `_collect_devices` ROCm/MPS backend fall-through (priority order) |
| `core/gpu.py` | 172-173, 190-191 | `_try_ROCM` / `_try_MPS` success paths |
| `core/gpu.py` | 356-359 | `_query_ROCM` parse-block exception handlers (FileNotFound / Timeout) |
| `core/gpu.py` | 464 | `_csv_rows` blank/whitespace-row skip |

**Deviation from the dispatch sheet:** swap.py 121-122 was suggested as a
defensible pragma, but I covered it genuinely instead. Line 122 is a *normal*
return (the lockfile-race result), not an exception log — pragma-ing a live
return is wrong — and line 121 is the exact parallel of start.py's OSError
cleanup handler, which already has a genuine test
(`test_start_lockfile_race_terminate_oserror_does_not_mask_error`). Covering
keeps the two race-cleanup paths symmetric.

## Excluded (defensible `# pragma: no cover` + reason)

| Module | Line(s) | Reason |
|---|---|---|
| `operations/orphan.py` | 73-74 | `int(process.pid)` coercion guard; `psutil.Process.pid` is always int → effectively unreachable |
| `operations/stop.py` | 217-222 | OSError handler in the daemon background thread's lockfile/audit emit; psutil errors already absorbed in core.process, threaded injection not worth the scaffolding |

## Bounced → excluded with issue reference

| Module | Line(s) | Reason |
|---|---|---|
| `core/gpu.py` | 380-384 | **Dead branch (#246).** `_query_MPS`'s per-line regex requires a literal `\n`, but `splitlines()` strips it → never matches real `system_profiler` output. The block-level fallback below is the live MPS-discovery path. Fix is a production MPS-parse change, unverifiable on this non-Apple (RTX-8000) host — surfaced for operator decision rather than applied unilaterally. |

The dispatch sheet listed 380-384 as genuine-coverable; it is not reachable in
the real flow, so covering it would have required an unnatural mock asserting
behavior that cannot occur in production — exactly the masking the BOUNCE rule
guards against.

## Gates

- Full pytest: **1261 passed, 12 skipped**.
- Non-UI coverage **96.22%** (`--cov-fail-under=93` satisfied).
- Owned modules `start.py` / `swap.py` / `orphan.py` / `stop.py` / `core/gpu.py` all **100%** (covered or excluded).

Closes nothing on its own; files #246 as follow-up.