### PR TITLE
fix(state): unpack wait_for_server_ready tuple to make eviction rollback reachable

### DIFF
--- a/llauncher/state.py
+++ b/llauncher/state.py
@@ -516,12 +516,8 @@ class LauncherState:
         # ── Phase 4: Readiness poll ─────────────────────────────────────
 
         try:
-            ready = wait_for_server_ready(port, timeout=readiness_timeout)
-            # dead until #249 — wait_for_server_ready returns tuple[bool, list[str]]
-            # but line 519 binds it without unpacking, so `not ready` is always
-            # False; pragma'd honestly rather than fake-covered, real fix tracked
-            # in #249.
-            if not ready:  # pragma: no cover
+            ready, _logs = wait_for_server_ready(port, timeout=readiness_timeout)
+            if not ready:
                 # Terminate new process
                 stop_server_by_pid(new_pid)
                 self.running.pop(port, None)

--- a/tests/unit/test_core_runtime_coverage.py
+++ b/tests/unit/test_core_runtime_coverage.py
@@ -307,13 +307,75 @@ class TestEvictionRollbackRecovery:
         )
         return state
 
-    # NOTE: `test_readiness_false_rollback_failure_unavailable` was removed as
-    # false coverage (#244 → corrective for #249). It mocked
-    # `wait_for_server_ready` with a bare `return_value=False`, which the real
-    # function — `tuple[bool, list[str]]` — never returns. state.py:519 binds the
-    # result without unpacking, so `not ready` is always False and the readiness-
-    # failure rollback block (state.py ~520-562) is dead. That block is now
-    # honestly `# pragma: no cover` pending the genuine fix in #249.
+    def test_readiness_false_rollback_succeeds_restored(self, tmp_path):
+        """520-548: wait_for_server_ready returns a real (False, logs) tuple,
+        the new process is terminated, and rollback restores the evicted
+        server. Regression test for #249 — a prior version of this test
+        mocked `wait_for_server_ready` with a bare `return_value=False`,
+        which the real function (`tuple[bool, list[str]]`) never returns;
+        that false coverage masked state.py:519 binding the tuple without
+        unpacking, which made `if not ready:` permanently unreachable.
+        """
+        state = self._two_model_state(tmp_path)
+        with patch("llauncher.state.process_stop_server", return_value=True), \
+             patch("llauncher.state.stop_server_by_pid") as mock_stop_by_pid, \
+             patch("llauncher.state.wait_for_server_ready",
+                   return_value=(False, ["timed out waiting for ready"])), \
+             patch("llauncher.state.process_start_server") as mock_start:
+            mock_start.side_effect = [MagicMock(pid=111), MagicMock(pid=222)]
+            result = state._start_with_eviction_impl(
+                "new", port=8081, caller="cli",
+                readiness_timeout=5, strict_rollback=True,
+            )
+        mock_stop_by_pid.assert_called_once_with(111)
+        assert result.success is False
+        assert result.port_state == "restored"
+        assert result.rolled_back is True
+        assert result.restored_model == "old"
+        assert "Readiness timeout after 5s" in result.error
+        assert state.running[8081].config_name == "old"
+        assert state.running[8081].pid == 222
+
+    def test_readiness_false_rollback_fails_unavailable(self, tmp_path):
+        """549-558: readiness False, rollback start also raises → unavailable,
+        manual intervention required."""
+        state = self._two_model_state(tmp_path)
+        with patch("llauncher.state.process_stop_server", return_value=True), \
+             patch("llauncher.state.stop_server_by_pid"), \
+             patch("llauncher.state.wait_for_server_ready",
+                   return_value=(False, [])), \
+             patch("llauncher.state.process_start_server") as mock_start:
+            mock_start.side_effect = [MagicMock(pid=111), RuntimeError("rollback boom")]
+            result = state._start_with_eviction_impl(
+                "new", port=8081, caller="cli",
+                readiness_timeout=5, strict_rollback=True,
+            )
+        assert result.success is False
+        assert result.port_state == "unavailable"
+        assert result.rolled_back is False
+        assert "Rollback failed" in result.error
+        assert 8081 not in state.running
+
+    def test_readiness_false_no_rollback_non_strict_unavailable(self, tmp_path):
+        """560-566: readiness False, strict_rollback False → no rollback
+        attempted, port left unavailable."""
+        state = self._two_model_state(tmp_path)
+        with patch("llauncher.state.process_stop_server", return_value=True), \
+             patch("llauncher.state.stop_server_by_pid"), \
+             patch("llauncher.state.wait_for_server_ready",
+                   return_value=(False, [])), \
+             patch("llauncher.state.process_start_server",
+                   return_value=MagicMock(pid=111)):
+            result = state._start_with_eviction_impl(
+                "new", port=8081, caller="cli",
+                readiness_timeout=5, strict_rollback=False,
+            )
+        assert result.success is False
+        assert result.port_state == "unavailable"
+        assert result.rolled_back is False
+        assert "Readiness timeout after 5s" in result.error
+        assert result.new_model_attempted == "new"
+        assert 8081 not in state.running
 
     def test_readiness_raises_rollback_succeeds_restored(self, tmp_path):
         """563-587: wait_for_server_ready raises, rollback restores old."""


### PR DESCRIPTION
## What
Unpacks the `(bool, list[str])` return of `wait_for_server_ready` at `state.py:519` (`ready, _logs = ...`) instead of binding it as a bare name.

## Why
`wait_for_server_ready` returns `tuple[bool, list[str]]` on every path. `state.py:519` bound the whole tuple to `ready` without unpacking, so `if not ready:` evaluated `not (bool, list)` — always `False` for a non-empty tuple. The readiness-failure rollback branch during an eviction-based start (state.py ~520-562, meant to restore the just-evicted server when the new one fails to come ready) was silently dead code. The exception-driven rollback path (`except Exception` further down) was unaffected.

PR #250 already pragma'd this branch honestly (`# pragma: no cover`, pointing at this issue) after catching that a prior test faked coverage over it with a bare `return_value=False` mock — a shape `wait_for_server_ready` never actually returns. This PR lands the real fix and replaces the pragma with genuine coverage.

Fixes #249.

## How tested
- Removed the pragma; added three tests in `tests/unit/test_core_runtime_coverage.py::TestEvictionRollbackRecovery` that drive a real `(False, logs)` readiness failure through `_start_with_eviction_impl` and assert on the three exits:
  - `test_readiness_false_rollback_succeeds_restored` — new process terminated (`stop_server_by_pid` called), old server restored, `EvictionResult(port_state="restored", rolled_back=True, restored_model="old")`.
  - `test_readiness_false_rollback_fails_unavailable` — rollback start itself raises → `unavailable`, "Rollback failed" surfaced.
  - `test_readiness_false_no_rollback_non_strict_unavailable` — `strict_rollback=False` → no rollback attempted, port left `unavailable`.
- Full suite: `pytest -q` → 1329 passed, 11 skipped, 1 pre-existing failure (`tests/unit/test_cli.py::test_config_path_printed`, unrelated baseline red, unaffected by this change).
- Coverage: 100% total (`--cov-fail-under=93` gate passes); no remaining `# pragma: no cover` on the previously-dead branch.