### PR TITLE
feat(core): add metrics config field to enable llama-server --metrics

### DIFF
--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -178,6 +178,12 @@ def build_command(
     if config.mlock:
         cmd.append("--mlock")
 
+    # Prometheus /metrics endpoint (issue #169). Default-on: cheap scrape
+    # surface, and the structured source for tps/kv-cache/draft-acceptance
+    # telemetry that /slots doesn't cover.
+    if config.metrics:
+        cmd.append("--metrics")
+
     # Extra args (parse free-form string into arguments)
     if config.extra_args:
         cmd.extend(shlex.split(config.extra_args))

--- a/llauncher/mcp_server/tools/config.py
+++ b/llauncher/mcp_server/tools/config.py
@@ -33,6 +33,7 @@ def get_tools() -> list[Tool]:
                             "parallel": {"type": "integer"},
                             "flash_attn": {"type": "string", "enum": ["on", "off", "auto"]},
                             "no_mmap": {"type": "boolean"},
+                            "metrics": {"type": "boolean", "description": "Enable llama-server's Prometheus /metrics endpoint (--metrics). Defaults to true."},
                             "extra_args": {"type": "string", "description": "Additional command-line arguments (space-separated). Flags llauncher emits natively (e.g. --batch-size, --ubatch-size, --parallel, --threads-batch) are rejected here — set the dedicated field instead (issue #156)."},
                         },
                     },
@@ -78,6 +79,7 @@ def get_tools() -> list[Tool]:
                             "threads": {"type": "integer"},
                             "flash_attn": {"type": "string"},
                             "no_mmap": {"type": "boolean"},
+                            "metrics": {"type": "boolean", "description": "Enable llama-server's Prometheus /metrics endpoint (--metrics). Defaults to true."},
                             "extra_args": {"type": "string", "description": "Additional command-line arguments (space-separated, use quotes for args with spaces)"},
                         },
                         "required": ["name", "model_path"],
@@ -165,6 +167,8 @@ async def update_model_config(state: LauncherState, args: dict) -> dict:
             updated_config.flash_attn = updates["flash_attn"]
         if "no_mmap" in updates:
             updated_config.no_mmap = updates["no_mmap"]
+        if "metrics" in updates:
+            updated_config.metrics = updates["metrics"]
         if "extra_args" in updates:
             updated_config.extra_args = updates["extra_args"]
 

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -142,6 +142,7 @@ MANAGED_NATIVE_FLAG_TO_FIELD: dict[str, str] = {
     "--repeat-penalty": "repeat_penalty",
     "--reverse-prompt": "reverse_prompt",
     "--mlock": "mlock",
+    "--metrics": "metrics",
 }
 
 MANAGED_NATIVE_FLAGS: frozenset[str] = frozenset(MANAGED_NATIVE_FLAG_TO_FIELD)
@@ -196,6 +197,15 @@ class ModelConfig(BaseModel):
     repeat_penalty: float | None = None
     reverse_prompt: str | None = None
     mlock: bool = False
+    metrics: bool = Field(
+        default=True,
+        description=(
+            "Enable llama-server's Prometheus /metrics endpoint "
+            "(--metrics). Default on: negligible overhead, and the clean "
+            "structured source for tps/kv-cache/draft-acceptance "
+            "telemetry (issue #169)."
+        ),
+    )
     extra_args: str = ""
 
     @field_validator("extra_args", mode="before")

--- a/llauncher/ui/tabs/forms.py
+++ b/llauncher/ui/tabs/forms.py
@@ -55,6 +55,12 @@ def render_add_model(state: LauncherState) -> None:
             with col_adv2:
                 mlock = st.checkbox("Lock Memory in RAM (mlock)", value=False)
 
+            metrics = st.checkbox(
+                "Enable Prometheus Metrics (--metrics)",
+                value=True,
+                help="Exposes the /metrics endpoint for tps, kv-cache, and draft-acceptance telemetry.",
+            )
+
             col_adv3, col_adv4, col_adv5 = st.columns(3)
             with col_adv3:
                 n_cpu_moe = st.number_input(
@@ -114,7 +120,7 @@ def render_add_model(state: LauncherState) -> None:
         if submitted:
             _process_add_model(state, name, model_path, mmproj_path,
                              n_gpu_layers, ctx_size, threads, flash_attn,
-                             no_mmap, parallel, mlock, n_cpu_moe, batch_size,
+                             no_mmap, parallel, mlock, metrics, n_cpu_moe, batch_size,
                              temperature, top_k, top_p, min_p, repeat_penalty,
                              reverse_prompt, extra_args)
 
@@ -131,6 +137,7 @@ def _process_add_model(
     no_mmap: bool,
     parallel: int,
     mlock: bool,
+    metrics: bool,
     n_cpu_moe: int,
     batch_size: int,
     temperature: float,
@@ -155,6 +162,7 @@ def _process_add_model(
         no_mmap: Disable memory mapping flag.
         parallel: Parallel slots.
         mlock: Lock memory in RAM flag.
+        metrics: Enable Prometheus /metrics endpoint flag.
         n_cpu_moe: CPU MOE threads.
         batch_size: Batch size.
         temperature: Temperature value.
@@ -192,6 +200,7 @@ def _process_add_model(
             no_mmap=no_mmap,
             parallel=parallel,
             mlock=mlock,
+            metrics=metrics,
             n_cpu_moe=n_cpu_moe if n_cpu_moe > 0 else None,
             batch_size=batch_size if batch_size > 0 else None,
             temperature=temperature if temperature > 0 else None,
@@ -281,6 +290,12 @@ def render_edit_model(state: LauncherState, model_name: str | None = None) -> No
             with col_adv2:
                 mlock = st.checkbox("Lock Memory in RAM (mlock)", value=config.mlock)
 
+            metrics = st.checkbox(
+                "Enable Prometheus Metrics (--metrics)",
+                value=config.metrics,
+                help="Exposes the /metrics endpoint for tps, kv-cache, and draft-acceptance telemetry.",
+            )
+
             col_adv3, col_adv4, col_adv5 = st.columns(3)
             with col_adv3:
                 n_cpu_moe = st.number_input(
@@ -349,7 +364,7 @@ def render_edit_model(state: LauncherState, model_name: str | None = None) -> No
         if submitted:
             _process_edit_model(state, model_name, model_path, mmproj_path,
                               n_gpu_layers, ctx_size, threads, flash_attn, no_mmap,
-                              parallel, mlock, n_cpu_moe, batch_size, temperature,
+                              parallel, mlock, metrics, n_cpu_moe, batch_size, temperature,
                               top_k, top_p, min_p, repeat_penalty, reverse_prompt,
                               extra_args)
 
@@ -366,6 +381,7 @@ def _process_edit_model(
     no_mmap: bool,
     parallel: int,
     mlock: bool,
+    metrics: bool,
     n_cpu_moe: int,
     batch_size: int,
     temperature: float,
@@ -390,6 +406,7 @@ def _process_edit_model(
         no_mmap: Disable memory mapping flag.
         parallel: Parallel slots.
         mlock: Lock memory in RAM flag.
+        metrics: Enable Prometheus /metrics endpoint flag.
         n_cpu_moe: CPU MOE threads.
         batch_size: Batch size.
         temperature: Temperature value.
@@ -423,6 +440,7 @@ def _process_edit_model(
                 "no_mmap": no_mmap,
                 "parallel": parallel,
                 "mlock": mlock,
+                "metrics": metrics,
                 "n_cpu_moe": n_cpu_moe if n_cpu_moe > 0 else None,
                 "batch_size": batch_size if batch_size > 0 else None,
                 "temperature": temperature if temperature > 0 else None,

--- a/tests/unit/mcp/test_config_tools.py
+++ b/tests/unit/mcp/test_config_tools.py
@@ -95,9 +95,9 @@ class TestUpdateModelConfig:
 
     @pytest.mark.asyncio
     async def test_update_model_config_sets_remaining_native_fields(self, mock_state):
-        """Cover the threads / flash_attn / no_mmap apply branches so the
+        """Cover the threads / flash_attn / no_mmap / metrics apply branches so
 
-        whole update_model_config field-apply block is exercised.
+        the whole update_model_config field-apply block is exercised.
         """
         with patch("llauncher.core.config.ConfigStore"):
             result = await update_model_config(
@@ -108,6 +108,7 @@ class TestUpdateModelConfig:
                         "threads": 12,
                         "flash_attn": "off",
                         "no_mmap": True,
+                        "metrics": False,
                     },
                 },
             )
@@ -117,6 +118,7 @@ class TestUpdateModelConfig:
         assert updated.threads == 12
         assert updated.flash_attn == "off"
         assert updated.no_mmap is True
+        assert updated.metrics is False
 
     @pytest.mark.asyncio
     async def test_update_model_config_rejects_colliding_extra_args(self, mock_state):
@@ -438,3 +440,15 @@ class TestGetTools:
         props = tools["update_model_config"].inputSchema["properties"]["config"]["properties"]
         for field in ("batch_size", "ubatch_size", "parallel", "threads_batch"):
             assert field in props, field
+
+    def test_metrics_field_reachable_via_mcp_config_schema(self):
+        """Issue #169: the ``metrics`` toggle must be discoverable via both
+
+        ``update_model_config`` and ``add_model`` input schemas, and typed
+        as boolean.
+        """
+        tools = {t.name: t for t in get_tools()}
+        update_props = tools["update_model_config"].inputSchema["properties"]["config"]["properties"]
+        add_props = tools["add_model"].inputSchema["properties"]["config"]["properties"]
+        assert update_props["metrics"]["type"] == "boolean"
+        assert add_props["metrics"]["type"] == "boolean"

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -239,6 +239,18 @@ class TestBuildCommand:
         assert "--repeat-penalty" in cmd
         assert "1.5" in cmd
 
+    def test_metrics_default_on(self, minimal_config):
+        """Issue #169: metrics defaults to True and emits --metrics."""
+        assert minimal_config.metrics is True
+        cmd = build_command(minimal_config, port=8080)
+        assert "--metrics" in cmd
+
+    def test_metrics_disabled_omits_flag(self, minimal_config):
+        """Issue #169: metrics=False must not emit --metrics."""
+        minimal_config.metrics = False
+        cmd = build_command(minimal_config, port=8080)
+        assert "--metrics" not in cmd
+
 
 def _alias_value(cmd: list[str]) -> str:
     """Return the argv token immediately following ``--alias``."""


### PR DESCRIPTION
## What

Adds a first-class `ModelConfig.metrics: bool` field (default `true`) that injects `--metrics` into the launch command in `core/process.py::build_command`, and surfaces the toggle in the MCP config schema (`add_model` / `update_model_config`) and the Streamlit add/edit forms.

## Why

Managed llama-server instances launched without `--metrics`, so the Prometheus `/metrics` endpoint was disabled (`501 Not Implemented`). `/slots` covers most progress telemetry, but clean tps and speculative/draft-acceptance stats need `/metrics` — otherwise they're only observable via log scraping. Closes #169.

## How

- `llauncher/models/config.py`: new `metrics: bool = True` field on `ModelConfig`; registered `--metrics` → `metrics` in `MANAGED_NATIVE_FLAG_TO_FIELD` so the issue #156 extra_args collision guard covers it (a config can't silently drop this flag into `extra_args` and have it first-wins-dropped).
- `llauncher/core/process.py::build_command`: emits `--metrics` when `config.metrics` is true (mirrors the existing `mlock`/`no_mmap` boolean-flag pattern).
- `llauncher/mcp_server/tools/config.py`: `metrics` added to the `update_model_config` and `add_model` input schemas, plus the apply branch in `update_model_config`.
- `llauncher/ui/tabs/forms.py`: `metrics` checkbox (default checked) added to both the add-model and edit-model forms, threaded through to `ModelConfig` construction/update.

## How tested

- New/extended unit tests:
  - `tests/unit/test_process.py`: `--metrics` emitted by default, omitted when `metrics=False`.
  - `tests/unit/test_models_config_extra_args.py`: existing parametrized `MANAGED_NATIVE_FLAGS` tests automatically cover `--metrics` (deny-on-write, warn-on-load, drift guard).
  - `tests/unit/mcp/test_config_tools.py`: `metrics` apply branch in `update_model_config`, and schema-exposure test for both `add_model` and `update_model_config`.
- `tests/unit/test_process.py::TestBuildCommandManagedFlagDriftGuard::test_every_emitted_flag_is_registered` passes — confirms `--metrics` is registered against the issue #156 collision guard.
- Full `pytest` run: 1 failed (pre-existing baseline failure `tests/unit/test_cli.py::test_config_path_printed`, unrelated to this change), 1330 passed, 11 skipped.
- Coverage on non-UI scope: 100% (floor is 93%).
- Runtime `/metrics` curl against a live server was not exercised in this sandboxed worktree (no GGUF model file available here); the fix is fully covered at the `build_command` argv-assembly level, which is the exact mechanism `subprocess.Popen` consumes.

DO NOT MERGE per dispatch contract — awaiting review.