### PR TITLE
fix(.gitignore): drop no-op tilde form, ignore .llauncher/ at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,7 @@ cython_debug/
 
 # llauncher specific
 *.log
-~/.llauncher/
+.llauncher/
 llauncher-config.json
 .claude/*
 !.claude/architecture.md

--- a/tests/architecture/test_gitignore_state_dir.py
+++ b/tests/architecture/test_gitignore_state_dir.py
@@ -1,0 +1,84 @@
+"""Static guard: the ``.llauncher/`` state-dir pattern must actually ignore.
+
+Why this test exists
+---------------------
+``.gitignore`` patterns do not perform tilde (``~``) expansion. A prior
+version of this file read ``~/.llauncher/``, which only matches a literal
+directory *named* ``~`` — i.e. it guarded nothing. A full copy of the
+operator's live ``~/.llauncher`` state dir (including ``agent.token`` and
+``audit.jsonl``) sat unignored under ``docs/handoffs/.llauncher/`` for
+several days as a result, invisible to ``git status`` only because its
+0700 perms turned the listing into a permission-denied warning (#252).
+
+This test pins the fix (``.llauncher/`` — no tilde, matches at any depth)
+by asking Git itself, via ``git check-ignore``, exactly as the issue's
+acceptance criteria specify. It is a regression guard against the pattern
+ever regaining a tilde or losing its match-at-any-depth shape.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+# Repo root = two parents up from this file: tests/architecture/<file>.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GITIGNORE = _REPO_ROOT / ".gitignore"
+
+
+def test_gitignore_has_no_tilde_home_patterns() -> None:
+    """No ``.gitignore`` line may rely on tilde expansion.
+
+    Git never expands ``~`` in ignore patterns, so any such line matches
+    only a literal directory named ``~`` and guards nothing.
+    """
+    lines = _GITIGNORE.read_text().splitlines()
+    tilde_home_lines = [
+        line for line in lines if re.match(r"^~[/\\]", line.strip())
+    ]
+    assert not tilde_home_lines, (
+        "`.gitignore` contains tilde-anchored pattern(s) that gitignore "
+        f"cannot expand and therefore never match: {tilde_home_lines!r}"
+    )
+
+
+def test_gitignore_llauncher_pattern_present_without_tilde() -> None:
+    """The literal fix from #252: ``.llauncher/`` present, no tilde form."""
+    text = _GITIGNORE.read_text()
+    assert ".llauncher/" in text.splitlines()
+    assert "~/.llauncher/" not in text
+
+
+def test_llauncher_state_dir_ignored_at_any_depth(tmp_path: Path) -> None:
+    """``git check-ignore`` must match a ``.llauncher/`` dir at repo root
+    and nested arbitrarily deep — mirroring the exact probe from the
+    issue's acceptance criteria (root case and the ``docs/handoffs/``
+    depth where the real incident occurred).
+    """
+    probes = [
+        _REPO_ROOT / ".llauncher",
+        _REPO_ROOT / "docs" / "handoffs" / ".llauncher",
+    ]
+    created = []
+    try:
+        for probe in probes:
+            probe.mkdir(parents=True, exist_ok=False)
+            created.append(probe)
+
+        result = subprocess.run(
+            ["git", "check-ignore", *[str(p) for p in probes]],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        matched = set(result.stdout.splitlines())
+        assert result.returncode == 0, (
+            f"git check-ignore did not match all probes: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        for probe in probes:
+            assert str(probe) in matched, f"{probe} was not reported ignored"
+    finally:
+        for probe in reversed(created):
+            probe.rmdir()


### PR DESCRIPTION
Fixes #252.

## What

`.gitignore` line 140 read `~/.llauncher/`. Replaced with `.llauncher/` so a
`llauncher` state dir is ignored at any depth in the tree, regardless of
where a misconfigured `$HOME` or backup lands one.

## Why

gitignore patterns do not perform tilde expansion — `~/.llauncher/` only
ever matched a literal directory named `~`, i.e. it guarded nothing. A full
copy of the operator's live `~/.llauncher` state dir (containing
`agent.token`, `audit.jsonl`, `config.json`, and ~11MB of server logs) sat
unignored under `docs/handoffs/.llauncher/` since 2026-06-26, one
`git add -A` away from being committed. It was masked from `git status`
only because its 0700 perms made git emit a permission-denied warning
instead of listing it.

## How tested

- Added `tests/architecture/test_gitignore_state_dir.py` — a static guard
  (same style as the existing `tests/architecture/test_ui_layer_boundaries.py`)
  that:
  - asserts no `.gitignore` line is tilde-anchored (bans regaining a no-op
    pattern),
  - asserts the literal `.llauncher/` pattern is present and the tilde form
    is gone,
  - runs `git check-ignore` against both probes named in the issue's
    acceptance criteria (repo-root `.llauncher` and nested
    `docs/handoffs/.llauncher`), asserting both match.
- Manually reproduced the acceptance criteria via `mkdir -p` + `git
  check-ignore -v` before writing the test; both probes now match against
  `.gitignore:140:.llauncher/`, neither matched before the fix.
- Full `pytest` run (excluding `tests/ui`, matching the project's non-UI
  coverage gate): 1323 passed, 11 skipped, 1 pre-existing failure
  (`tests/unit/test_cli.py::test_config_path_printed`, present on
  `origin/main` before this change — no new failures introduced).
  Coverage: 100% (gate is `--cov-fail-under=93`).

DO NOT MERGE per dispatch contract — awaiting review.