### PR TITLE
fix(preflight): all-None free_vram_mb fails loud, not "0 MiB"

### DIFF
--- a/llauncher/operations/preflight.py
+++ b/llauncher/operations/preflight.py
@@ -136,6 +136,12 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
       blind OOM, the check refuses with a ``"cannot verify VRAM headroom"``
       reason (#150). This is fail-closed by design: a backend that claims to
       exist must be able to report its devices.
+    - **Fail loud (same reason) when devices are present but every one is
+      missing ``free_vram_mb``.** A non-empty device list where no entry
+      reports usable telemetry is the same "cannot verify" situation as an
+      empty list — collapsing it to ``0 MiB`` would misreport unknown
+      headroom as a genuine zero (#241). A device list with at least one
+      real number takes the normal best-device path below unchanged.
     - Compute :func:`estimate_vram_mb` for ``config``.
     - Pass if **any** device reports ``free_vram_mb >= required``. We pick
       the most-free device rather than enforcing an exact placement; the
@@ -166,8 +172,23 @@ def default_vram_check(config: ModelConfig) -> tuple[bool, str]:
             "but reported no device data"
         )
 
+    free_vram_values = [d.get("free_vram_mb") for d in devices]
+    if all(v is None for v in free_vram_values):
+        # Devices present but none report usable telemetry: VRAM headroom
+        # is unknown, not genuinely zero. Fail loud with the same reason as
+        # the empty-devices branch rather than misreport "0 MiB free" (#241).
+        logger.warning(
+            "VRAM pre-flight: backend(s) %s reported devices but no "
+            "free_vram_mb values; refusing launch (cannot verify VRAM headroom)",
+            backends,
+        )
+        return False, (
+            f"cannot verify VRAM headroom: GPU backend(s) {backends} reported "
+            "devices with no free_vram_mb data"
+        )
+
     required_mb = estimate_vram_mb(config)
-    best_free = max(int(d.get("free_vram_mb") or 0) for d in devices)
+    best_free = max(int(v or 0) for v in free_vram_values)
 
     if best_free >= required_mb:
         return True, ""

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -199,8 +199,12 @@ def test_default_vram_check_picks_best_device() -> None:
     assert ok is True
 
 
-def test_default_vram_check_handles_missing_free_vram_field() -> None:
-    """Resilience: a device without ``free_vram_mb`` is treated as 0 MiB."""
+def test_default_vram_check_all_devices_missing_free_vram_fails_loud() -> None:
+    """#241: all-``None`` free_vram_mb must fail loud as "cannot verify",
+
+    not collapse to a misleading "insufficient VRAM ... 0 MiB" reason. The
+    telemetry is unknown, not genuinely zero.
+    """
     cfg = _config("mistral-7b", "/models/mistral-7b.gguf")
     with _patch_gpu({
         "backends": ["nvidia"],
@@ -208,3 +212,37 @@ def test_default_vram_check_handles_missing_free_vram_field() -> None:
     }):
         ok, reason = pf.default_vram_check(cfg)
     assert ok is False
+    assert "cannot verify vram headroom" in reason.lower()
+    assert "insufficient" not in reason.lower()
+
+
+def test_default_vram_check_all_devices_missing_key_fails_loud() -> None:
+    """#241: same as above when the key is absent entirely, and across
+    multiple devices — not just a single ``None`` value."""
+    cfg = _config("mistral-7b", "/models/mistral-7b.gguf")
+    with _patch_gpu({
+        "backends": ["nvidia"],
+        "devices": [
+            {"index": 0, "name": "RTX-a"},
+            {"index": 1, "name": "RTX-b", "free_vram_mb": None},
+        ],
+    }):
+        ok, reason = pf.default_vram_check(cfg)
+    assert ok is False
+    assert "cannot verify vram headroom" in reason.lower()
+
+
+def test_default_vram_check_mixed_none_and_real_value_uses_real_value() -> None:
+    """#241: the genuine-capacity path is unchanged when at least one device
+    reports a real ``free_vram_mb`` number, even alongside unreadable peers."""
+    cfg = _config("mistral-7b", "/models/mistral-7b.gguf")  # ~7168 MiB needed
+    with _patch_gpu({
+        "backends": ["nvidia"],
+        "devices": [
+            {"index": 0, "name": "unreadable", "free_vram_mb": None},
+            {"index": 1, "name": "readable", "free_vram_mb": 16000},
+        ],
+    }):
+        ok, reason = pf.default_vram_check(cfg)
+    assert ok is True
+    assert reason == ""


### PR DESCRIPTION
## Summary
- `default_vram_check` collapsed a non-empty device list where every entry had `free_vram_mb` missing/`None` into `best_free = 0`, producing a misleading "insufficient VRAM ... 0 MiB" reason.
- Now, when every device's `free_vram_mb` is unreadable, the check fails loud with the same `"cannot verify VRAM headroom"` reason already used for the empty-devices case (#150), rather than misreporting unknown telemetry as a genuine zero.
- The genuine-capacity path is unchanged: if at least one device reports a real `free_vram_mb` number, the best-device comparison proceeds as before.

Closes #241.

## Test plan
- [x] `tests/unit/test_preflight.py::test_default_vram_check_all_devices_missing_free_vram_fails_loud` (new, single-device `None`)
- [x] `tests/unit/test_preflight.py::test_default_vram_check_all_devices_missing_key_fails_loud` (new, multi-device, key absent + `None`)
- [x] `tests/unit/test_preflight.py::test_default_vram_check_mixed_none_and_real_value_uses_real_value` (new, genuine-capacity path unchanged)
- [x] Full `pytest -m "not integration and not live"`: 1283 passed, 9 skipped, 1 pre-existing failure (`test_cli.py::test_config_path_printed`, matches baseline F0, not touched by this change)
- [x] `--cov-fail-under=93`: total coverage 99.70%, `llauncher/operations/preflight.py` at 100%