### PR TITLE
docs(scripts/windows): document LLAMA_SERVER_PATH in agent.env.example

### DIFF
--- a/scripts/windows/llauncher-agent.env.example
+++ b/scripts/windows/llauncher-agent.env.example
@@ -53,6 +53,22 @@ LLAUNCHER_AGENT_HOST=0.0.0.0
 # Port. Default 8765.
 LLAUNCHER_AGENT_PORT=8765
 
+# --- llama-server binary (optional override) ---------------------------
+
+# Path to the llama-server executable the agent launches. Default (code):
+# %USERPROFILE%\.local\bin\llama-server(.exe), resolved via `Path.home()`
+# in the Python process. `nssm install` defaults the service account to
+# LocalSystem, whose `Path.home()` does NOT resolve to the operator's own
+# profile — so both this default AND the project-root `.env` fallback
+# (see the note above) silently miss. Set this explicitly whenever the
+# service runs under LocalSystem or any account other than the operator's,
+# or whenever llama-server.exe lives outside the default location.
+# LLAMA_SERVER_PATH=C:\path\to\llama-server.exe
+
+# Path to the launch-scripts directory. Same default/LocalSystem caveat
+# as LLAMA_SERVER_PATH above.
+# SCRIPTS_PATH=C:\path\to\scripts
+
 # --- Identity ---------------------------------------------------------
 
 # Friendly name shown in the UI's node selector and audit log.

--- a/tests/unit/test_windows_agent_env_example_docs.py
+++ b/tests/unit/test_windows_agent_env_example_docs.py
@@ -1,0 +1,82 @@
+"""Regression guard for issue #123 — LLAMA_SERVER_PATH documented in the
+Windows agent env template.
+
+``scripts/windows/llauncher-agent.env.example`` is the source
+``install.ps1`` copies into ``%USERPROFILE%\\.llauncher\\agent.env`` and
+feeds to NSSM's ``AppEnvironmentExtra``. Before this fix, the template
+covered auth/network/identity vars but never mentioned
+``LLAMA_SERVER_PATH`` (or ``SCRIPTS_PATH``), so an operator installing
+the service under a non-default llama-server location — or under
+NSSM's default LocalSystem account, whose home does not resolve to the
+operator's own ``~/.local/bin`` — had no documented override channel in
+the file NSSM actually injects.
+
+This pins:
+  1. Both vars are present as commented (opt-in) examples, matching the
+     "commented example, uncomment to override" shape already used by
+     the other windows/systemd templates.
+  2. The line is a genuine comment, not an active assignment — this
+     file must not silently start setting ``LLAMA_SERVER_PATH`` for
+     every fresh install (that stays the code default in
+     ``llauncher/core/settings.py``).
+  3. The systemd sibling template already documents ``LLAMA_SERVER_PATH``
+     (added for issue #195) — this guards the two per-platform templates
+     from drifting back out of parity on this variable.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+WINDOWS_ENV_EXAMPLE = _repo_root() / "scripts" / "windows" / "llauncher-agent.env.example"
+SYSTEMD_ENV_EXAMPLE = _repo_root() / "scripts" / "systemd" / "llauncher-agent.env.example"
+
+
+@pytest.fixture
+def windows_env_text() -> str:
+    return WINDOWS_ENV_EXAMPLE.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("var_name", ["LLAMA_SERVER_PATH", "SCRIPTS_PATH"])
+def test_var_documented_as_commented_example(windows_env_text: str, var_name: str) -> None:
+    """Each var appears as a commented-out ``# NAME=...`` example line."""
+    pattern = re.compile(rf"^#\s*{re.escape(var_name)}=\S", re.MULTILINE)
+    assert pattern.search(windows_env_text), (
+        f"{var_name} is not documented as a commented example in "
+        f"{WINDOWS_ENV_EXAMPLE}"
+    )
+
+
+@pytest.mark.parametrize("var_name", ["LLAMA_SERVER_PATH", "SCRIPTS_PATH"])
+def test_var_not_active_by_default(windows_env_text: str, var_name: str) -> None:
+    """The new guidance must not flip these into live assignments — a
+    fresh install should still fall back to the code default in
+    ``llauncher/core/settings.py``, not a value baked into the template.
+    """
+    pattern = re.compile(rf"^{re.escape(var_name)}=", re.MULTILINE)
+    assert not pattern.search(windows_env_text), (
+        f"{var_name} must stay commented-out in the .example template; "
+        "found an active (uncommented) assignment."
+    )
+
+
+def test_llama_server_path_documented_on_both_platform_templates() -> None:
+    """Windows and systemd templates stay in parity on this variable."""
+    systemd_text = SYSTEMD_ENV_EXAMPLE.read_text(encoding="utf-8")
+    assert "LLAMA_SERVER_PATH" in systemd_text, (
+        "expected the systemd template (added for #195) to already "
+        "document LLAMA_SERVER_PATH; if this fails the fixture repo "
+        "state has changed and the parity guard needs updating"
+    )


### PR DESCRIPTION
## What

Adds a commented `LLAMA_SERVER_PATH` (and `SCRIPTS_PATH`) example section to `scripts/windows/llauncher-agent.env.example`, in the same "commented example, uncomment to override" shape already used for `LLAUNCHER_AGENT_TOKEN`/`_HOST`/`_PORT`.

## Why

The Windows NSSM env template covered the agent's own auth/network/identity vars but never mentioned `LLAMA_SERVER_PATH`. NSSM injects this file directly into the service's process environment — it does **not** see the project-root `.env` fallback unless that fallback happens to resolve, which it silently won't when:

- `nssm install` defaults the service account to LocalSystem (no `ObjectName` is set in `install.ps1`), whose `Path.home()` doesn't point at the operator's own profile, so both the code default (`~/.local/bin/llama-server`) and the `.env` fallback path miss.
- `llama-server.exe` lives outside the default location and the working tree ever moves (breaking the CWD-relative `.env` discovery `load_dotenv()` depends on).

The systemd sibling template already documents `LLAMA_SERVER_PATH` for the analogous `--system` mode gap (issue #195); this brings the Windows template into parity, per the issue's ask to "consider also SCRIPTS_PATH and other vars an operator might reasonably override."

Docs-only change — no code paths touched, no behavior change to defaults (the vars stay commented/opt-in, so a fresh install is unaffected).

## How tested

- Added `tests/unit/test_windows_agent_env_example_docs.py`: asserts both vars are documented as commented examples, asserts neither is accidentally left as an active (uncommented) assignment, and pins parity with the systemd template.
- Full suite: `pytest tests/` — 1 pre-existing failure (`tests/unit/test_cli.py::test_config_path_printed`, unrelated baseline red per the run's F0 list), 1331 passed, 11 skipped. No new failures introduced.
- Coverage: `Required test coverage of 93% reached. Total coverage: 100.00%`.

Closes #123