### PR TITLE
feat(cli): add global --state-dir override (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ Tails the local audit log at `LAUNCHER_AUDIT_PATH` (`~/.llauncher/audit.jsonl` b
 
 The `llauncher` Typer CLI is a co-equal consumer of `llauncher/operations/` alongside the MCP server, HTTP Agent, and Streamlit UI. Every group supports a `--json` / `-j` flag for machine-readable output; the default is a Rich-rendered color table for human use.
 
+A global `--state-dir` option (before the subcommand) points a single invocation at a config/state directory other than the default, with precedence `--state-dir` > `LAUNCHER_STATE_DIR` env > `~/.llauncher`:
+
+```bash
+llauncher --state-dir /var/lib/llauncher model list
+```
+
+This is the mechanism for a non-login/non-interactive caller (an automation harness, a service account) to read a shared multiuser state dir without exporting `LAUNCHER_STATE_DIR` or symlinking `~/.llauncher`.
+
 **Subcommand groups:**
 
 ```bash

--- a/llauncher/__init__.py
+++ b/llauncher/__init__.py
@@ -5,7 +5,26 @@ from dotenv import load_dotenv
 # Load .env file from project root at package import time
 load_dotenv()
 
-from llauncher.state import LauncherState
-
 __version__ = "0.4.0a0"
 __all__ = ["LauncherState"]
+
+
+def __getattr__(name: str):
+    """Lazily re-export ``LauncherState`` (PEP 562).
+
+    ``llauncher.state`` transitively imports ``llauncher.core.settings``,
+    which resolves ``LAUNCHER_STATE_DIR`` (and every path derived from it)
+    at *module import time*. Importing it eagerly here — merely as a side
+    effect of ``import llauncher`` — froze those paths before the CLI's
+    ``--state-dir`` root callback (issue #215) ever got a chance to set
+    the env var, defeating the override for every subcommand. No callers
+    in this repo use the ``llauncher.LauncherState`` re-export (they use
+    ``from llauncher.state import LauncherState`` directly); this keeps
+    the attribute available for any external consumer without paying the
+    eager-import cost on every ``import llauncher``.
+    """
+    if name == "LauncherState":
+        from llauncher.state import LauncherState
+
+        return LauncherState
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -10,6 +10,7 @@ Output uses Rich tables with color-coded status indicators and supports --json f
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -18,17 +19,43 @@ from rich.console import Console
 from rich.table import Table
 from rich.text import Text
 
-from llauncher.core.config import CONFIG_PATH, ConfigStore
-from llauncher.models.config import ModelConfig
-from llauncher.remote.registry import NodeRegistry
-from llauncher.remote.node import RemoteNode
-from llauncher.state import LauncherState
-
 app = typer.Typer(
     name="llauncher",
     help="CLI for managing llama.cpp server instances",
     add_completion=False,
 )
+
+
+# ---------------------------------------------------------------------------
+# Root callback: --state-dir (issue #215)
+# ---------------------------------------------------------------------------
+#
+# ``llauncher.core.settings`` resolves ``LAUNCHER_STATE_DIR`` (and every
+# config/state path derived from it — ``config.CONFIG_PATH``,
+# ``registry.NODES_FILE``, ``LAUNCHER_RUN_DIR``, ...) at *module import
+# time*. For ``--state-dir`` to win over the env var, this callback must
+# set ``LAUNCHER_STATE_DIR`` in ``os.environ`` before any of those modules
+# are first imported in this process. That's why every command below
+# imports its config/state/registry dependencies *lazily*, inside the
+# function body, rather than at module scope: this callback always runs
+# before Typer dispatches to a subcommand, so as long as nothing above
+# this line has already imported the settings chain, the subcommand's
+# lazy import is the first one — and it sees this override.
+@app.callback()
+def main(
+    state_dir: Optional[Path] = typer.Option(
+        None,
+        "--state-dir",
+        help=(
+            "Override the llauncher state/config directory for this "
+            "invocation. Precedence: --state-dir > LAUNCHER_STATE_DIR env "
+            "> ~/.llauncher default."
+        ),
+    ),
+) -> None:
+    """CLI for managing llama.cpp server instances."""
+    if state_dir is not None:
+        os.environ["LAUNCHER_STATE_DIR"] = str(state_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +149,8 @@ def list_models(
     as_json: bool = typer.Option(False, "--json", "-j", help="Output in JSON format"),
 ) -> None:
     """List all configured models."""
+    from llauncher.core.config import ConfigStore
+
     names = ConfigStore.list_models()
     if as_json:
         _json_output(names)
@@ -138,6 +167,8 @@ def model_info(
     as_json: bool = typer.Option(False, "--json", "-j", help="Output in JSON format"),
 ) -> None:
     """Show detailed information for a single model."""
+    from llauncher.core.config import ConfigStore
+
     config = ConfigStore.get_model(name)
 
     if config is None:
@@ -262,6 +293,8 @@ def server_status(
     as_json: bool = typer.Option(False, "--json", "-j", help="Output in JSON format"),
 ) -> None:
     """Show status of all running servers."""
+    from llauncher.state import LauncherState
+
     state = LauncherState()
 
     if as_json:
@@ -351,6 +384,8 @@ def add_node(
     api_key: str | None = typer.Option(None, "--api-key", "-k", help="API key for authentication"),
 ) -> None:
     """Register a new llauncher agent node."""
+    from llauncher.remote.registry import NodeRegistry
+
     registry = NodeRegistry()
     actual_port = port or 8765
     ok, msg = registry.add_node(name=name, host=host, port=actual_port, api_key=api_key)
@@ -365,6 +400,8 @@ def list_nodes(
     as_json: bool = typer.Option(False, "--json", "-j", help="Output in JSON format"),
 ) -> None:
     """List all registered nodes."""
+    from llauncher.remote.registry import NodeRegistry
+
     registry = NodeRegistry()
 
     if as_json:
@@ -385,6 +422,8 @@ def remove_node(
     name: str = typer.Argument(..., help="Name of the node to remove"),
 ) -> None:
     """Remove a registered node."""
+    from llauncher.remote.registry import NodeRegistry
+
     registry = NodeRegistry()
     ok, msg = registry.remove_node(name)
     if not ok:
@@ -399,6 +438,8 @@ def node_status(
     as_json: bool = typer.Option(False, "--json", "-j", help="Output in JSON format"),
 ) -> None:
     """Show status of registered nodes (online only by default)."""
+    from llauncher.remote.registry import NodeRegistry
+
     registry = NodeRegistry()
 
     # Ping all to refresh statuses
@@ -451,6 +492,8 @@ config_app = typer.Typer(name="config", help="Configuration management utilities
 @config_app.command("path")
 def config_path() -> None:
     """Print the path to the llauncher configuration file."""
+    from llauncher.core.config import CONFIG_PATH
+
     console.print(f"[green]{CONFIG_PATH}[/green]")
 
 
@@ -459,6 +502,9 @@ def validate_config(
     name: str = typer.Argument(..., help="Name of the model to validate"),
 ) -> None:
     """Validate a model configuration without starting a server."""
+    from llauncher.core.config import ConfigStore
+    from llauncher.models.config import ModelConfig
+
     config = ConfigStore.get_model(name)
 
     if config is None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -145,7 +145,7 @@ def test_server_status_no_servers(mock_config_store, sample_model_config):
     """Server status with no running servers should show informational message."""
     _dir, _path = mock_config_store
 
-    with patch("llauncher.cli.LauncherState") as MockState:
+    with patch("llauncher.state.LauncherState") as MockState:
         instance = MagicMock()
         instance.running = {}
         MockState.return_value = instance
@@ -159,7 +159,7 @@ def test_server_status_json_empty(mock_config_store):
     """Server status --json with no servers should return empty JSON object."""
     _dir, _path = mock_config_store
 
-    with patch("llauncher.cli.LauncherState") as MockState:
+    with patch("llauncher.state.LauncherState") as MockState:
         instance = MagicMock()
         instance.running = {}
         MockState.return_value = instance
@@ -483,7 +483,7 @@ def test_node_add_duplicate_fails(tmp_path):
 
     nodes_file = tmp_path / ".llauncher" / "nodes.json"
 
-    with patch("llauncher.cli.NodeRegistry", spec=NodeRegistry) as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry", spec=NodeRegistry) as MockReg:
         reg_instance = MagicMock()
         MockReg.return_value = reg_instance
         reg_instance.add_node.return_value = (False, "Node 'my-node' already exists")
@@ -513,7 +513,7 @@ def test_node_remove(node_config_file):
 
 def test_node_remove_not_found():
     """Removing a non-existent node should error."""
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         MockReg.return_value = reg_instance
         reg_instance.remove_node.return_value = (False, "Node 'ghost' not found")
@@ -527,7 +527,7 @@ def test_node_status_json(node_config_file):
     # Add a node first
     runner.invoke(app, ["node", "add", "jstatus-node", "--host", "9.8.7.6"])
 
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         MockReg.return_value = reg_instance
 
@@ -556,7 +556,7 @@ def test_config_path_printed(mock_config_store):
     """Config path should print the path to the configuration file."""
     _dir, cfg_path = mock_config_store
 
-    with patch("llauncher.cli.CONFIG_PATH", cfg_path):
+    with patch("llauncher.core.config.CONFIG_PATH", cfg_path):
         result = runner.invoke(app, ["config", "path"])
     assert result.exit_code == 0
     assert str(cfg_path) in result.stdout
@@ -643,7 +643,7 @@ def test_node_status_ping_failure_is_swallowed(node_config_file):
     """
     node = _mock_node("10.0.0.9", 8765, "online")
 
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         reg_instance._nodes = {"flaky": node}
         pinger = MagicMock()
@@ -672,7 +672,7 @@ def test_server_status_json_with_running_server(mock_config_store):
     srv = MagicMock()
     srv.to_dict.return_value = {"port": 8080, "config_name": "m", "pid": 7}
 
-    with patch("llauncher.cli.LauncherState") as MockState:
+    with patch("llauncher.state.LauncherState") as MockState:
         instance = MagicMock()
         instance.running = {8080: srv}
         MockState.return_value = instance
@@ -705,7 +705,7 @@ def test_server_status_table_uptime_boundaries(mock_config_store):
         8003: _srv("seconds", 13, 42),    # < 60    → "42s"
     }
 
-    with patch("llauncher.cli.LauncherState") as MockState:
+    with patch("llauncher.state.LauncherState") as MockState:
         instance = MagicMock()
         instance.running = running
         MockState.return_value = instance
@@ -720,7 +720,7 @@ def test_server_status_table_uptime_boundaries(mock_config_store):
 
 def test_list_nodes_json(node_config_file):
     """``node list --json`` emits ``registry.to_dict()`` (cli.py:371-372)."""
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         reg_instance.to_dict.return_value = {"nodeA": {"host": "1.2.3.4", "port": 8765}}
         MockReg.return_value = reg_instance
@@ -745,7 +745,7 @@ def test_node_status_table_online_only(node_config_file):
     online = _mock_node("10.0.0.1", 8765, "online")
     offline = _mock_node("10.0.0.2", 8765, "offline")
 
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         reg_instance._nodes = {"up": online, "down": offline}
         # get_node(...).ping() is a no-op MagicMock — the ping loop's try
@@ -764,7 +764,7 @@ def test_node_status_table_all_includes_offline(node_config_file):
     online = _mock_node("10.0.0.1", 8765, "online")
     offline = _mock_node("10.0.0.2", 8765, "offline")
 
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         reg_instance._nodes = {"up": online, "down": offline}
         MockReg.return_value = reg_instance
@@ -777,7 +777,7 @@ def test_node_status_table_all_includes_offline(node_config_file):
 
 def test_node_status_table_empty_roster(node_config_file):
     """``node status`` with no registered nodes prints the empty notice (cli.py:435-436)."""
-    with patch("llauncher.cli.NodeRegistry") as MockReg:
+    with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
         reg_instance = MagicMock()
         reg_instance._nodes = {}
         MockReg.return_value = reg_instance
@@ -801,9 +801,9 @@ def test_config_validate_schema_exception(mock_config_store):
         "model_path": "/fake/path/model.gguf",
     })
 
-    with patch("llauncher.cli.ConfigStore.get_model", return_value=cfg):
+    with patch("llauncher.core.config.ConfigStore.get_model", return_value=cfg):
         with patch(
-            "llauncher.cli.ModelConfig.model_validate",
+            "llauncher.models.config.ModelConfig.model_validate",
             side_effect=ValueError("schema boom"),
         ):
             result = runner.invoke(app, ["config", "validate", "broken-model"])

--- a/tests/unit/test_cli_state_dir.py
+++ b/tests/unit/test_cli_state_dir.py
@@ -1,0 +1,215 @@
+"""Tests for the CLI's global ``--state-dir`` override (issue #215).
+
+Background
+----------
+``llauncher.core.settings`` resolves ``LAUNCHER_STATE_DIR`` (and every
+config/state path derived from it) at *module import time*. For a
+per-invocation ``--state-dir`` flag to win, it has to land in
+``os.environ`` before any of those modules are first imported in the
+process — see ``llauncher.cli.main``'s docstring for why the
+config/state/registry imports were moved out of module scope and into
+each command body.
+
+Test strategy
+-------------
+- In-process (``CliRunner``) tests pin the root callback's own
+  precedence contract: flag > env > untouched-when-absent. These run in
+  the *same* interpreter as the rest of the suite, so they cannot prove
+  the import-order fix by themselves (``llauncher.core.settings`` may
+  already be cached from an earlier test) — they only prove the
+  callback writes (or doesn't write) ``os.environ`` correctly.
+- The subprocess tests close that gap: each spawns a genuinely fresh
+  interpreter, so they exercise the real "callback runs before the
+  settings chain is ever imported" ordering the issue asked for, using
+  the acceptance criteria's literal invocation shape.
+- The env-var-redirects-every-path contract (``LAUNCHER_STATE_DIR`` ->
+  ``CONFIG_PATH`` / ``NODES_FILE`` / ``LAUNCHER_RUN_DIR`` / ...) is
+  already covered by ``test_state_dir.py`` and is not re-proven here.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from llauncher.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clean_state_dir_env(monkeypatch):
+    """Snapshot/restore LAUNCHER_STATE_DIR around every test in this module.
+
+    ``main()`` mutates ``os.environ`` directly by design (that mutation
+    has to be visible to modules imported *after* it runs). Calling
+    ``monkeypatch.delenv`` here — even though the actual write happens
+    inside the CLI invocation, not in this fixture — is enough for
+    monkeypatch to snapshot the pre-test value and restore it at
+    teardown, regardless of what the callback did to it in between.
+    """
+    monkeypatch.delenv("LAUNCHER_STATE_DIR", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# In-process: the callback's own precedence contract
+# ---------------------------------------------------------------------------
+
+
+def test_state_dir_flag_sets_env_var(tmp_path):
+    """``--state-dir X`` sets LAUNCHER_STATE_DIR to X before dispatch."""
+    target = tmp_path / "explicit-state"
+
+    with patch("llauncher.core.config.ConfigStore.list_models", return_value=[]):
+        result = runner.invoke(app, ["--state-dir", str(target), "model", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("LAUNCHER_STATE_DIR") == str(target)
+
+
+def test_state_dir_flag_overrides_existing_env_var(monkeypatch, tmp_path):
+    """The flag wins even when LAUNCHER_STATE_DIR is already set."""
+    env_dir = tmp_path / "from-env"
+    flag_dir = tmp_path / "from-flag"
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(env_dir))
+
+    with patch("llauncher.core.config.ConfigStore.list_models", return_value=[]):
+        result = runner.invoke(app, ["--state-dir", str(flag_dir), "model", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("LAUNCHER_STATE_DIR") == str(flag_dir)
+
+
+def test_state_dir_flag_absent_leaves_env_var_untouched(monkeypatch, tmp_path):
+    """With no flag, an existing env var is left exactly as it was."""
+    env_dir = tmp_path / "from-env-only"
+    monkeypatch.setenv("LAUNCHER_STATE_DIR", str(env_dir))
+
+    with patch("llauncher.core.config.ConfigStore.list_models", return_value=[]):
+        result = runner.invoke(app, ["model", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("LAUNCHER_STATE_DIR") == str(env_dir)
+
+
+def test_state_dir_flag_and_env_both_absent_no_env_mutation():
+    """With neither flag nor env set, the callback must not fabricate a value."""
+    with patch("llauncher.core.config.ConfigStore.list_models", return_value=[]):
+        result = runner.invoke(app, ["model", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "LAUNCHER_STATE_DIR" not in os.environ
+
+
+def test_state_dir_help_text_documents_precedence():
+    """``--help`` documents the flag and its precedence over the env var."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--state-dir" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Subprocess end-to-end: acceptance criteria, literal invocation form
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until a ``.git`` directory is found."""
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root (no .git ancestor) from {here}")
+
+
+def _subprocess_env(state_dir_env=None) -> dict:
+    """A fresh-process env with LAUNCHER_STATE_DIR set/unset and the repo on path.
+
+    Explicit ``PYTHONPATH`` (rather than relying on cwd) so the
+    subprocess resolves ``llauncher`` the same way regardless of the
+    directory pytest itself was invoked from.
+    """
+    env = dict(os.environ)
+    repo_root = str(_repo_root())
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([repo_root, existing] if existing else [repo_root])
+    # Rich falls back to a narrow default width when stdout isn't a TTY
+    # (as it never is under subprocess.run), which can wrap a long path
+    # mid-word. Pin a wide terminal so assertions can match the path
+    # substring verbatim instead of coupling to Rich's wrap points.
+    env["COLUMNS"] = "200"
+    if state_dir_env is None:
+        env.pop("LAUNCHER_STATE_DIR", None)
+    else:
+        env["LAUNCHER_STATE_DIR"] = str(state_dir_env)
+    return env
+
+
+def _run_cli(args: list[str], env: dict) -> subprocess.CompletedProcess:
+    """Invoke the real Typer app in a fresh interpreter (no cached imports)."""
+    return subprocess.run(
+        [sys.executable, "-c", "from llauncher.cli import app; app()", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_e2e_state_dir_flag_beats_env_no_symlink_needed(tmp_path):
+    """Acceptance: ``--state-dir`` shows that dir's registry, no env/symlink.
+
+    Mirrors the issue's repro: two distinct state dirs, each with its
+    own ``config.json``; the flag must select the *flagged* dir's
+    registry even though the env var points at the other one.
+    """
+    flagged = tmp_path / "flagged"
+    enved = tmp_path / "enved"
+    flagged.mkdir()
+    enved.mkdir()
+    (flagged / "config.json").write_text(
+        json.dumps({"flagged-model": {"name": "flagged-model", "model_path": "/fake/f.gguf"}})
+    )
+    (enved / "config.json").write_text(
+        json.dumps({"enved-model": {"name": "enved-model", "model_path": "/fake/e.gguf"}})
+    )
+
+    result = _run_cli(
+        ["--state-dir", str(flagged), "model", "list"],
+        env=_subprocess_env(state_dir_env=enved),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "flagged-model" in result.stdout
+    assert "enved-model" not in result.stdout
+
+
+def test_e2e_env_var_used_when_flag_absent(tmp_path):
+    """Acceptance: the env var still works as the default-override."""
+    enved = tmp_path / "enved-only"
+    enved.mkdir()
+    (enved / "config.json").write_text(
+        json.dumps({"enved-model": {"name": "enved-model", "model_path": "/fake/e.gguf"}})
+    )
+
+    result = _run_cli(["model", "list"], env=_subprocess_env(state_dir_env=enved))
+
+    assert result.returncode == 0, result.stderr
+    assert "enved-model" in result.stdout
+
+
+def test_e2e_config_path_reflects_state_dir_flag(tmp_path):
+    """``config path`` (the CONFIG_PATH consumer) also honors the flag."""
+    target = tmp_path / "cfg-target"
+    target.mkdir()
+
+    result = _run_cli(["--state-dir", str(target), "config", "path"], env=_subprocess_env())
+
+    assert result.returncode == 0, result.stderr
+    assert str(target / "config.json") in result.stdout

--- a/tests/unit/test_package_lazy_export.py
+++ b/tests/unit/test_package_lazy_export.py
@@ -1,0 +1,35 @@
+"""Tests for ``llauncher``'s lazy ``LauncherState`` re-export (issue #215).
+
+``llauncher/__init__.py`` used to import ``llauncher.state`` eagerly —
+purely as a side effect of ``import llauncher`` — which transitively
+resolved ``LAUNCHER_STATE_DIR`` (via ``llauncher.core.settings``) before
+the CLI's ``--state-dir`` root callback ever ran, defeating the
+override for every subcommand. The re-export is now lazy (PEP 562
+``__getattr__``); these tests pin that it still behaves like a normal
+module attribute for both the happy path and an unknown name.
+"""
+
+import llauncher
+
+
+def test_launcher_state_attribute_resolves_lazily():
+    """``llauncher.LauncherState`` still resolves to the real class."""
+    from llauncher.state import LauncherState as DirectLauncherState
+
+    assert llauncher.LauncherState is DirectLauncherState
+
+
+def test_from_import_still_works():
+    """``from llauncher import LauncherState`` uses the same lazy path."""
+    from llauncher import LauncherState
+    from llauncher.state import LauncherState as DirectLauncherState
+
+    assert LauncherState is DirectLauncherState
+
+
+def test_unknown_attribute_raises_attribute_error():
+    """An unrecognized name still raises AttributeError, not a lookup crash."""
+    import pytest
+
+    with pytest.raises(AttributeError, match="no attribute 'DoesNotExist'"):
+        llauncher.DoesNotExist

--- a/tests/unit/test_phase_d_coverage.py
+++ b/tests/unit/test_phase_d_coverage.py
@@ -357,7 +357,7 @@ class TestCliTableRenderBranches:
         cfg = ModelConfig.from_dict_unvalidated({
             "name": "tab-render", "model_path": str(tmp_path / "m.gguf"),
         })
-        with patch("llauncher.cli.ConfigStore.get_model", return_value=cfg):
+        with patch("llauncher.core.config.ConfigStore.get_model", return_value=cfg):
             result = runner.invoke(cli_app, ["model", "info", "tab-render"])
         assert result.exit_code == 0
         # Table headers appear in rendered output.
@@ -370,7 +370,7 @@ class TestCliTableRenderBranches:
             start_time=datetime.now(),  # uptime ~0s
         )
         fake_state = MagicMock(running={8081: srv})
-        with patch("llauncher.cli.LauncherState", return_value=fake_state):
+        with patch("llauncher.state.LauncherState", return_value=fake_state):
             result = runner.invoke(cli_app, ["server", "status"])
         assert result.exit_code == 0
         assert "Running Servers" in result.stdout or "8081" in result.stdout
@@ -379,7 +379,7 @@ class TestCliTableRenderBranches:
         """Node-list table branch — populates nodes registry then invokes."""
         nodes_file = tmp_path / "nodes.json"
         with patch("llauncher.remote.registry.NODES_FILE", nodes_file), \
-             patch("llauncher.cli.NodeRegistry") as MockReg:
+             patch("llauncher.remote.registry.NodeRegistry") as MockReg:
             fake_node = SimpleNamespace(
                 host="h.local", port=8765, api_key="",
                 status=SimpleNamespace(value="online"),
@@ -394,7 +394,7 @@ class TestCliTableRenderBranches:
 
     def test_node_list_empty_yellow_branch(self, tmp_path):
         """All-nodes filter with empty registry → 'No nodes registered' branch."""
-        with patch("llauncher.cli.NodeRegistry") as MockReg:
+        with patch("llauncher.remote.registry.NodeRegistry") as MockReg:
             MockReg.return_value._nodes = {}
             result = runner.invoke(cli_app, ["node", "list"])
         assert result.exit_code in (0, 2)


### PR DESCRIPTION
## Summary

- Adds a global `--state-dir` root option (`llauncher --state-dir <dir> <subcommand> ...`) that overrides the config/state directory for a single CLI invocation. Precedence: `--state-dir` flag > `LAUNCHER_STATE_DIR` env > `~/.llauncher` default.
- This closes the gap where a non-interactive/non-login caller (an automation harness, a service account) had no way to redirect the CLI at a shared multiuser state dir (e.g. `/var/lib/llauncher`) without exporting `LAUNCHER_STATE_DIR` or symlinking `~/.llauncher`.

## The design fork this uncovered (and how it's resolved)

`llauncher.core.settings` resolves `LAUNCHER_STATE_DIR` (and every path derived from it — `config.CONFIG_PATH`, `registry.NODES_FILE`, `LAUNCHER_RUN_DIR`, ...) at **module import time**. Two eager imports meant the settings chain was already frozen long before any CLI flag could be parsed:

1. `llauncher/__init__.py` unconditionally imported `llauncher.state.LauncherState` as a side effect of `import llauncher` — before `llauncher.cli` even loaded. No caller in this repo actually used the `llauncher.LauncherState` re-export (everyone does `from llauncher.state import LauncherState` directly), so this is now a lazy PEP 562 `__getattr__`.
2. `llauncher/cli.py` imported `ConfigStore`, `ModelConfig`, `NodeRegistry`, and `LauncherState` at module scope (plus an unused `RemoteNode` import, removed). These moves into each command body, matching the lazy-import pattern already used elsewhere in the file (`operations`, `delegation`, `marker`).

With both fixed, the root `@app.callback()` — which Typer always runs before dispatching to a subcommand — is the first code in the process to touch `os.environ`, and each subcommand's now-lazy import is the first thing to read it. No `importlib.reload` gymnastics, no sys.argv pre-scanning hack, no refactor of `settings.py`'s other module-level constants needed.

## Test plan

- [x] Full pytest: 1337 passed, 11 skipped, 1 known pre-existing failure (`tests/unit/test_cli.py::test_config_path_printed`, an unrelated Rich-console-width wrapping bug — confirmed failing identically on `origin/main` before this change).
- [x] Coverage: 100% (gate is `--cov-fail-under=93`).
- [x] New `tests/unit/test_cli_state_dir.py`: in-process precedence tests (flag > env > untouched-when-absent) on the callback itself, plus subprocess end-to-end tests spawning a genuinely fresh interpreter to prove the real import-order fix (not just the callback's `os.environ` write) — mirroring the issue's literal acceptance-criteria invocations (`model list`, `config path`, flag vs. env vs. neither).
- [x] New `tests/unit/test_package_lazy_export.py`: pins the lazy `llauncher.LauncherState` re-export behavior (attribute access, `from` import, unknown-attribute `AttributeError`).
- [x] Updated ~14 existing mock-patch targets in `tests/unit/test_cli.py` / `tests/unit/test_phase_d_coverage.py` from `llauncher.cli.X` to the origin module (`llauncher.core.config.X`, `llauncher.state.X`, `llauncher.remote.registry.X`) since those names no longer live on `llauncher.cli`'s module namespace.
- [x] Manual smoke test (both `CliRunner` and a real installed console script) confirming flag beats env, env used when flag absent, and `config path`/`server status` both work correctly.
- [x] Never touched resident :8081/:8082 servers.

Refs #215.