### PR TITLE
feat: implement ADR-019 server-metrics surface (SP-1..SP-6)

### DIFF
--- a/docs/adrs/accepted/adr-llnch-019-server-metrics-surface.md
+++ b/docs/adrs/accepted/adr-llnch-019-server-metrics-surface.md
@@ -1,6 +1,6 @@
 # ADR-LLNCH-019: Server-Metrics Surface — Live In-Server Inference Telemetry
 
-**Status:** Accepted (ratified 2026-06-19; implementation not yet begun)
+**Status:** Accepted (ratified 2026-06-19; implementation SP-1–SP-6 landed via #179 — `core/server_metrics.py`, `--slots`/`--no-slots` flag policy, `/server-metrics`+`/server-slots` agent endpoints, `server_metrics`/`server_slots` MCP tools, coverage + stub/real integration tests. SP-7 cross-repo handshake is a written finding, tracked on harness-tools#45, not a build blocker here.)
 **Date:** 2026-06-19
 **Amendment (2026-06-22):** `kv_cache_pct` is removed from the aggregate shape (§2 and §Testing). It is a *consumer-side derivation* — the footer computes context-fill locally from its token budget ÷ `ctx_size` — not server telemetry; and the observed `llama-server` build exposes **no** KV-cache metric on `/metrics` (#179 de-risk). Per `EMIT-CANONICAL / PARSE-AT-THE-DOOR`, llauncher surfaces only authoritative reads and **mints no derived metric**. No new invariant introduced.
 **Relationship to other ADRs:**

--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -239,6 +239,40 @@ def get_footer_context(port: int) -> dict:
     return ctx.to_dict()
 
 
+@router.get("/server-metrics/{port}")
+def get_server_metrics(port: int) -> dict:
+    """Aggregate live-telemetry snapshot for ``port`` (ADR-LLNCH-019).
+
+    Response shape is **pinned** by the ADR; do not extend without
+    amending it. Safe tier — no prompt text. Always ``200``: an
+    unreachable/loading/no-metrics-flag server is a degraded envelope
+    (``{"available": false, "reason": ...}``), not an HTTP error —
+    matching the ADR's PARSE-AT-THE-DOOR posture. Same auth as
+    ``/status`` (not exempt, see ``agent.middleware``).
+    """
+    from llauncher.core import server_metrics
+
+    return server_metrics.get_aggregate_metrics(port)
+
+
+@router.get("/server-slots/{port}")
+def get_server_slots(port: int) -> dict:
+    """Sensitive per-slot snapshot for ``port`` — includes prompt text.
+
+    Returns ``404 slots_disabled`` when the server was not started with
+    ``--slots`` (the launcher's default posture, issue #179 SP-1).
+    Other degraded states (unreachable) return ``200`` with a degraded
+    envelope, matching :func:`get_server_metrics`. Same auth as
+    ``/status`` (not exempt).
+    """
+    from llauncher.core import server_metrics
+
+    result = server_metrics.get_slots(port)
+    if result.get("reason") == "slots_disabled":
+        raise HTTPException(status_code=404, detail="slots_disabled")
+    return result
+
+
 @router.get("/models")
 def list_models() -> list[dict]:
     """List all configured models on this node."""

--- a/llauncher/core/process.py
+++ b/llauncher/core/process.py
@@ -184,6 +184,14 @@ def build_command(
     if config.metrics:
         cmd.append("--metrics")
 
+    # Slots-monitoring endpoint (issue #179 SP-1, ADR-LLNCH-019). The
+    # ``llama-server`` binary defaults ``--slots`` to ENABLED (PM-2
+    # de-risk finding) — the opposite of a safe default, since /slots
+    # includes per-slot prompt text. Emit the flag explicitly in both
+    # directions so the effective policy is a pure function of
+    # ``config.slots``, never the binary's own default.
+    cmd.append("--slots" if config.slots else "--no-slots")
+
     # Extra args (parse free-form string into arguments)
     if config.extra_args:
         cmd.extend(shlex.split(config.extra_args))

--- a/llauncher/core/server_metrics.py
+++ b/llauncher/core/server_metrics.py
@@ -1,0 +1,314 @@
+"""In-server inference telemetry reader (ADR-LLNCH-019, issue #179).
+
+Peer to :mod:`llauncher.core.gpu`: a stateless-per-poll collector with a
+short TTL cache (``LLAUNCHER_METRICS_CACHE_S``) absorbing poll cadence,
+and an injectable HTTP fetch seam (test-only, production-inert) mirroring
+``gpu.py``'s ``nvidia-smi`` mock. Outbound HTTP from ``core`` to the
+target model server's own port is a client call, not an upward import —
+the layer rule holds (see ``.claude/architecture.md``).
+
+Two capability tiers, kept **physically separate** — never a shared call
+gated by a flag — per the ADR:
+
+* :func:`get_aggregate_metrics` — ``/health`` + ``/metrics`` + lockfile
+  ``started_at``. Safe: no prompt text.
+* :func:`get_slots` — ``/slots``. Sensitive: per-slot detail including
+  prompt text.
+
+Both return a degraded envelope ``{"available": False, "reason": ...}``
+(``"loading" | "no-metrics-flag" | "unreachable"``) rather than raising,
+per PARSE-AT-THE-DOOR.
+
+Phase derivation note: the Prometheus gauges
+(``prompt_tokens_seconds`` / ``predicted_tokens_seconds``) are cumulative
+averages, and the counters (``prompt_tokens_total`` /
+``tokens_predicted_total``) are monotonic totals — neither alone signals
+real-time activity (issue #179 PM-1 de-risk finding). ``phase`` is
+therefore derived from the delta between this poll's counters and the
+*single* most-recently-seen sample for that port, gated by
+``requests_processing > 0``. This retains one sample per port (a
+one-slot-per-key cache, like the TTL cache above it) — it is not a
+history/ring-buffer; that accumulation is the deferred Streamlit-monitor
+scope (#176). From the caller's perspective this module is still
+point-in-time: one call in, one snapshot out.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import httpx
+
+from llauncher.core import settings
+from llauncher.core.config import ConfigStore
+from llauncher.core.lockfile import read_lockfile
+
+logger = logging.getLogger(__name__)
+
+
+_FETCH_TIMEOUT_S = 2.0
+_PROMETHEUS_PREFIX = "llamacpp:"
+
+
+# ------------------------------------------------------------------
+# Fetch seam (test-only, production-inert)
+# ------------------------------------------------------------------
+
+
+def _default_fetch(url: str) -> httpx.Response | None:
+    """Default HTTP GET; ``None`` signals a transport-level failure.
+
+    Non-2xx responses are returned (not raised) — callers branch on
+    ``status_code`` to distinguish ``loading`` (503) from
+    ``no-metrics-flag`` (501) from an ordinary success.
+    """
+    try:
+        return httpx.get(url, timeout=_FETCH_TIMEOUT_S)
+    except httpx.RequestError as exc:
+        logger.debug("server_metrics fetch failed for %s: %s", url, exc)
+        return None
+
+
+# Module-level seam: tests monkeypatch this name (mirrors
+# ``core.process.LOG_DIR`` / ``agent.routing._state`` patch points).
+# Production code never reassigns it.
+_fetch_url: Callable[[str], httpx.Response | None] = _default_fetch
+
+
+def node_identity() -> str:
+    """Resolve this node's identity for the ``(node, port, canonical_name)``
+    series key (ADR-LLNCH-019 §4).
+
+    Returns the agent self-report today. The mint-hardening swap point is
+    tracked at #174 — this function is the single place that resolver
+    would replace.
+    """
+    # TODO #174: node-identity mint hardening swap point.
+    from llauncher.core.node_info import get_node_name
+
+    return get_node_name()
+
+
+# ------------------------------------------------------------------
+# Prometheus text parsing (PM-1 de-risk: colon `llamacpp:` namespace)
+# ------------------------------------------------------------------
+
+
+def _parse_prometheus_text(text: str) -> dict[str, float]:
+    """Parse ``llamacpp:*`` Prometheus exposition text into a flat dict.
+
+    Skips ``# HELP`` / ``# TYPE`` comment lines and blanks. Non-numeric
+    or malformed lines are skipped rather than raising (PARSE-AT-THE-DOOR
+    within a best-effort scrape — a single bad line must not blank the
+    whole snapshot).
+    """
+    values: dict[str, float] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        name, raw_value = parts
+        if not name.startswith(_PROMETHEUS_PREFIX):
+            continue
+        key = name[len(_PROMETHEUS_PREFIX):]
+        try:
+            values[key] = float(raw_value)
+        except ValueError:
+            logger.debug("server_metrics: non-numeric metric line skipped: %r", line)
+            continue
+    return values
+
+
+# ------------------------------------------------------------------
+# Aggregate tier
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CounterSnapshot:
+    """Single most-recent counter sample for one port (delta gating only)."""
+
+    prompt_tokens_total: float
+    tokens_predicted_total: float
+
+
+# port -> last-seen counter snapshot. One slot per key; overwritten each
+# poll. Not a history — see module docstring.
+_last_counters: dict[int, _CounterSnapshot] = {}
+_last_counters_lock = threading.Lock()
+
+# port -> (envelope dict, expires_at monotonic). Short TTL cache absorbing
+# poll cadence, mirroring ``agent.footer_cache``.
+_aggregate_cache: dict[int, tuple[dict[str, Any], float]] = {}
+_aggregate_cache_lock = threading.Lock()
+
+
+def _degraded(reason: str) -> dict[str, Any]:
+    return {"available": False, "reason": reason}
+
+
+def _derive_phase(port: int, counters: dict[str, float]) -> str:
+    """Derive ``idle | prompt | generating`` from a live gauge plus a
+    one-sample counter delta (see module docstring for rationale).
+    """
+    requests_processing = counters.get("requests_processing", 0.0)
+    prompt_total = counters.get("prompt_tokens_total", 0.0)
+    predicted_total = counters.get("tokens_predicted_total", 0.0)
+
+    with _last_counters_lock:
+        prev = _last_counters.get(port)
+        _last_counters[port] = _CounterSnapshot(
+            prompt_tokens_total=prompt_total,
+            tokens_predicted_total=predicted_total,
+        )
+
+    if requests_processing <= 0:
+        return "idle"
+
+    if prev is None:
+        # Busy on the first-ever poll for this port: no delta to compare
+        # against yet. Generation dominates request wall-clock time in
+        # practice, so it's the better single-sample default.
+        return "generating"
+
+    delta_predicted = predicted_total - prev.tokens_predicted_total
+    delta_prompt = prompt_total - prev.prompt_tokens_total
+
+    if delta_predicted > 0:
+        return "generating"
+    if delta_prompt > 0:
+        return "prompt"
+    # Busy per the gauge, but neither counter moved since the last poll
+    # (e.g. a request just landed). Same best-effort default as above.
+    return "generating"
+
+
+def _collect_aggregate(port: int) -> dict[str, Any]:
+    """Read-through: probe the live server and lockfile; no cache."""
+    health_resp = _fetch_url(f"http://127.0.0.1:{port}/health")
+    if health_resp is None:
+        return _degraded("unreachable")
+    if health_resp.status_code == 503:
+        return _degraded("loading")
+    if health_resp.status_code != 200:
+        return _degraded("unreachable")
+
+    metrics_resp = _fetch_url(f"http://127.0.0.1:{port}/metrics")
+    if metrics_resp is None:
+        return _degraded("unreachable")
+    if metrics_resp.status_code == 501:
+        return _degraded("no-metrics-flag")
+    if metrics_resp.status_code != 200:
+        return _degraded("unreachable")
+
+    counters = _parse_prometheus_text(metrics_resp.text)
+
+    lf = read_lockfile(port)
+    started_at = lf.started_at if lf is not None else None
+    canonical_name = lf.model if lf is not None else None
+
+    slots_total: int | None = None
+    if lf is not None:
+        cfg = ConfigStore.get_model(lf.model)
+        if cfg is not None:
+            slots_total = cfg.parallel
+
+    return {
+        "available": True,
+        "state": "ok",
+        "phase": _derive_phase(port, counters),
+        "gen_tok_s": counters.get("predicted_tokens_seconds"),
+        "prompt_tok_s": counters.get("prompt_tokens_seconds"),
+        "slots_busy": _to_int(counters.get("requests_processing")),
+        "slots_total": slots_total,
+        "requests_deferred": _to_int(counters.get("requests_deferred")),
+        "started_at": started_at,
+        "node": node_identity(),
+        "canonical_name": canonical_name,
+    }
+
+
+def get_aggregate_metrics(port: int, *, force_refresh: bool = False) -> dict[str, Any]:
+    """Return the aggregate-tier snapshot for ``port`` (ADR-LLNCH-019 §2).
+
+    Cached for ``LLAUNCHER_METRICS_CACHE_S`` seconds (``<= 0`` disables
+    caching). Never raises: unreachable/loading/no-metrics-flag all
+    return the degraded envelope.
+    """
+    ttl = settings.LLAUNCHER_METRICS_CACHE_S
+    now = time.monotonic()
+
+    if ttl > 0 and not force_refresh:
+        with _aggregate_cache_lock:
+            cached = _aggregate_cache.get(port)
+            if cached is not None and cached[1] > now:
+                return cached[0]
+
+    result = _collect_aggregate(port)
+
+    if ttl > 0:
+        with _aggregate_cache_lock:
+            _aggregate_cache[port] = (result, time.monotonic() + ttl)
+
+    return result
+
+
+def clear_cache() -> None:
+    """Drop all cached state (aggregate cache + phase-delta samples).
+
+    Primarily for tests; production never needs to invalidate — the TTL
+    and per-poll overwrite are self-healing.
+    """
+    with _aggregate_cache_lock:
+        _aggregate_cache.clear()
+    with _last_counters_lock:
+        _last_counters.clear()
+
+
+# ------------------------------------------------------------------
+# Slots tier (sensitive — prompt text)
+# ------------------------------------------------------------------
+
+
+def get_slots(port: int) -> dict[str, Any]:
+    """Return the sensitive slots-tier snapshot for ``port``.
+
+    Not cached (each read must reflect the current slot occupants).
+    Returns ``{"available": False, "reason": "slots_disabled"}`` when the
+    server does not expose ``/slots`` (started without ``--slots``, i.e.
+    the llama-server default posture after issue #179's ``--no-slots``
+    flag policy), matching the agent's ``404 slots_disabled`` contract
+    at the HTTP layer.
+    """
+    resp = _fetch_url(f"http://127.0.0.1:{port}/slots")
+    if resp is None:
+        return _degraded("unreachable")
+    if resp.status_code == 501:
+        return _degraded("slots_disabled")
+    if resp.status_code != 200:
+        return _degraded("unreachable")
+
+    try:
+        slots = resp.json()
+    except ValueError:
+        logger.debug("server_metrics: /slots on port %s returned non-JSON body", port)
+        return _degraded("unreachable")
+
+    return {
+        "available": True,
+        "node": node_identity(),
+        "slots": slots,
+    }
+
+
+def _to_int(value: float | None) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/llauncher/core/settings.py
+++ b/llauncher/core/settings.py
@@ -170,3 +170,9 @@ LLAUNCHER_STOP_GRACE_S = float(os.getenv("LLAUNCHER_STOP_GRACE_S", "5.0"))
 # redraws per second collapse into one lockfile + ConfigStore read).
 # ``<= 0`` disables caching — every request hits disk.
 LAUNCHER_FOOTER_CACHE_S = float(os.getenv("LAUNCHER_FOOTER_CACHE_S", "1.0"))
+
+# TTL in seconds for the ``/server-metrics/{port}`` aggregate-tier cache
+# (ADR-LLNCH-019, issue #179). Absorbs poll cadence so a burst of
+# consumer polls collapses into one round-trip to the model server's
+# ``/health`` + ``/metrics`` endpoints. ``<= 0`` disables caching.
+LLAUNCHER_METRICS_CACHE_S = float(os.getenv("LLAUNCHER_METRICS_CACHE_S", "2.0"))

--- a/llauncher/mcp_server/server.py
+++ b/llauncher/mcp_server/server.py
@@ -83,6 +83,10 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
         return await servers_tools.cancel_server(arguments)
     elif name == "delete_model":
         return await config_tools.delete_model(arguments)
+    elif name == "server_metrics":
+        return await servers_tools.server_metrics(arguments)
+    elif name == "server_slots":
+        return await servers_tools.server_slots(arguments)
 
     # ── Stateless config tools ──────────────────────────────────────
     if name == "validate_config":

--- a/llauncher/mcp_server/tools/servers.py
+++ b/llauncher/mcp_server/tools/servers.py
@@ -187,6 +187,48 @@ def get_tools() -> list[Tool]:
                 "required": ["port"],
             },
         ),
+        Tool(
+            name="server_metrics",
+            description=(
+                "Live in-server inference telemetry for a running server "
+                "(ADR-LLNCH-019): phase (idle/prompt/generating), "
+                "gen_tok_s, prompt_tok_s, slot counts, started_at. Safe "
+                "tier — no prompt text. Local-node only. Returns a "
+                "degraded envelope ({'available': false, 'reason': "
+                "'loading'|'no-metrics-flag'|'unreachable'}) rather than "
+                "erroring when the target server can't be read."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "port": {
+                        "type": "integer",
+                        "description": "Port number of the server",
+                    },
+                },
+                "required": ["port"],
+            },
+        ),
+        Tool(
+            name="server_slots",
+            description=(
+                "Per-slot detail for a running server, including prompt "
+                "text (ADR-LLNCH-019). Sensitive tier — grant separately "
+                "from server_metrics. Local-node only. Returns "
+                "{'available': false, 'reason': 'slots_disabled'} when "
+                "the server was not started with --slots."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "port": {
+                        "type": "integer",
+                        "description": "Port number of the server",
+                    },
+                },
+                "required": ["port"],
+            },
+        ),
     ]
 
 
@@ -306,6 +348,43 @@ async def cancel_server(args: dict) -> dict:
         "marker_existed": delivered,
         "port": port,
     }
+
+
+# ─── Stateless collector tools (core.server_metrics, ADR-LLNCH-019) ──
+#
+# Unlike ``get_server_logs`` these don't consult ``LauncherState`` —
+# ``core.server_metrics`` reads the lockfile directly and polls the
+# target server itself (peer to ``core.gpu``, issue #179). Tier
+# separation is which tool a client is granted, not a flag: a client
+# holding ``server_metrics`` need not also hold ``server_slots``.
+
+
+async def server_metrics(args: dict) -> dict:
+    """Aggregate live-telemetry snapshot for ``args['port']`` (safe tier).
+
+    Thin wrapper over :func:`llauncher.core.server_metrics.get_aggregate_metrics`.
+    """
+    port = args.get("port")
+    if port is None:
+        return {"error": "Missing required argument: port"}
+
+    from llauncher.core import server_metrics as sm
+
+    return sm.get_aggregate_metrics(port)
+
+
+async def server_slots(args: dict) -> dict:
+    """Per-slot snapshot for ``args['port']``, including prompt text (sensitive tier).
+
+    Thin wrapper over :func:`llauncher.core.server_metrics.get_slots`.
+    """
+    port = args.get("port")
+    if port is None:
+        return {"error": "Missing required argument: port"}
+
+    from llauncher.core import server_metrics as sm
+
+    return sm.get_slots(port)
 
 
 # ───────────────── Read tools (state-backed) ───────────────────────

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -143,6 +143,8 @@ MANAGED_NATIVE_FLAG_TO_FIELD: dict[str, str] = {
     "--reverse-prompt": "reverse_prompt",
     "--mlock": "mlock",
     "--metrics": "metrics",
+    "--slots": "slots",
+    "--no-slots": "slots",
 }
 
 MANAGED_NATIVE_FLAGS: frozenset[str] = frozenset(MANAGED_NATIVE_FLAG_TO_FIELD)
@@ -204,6 +206,18 @@ class ModelConfig(BaseModel):
             "(--metrics). Default on: negligible overhead, and the clean "
             "structured source for tps/kv-cache/draft-acceptance "
             "telemetry (issue #169)."
+        ),
+    )
+    slots: bool = Field(
+        default=False,
+        description=(
+            "Expose llama-server's /slots monitoring endpoint (--slots). "
+            "Default OFF: /slots includes per-slot prompt text, so this "
+            "is a sensitive opt-in — note llama-server's own binary "
+            "default is the inverse (ENABLED); llauncher always emits "
+            "--slots or --no-slots explicitly so the effective policy is "
+            "config-driven, not the binary default (ADR-LLNCH-019, "
+            "issue #179 PM-2 de-risk)."
         ),
     )
     extra_args: str = ""

--- a/tests/integration/test_server_metrics_live.py
+++ b/tests/integration/test_server_metrics_live.py
@@ -1,0 +1,156 @@
+"""Integration coverage for /server-metrics/{port} + /server-slots/{port}
+(ADR-LLNCH-019, issue #179 SP-6).
+
+Two tiers of proof, matching the ``test_self_swap.py`` / ``test_swap.py``
+convention:
+
+* **Stub-mode (default, runs in CI).** A real subprocess on a real port,
+  driven through the same in-process MCP dispatch + agent ``TestClient``
+  the production stack uses. The stub binary listens but never speaks
+  HTTP, so the pinned, deterministic outcome is the "unreachable"
+  degraded envelope — this proves every hop (agent routing →
+  ``core.server_metrics`` → lockfile read → live probe) is wired,
+  without needing a real ``llama-server`` binary or GGUF.
+* **Real-mode (opt-in via ``LLAUNCHER_INTEGRATION_REAL=1`` +
+  ``LLAMA_SMALL_GGUF``, `` LLAMA_SERVER_PATH``).** Starts an actual
+  ``llama-server``, polls ``/server-metrics/{port}`` until the aggregate
+  tier reports ``available``, and asserts ``phase``/tok-s are
+  populated — the ADR Testing section's "poll, assert phase/rate"
+  acceptance criterion. Skips gracefully (``real_binary_env`` fixture)
+  when not opted in, per the SP-6 "skips gracefully" requirement.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+
+import pytest
+
+from llauncher.core import server_metrics
+
+
+pytestmark = pytest.mark.integration
+
+
+def _free_port() -> int:
+    """Return a likely-free local port (bind+close is good enough in tests)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture(autouse=True)
+def _clear_metrics_state():
+    server_metrics.clear_cache()
+    yield
+    server_metrics.clear_cache()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Stub-mode: end-to-end wiring proof (runs in CI)
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def test_server_metrics_wiring_against_stub(
+    mcp_env, register_model, mcp_dispatch, agent_client
+):
+    """Full agent-HTTP → core.server_metrics → live-port round trip.
+
+    The stub accepts the connection and closes it without sending a
+    response, so httpx surfaces a transport error which
+    ``core.server_metrics`` maps to the "unreachable" degraded envelope
+    — the deterministic, CI-safe proof that the wiring is intact.
+    """
+    del mcp_env  # fixture wires the isolated run/config dirs; not read directly
+    register_model("alpha")
+    port = _free_port()
+
+    start_result = await mcp_dispatch(
+        "start_server", {"model_name": "alpha", "port": port}
+    )
+    assert start_result["success"] is True, start_result
+
+    try:
+        response = agent_client.get(f"/server-metrics/{port}")
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "unreachable"}
+
+        slots_response = agent_client.get(f"/server-slots/{port}")
+        assert slots_response.status_code == 200
+        assert slots_response.json() == {"available": False, "reason": "unreachable"}
+    finally:
+        await mcp_dispatch("stop_server", {"port": port})
+
+
+async def test_server_metrics_empty_port_is_degraded_not_crash(agent_client):
+    """A port with no server at all degrades cleanly, matching PARSE-AT-THE-DOOR."""
+    port = _free_port()
+    response = agent_client.get(f"/server-metrics/{port}")
+    assert response.status_code == 200
+    assert response.json() == {"available": False, "reason": "unreachable"}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Real-mode: canonical live proof (opt-in, skips gracefully otherwise)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.live
+@pytest.mark.integration_real
+async def test_server_metrics_live_reports_phase_and_rate(
+    real_binary_env, mcp_dispatch, agent_client
+):
+    """Real llama-server: poll until the aggregate tier is available.
+
+    Also grounds the SP-1 ``--no-slots`` default live: with
+    ``ModelConfig.slots`` at its default (``False``), ``/server-slots``
+    must 404 ``slots_disabled``.
+    """
+    from llauncher.core.config import ConfigStore
+    from llauncher.models.config import ModelConfig
+
+    gguf = real_binary_env["gguf"]
+    cfg = ModelConfig.from_dict_unvalidated(
+        {
+            "name": "alpha",
+            "model_path": str(gguf),
+            "n_gpu_layers": 0,
+            "ctx_size": 512,
+            "threads_batch": 1,
+            "ubatch_size": 1,
+            "flash_attn": "off",
+        }
+    )
+    ConfigStore.add_model(cfg, caller="issue-179-live-test")
+
+    port = _free_port()
+    start = await mcp_dispatch("start_server", {"model_name": "alpha", "port": port})
+    assert start["success"], start
+
+    try:
+        deadline = time.monotonic() + 30.0
+        snapshot = None
+        while time.monotonic() < deadline:
+            response = agent_client.get(f"/server-metrics/{port}")
+            assert response.status_code == 200
+            snapshot = response.json()
+            if snapshot.get("available"):
+                break
+            time.sleep(0.5)
+
+        assert snapshot is not None and snapshot["available"] is True, snapshot
+        assert snapshot["state"] == "ok"
+        assert snapshot["phase"] in ("idle", "prompt", "generating")
+        assert isinstance(snapshot["gen_tok_s"], (int, float))
+        assert isinstance(snapshot["prompt_tok_s"], (int, float))
+        assert snapshot["slots_total"] == cfg.parallel
+        assert snapshot["canonical_name"] == "alpha"
+
+        slots_response = agent_client.get(f"/server-slots/{port}")
+        assert slots_response.status_code == 404
+        assert slots_response.json() == {"detail": "slots_disabled"}
+    finally:
+        await mcp_dispatch("stop_server", {"port": port})

--- a/tests/unit/mcp/test_server_extended.py
+++ b/tests/unit/mcp/test_server_extended.py
@@ -117,6 +117,8 @@ class TestDispatchToolAllTools:
             ("stop_server", "llauncher.mcp_server.server.servers_tools.stop_server"),
             ("swap_server", "llauncher.mcp_server.server.servers_tools.swap_server"),
             ("delete_model", "llauncher.mcp_server.server.config_tools.delete_model"),
+            ("server_metrics", "llauncher.mcp_server.server.servers_tools.server_metrics"),
+            ("server_slots", "llauncher.mcp_server.server.servers_tools.server_slots"),
         ]
 
         for tool_name, module_path in stateless_verbs:

--- a/tests/unit/mcp/test_servers_tools.py
+++ b/tests/unit/mcp/test_servers_tools.py
@@ -14,6 +14,8 @@ import pytest
 from llauncher.mcp_server.tools.servers import (
     get_server_logs,
     get_tools,
+    server_metrics,
+    server_slots,
     server_status,
     start_server,
     stop_server,
@@ -340,14 +342,16 @@ class TestGetServerLogs:
 class TestGetTools:
     """Tool descriptors must reflect the port-keyed shape."""
 
-    def test_returns_seven_tools(self):
-        """start, stop, swap, cancel, server_status, get_server_logs, list_orphans (ADR-015)."""
+    def test_returns_nine_tools(self):
+        """start, stop, swap, cancel, server_status, get_server_logs,
+        list_orphans (ADR-015), server_metrics + server_slots (ADR-LLNCH-019).
+        """
         tools = get_tools()
         names = [t.name for t in tools]
-        assert len(tools) == 7
+        assert len(tools) == 9
         for expected in ("start_server", "stop_server", "swap_server",
                          "cancel_server", "server_status", "get_server_logs",
-                         "list_orphans"):
+                         "list_orphans", "server_metrics", "server_slots"):
             assert expected in names
 
     def test_start_server_requires_model_and_port(self):
@@ -560,3 +564,71 @@ class TestCancelServer:
             "marker_existed": False,
             "port": 9999,
         }
+
+
+# ─── server_metrics / server_slots (ADR-LLNCH-019, issue #179 SP-5) ───
+
+
+class TestServerMetricsTool:
+    """Thin wrapper over ``core.server_metrics.get_aggregate_metrics``."""
+
+    @pytest.mark.asyncio
+    async def test_missing_port(self):
+        result = await server_metrics({})
+        assert result == {"error": "Missing required argument: port"}
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_core_server_metrics(self):
+        snapshot = {"available": True, "phase": "idle"}
+        with patch(
+            "llauncher.core.server_metrics.get_aggregate_metrics",
+            return_value=snapshot,
+        ) as mock_get:
+            result = await server_metrics({"port": 8081})
+
+        mock_get.assert_called_once_with(8081)
+        assert result == snapshot
+
+    @pytest.mark.asyncio
+    async def test_returns_degraded_envelope_verbatim(self):
+        degraded = {"available": False, "reason": "unreachable"}
+        with patch(
+            "llauncher.core.server_metrics.get_aggregate_metrics",
+            return_value=degraded,
+        ):
+            result = await server_metrics({"port": 9999})
+
+        assert result == degraded
+
+
+class TestServerSlotsTool:
+    """Thin wrapper over ``core.server_metrics.get_slots``."""
+
+    @pytest.mark.asyncio
+    async def test_missing_port(self):
+        result = await server_slots({})
+        assert result == {"error": "Missing required argument: port"}
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_core_server_metrics(self):
+        payload = {"available": True, "node": "n1", "slots": []}
+        with patch(
+            "llauncher.core.server_metrics.get_slots", return_value=payload
+        ) as mock_get:
+            result = await server_slots({"port": 8081})
+
+        mock_get.assert_called_once_with(8081)
+        assert result == payload
+
+    @pytest.mark.asyncio
+    async def test_returns_slots_disabled_envelope_verbatim(self):
+        """No HTTP-status mapping at the MCP layer — the tool call returns
+        the envelope as-is; only the agent HTTP endpoint maps this to 404.
+        """
+        disabled = {"available": False, "reason": "slots_disabled"}
+        with patch(
+            "llauncher.core.server_metrics.get_slots", return_value=disabled
+        ):
+            result = await server_slots({"port": 8081})
+
+        assert result == disabled

--- a/tests/unit/test_agent_server_metrics_api.py
+++ b/tests/unit/test_agent_server_metrics_api.py
@@ -1,0 +1,112 @@
+"""Unit tests for GET /server-metrics/{port} and GET /server-slots/{port}
+(ADR-LLNCH-019, issue #179 SP-3/SP-4).
+
+The agent layer is a thin HTTP wrapper over
+:mod:`llauncher.core.server_metrics` — these tests patch that module's
+public functions and assert the routing/status-code mapping, not the
+telemetry logic itself (covered by ``tests/unit/test_server_metrics.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from llauncher.agent.middleware import _AUTH_EXEMPT_PATHS
+from llauncher.agent.server import create_app_unauthenticated
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app_unauthenticated()
+    return TestClient(app)
+
+
+class TestNotAuthExempt:
+    """ADR-LLNCH-019 §5: same auth as /status — never exempt."""
+
+    def test_server_metrics_path_not_in_exempt_set(self):
+        assert "/server-metrics/{port}" not in _AUTH_EXEMPT_PATHS
+        assert "/server-metrics/8081" not in _AUTH_EXEMPT_PATHS
+
+    def test_server_slots_path_not_in_exempt_set(self):
+        assert "/server-slots/{port}" not in _AUTH_EXEMPT_PATHS
+        assert "/server-slots/8081" not in _AUTH_EXEMPT_PATHS
+
+
+class TestServerMetricsEndpoint:
+    """GET /server-metrics/{port} — aggregate/safe tier."""
+
+    def test_available_snapshot_passes_through_verbatim(self, client, monkeypatch):
+        snapshot = {
+            "available": True,
+            "state": "ok",
+            "phase": "generating",
+            "gen_tok_s": 22.1,
+            "prompt_tok_s": 5.5,
+            "slots_busy": 1,
+            "slots_total": 4,
+            "requests_deferred": 0,
+            "started_at": "2026-07-01T00:00:00+00:00",
+            "node": "test-node",
+            "canonical_name": "qwen",
+        }
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_aggregate_metrics",
+            lambda port: snapshot if port == 8081 else None,
+        )
+        response = client.get("/server-metrics/8081")
+        assert response.status_code == 200
+        assert response.json() == snapshot
+
+    def test_degraded_envelope_is_still_200(self, client, monkeypatch):
+        degraded = {"available": False, "reason": "loading"}
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_aggregate_metrics",
+            lambda port: degraded,
+        )
+        response = client.get("/server-metrics/9999")
+        assert response.status_code == 200
+        assert response.json() == degraded
+
+    @pytest.mark.parametrize("reason", ["loading", "no-metrics-flag", "unreachable"])
+    def test_every_degraded_reason_is_200(self, client, monkeypatch, reason):
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_aggregate_metrics",
+            lambda port: {"available": False, "reason": reason},
+        )
+        response = client.get("/server-metrics/8081")
+        assert response.status_code == 200
+        assert response.json()["reason"] == reason
+
+
+class TestServerSlotsEndpoint:
+    """GET /server-slots/{port} — sensitive tier."""
+
+    def test_available_snapshot_passes_through(self, client, monkeypatch):
+        payload = {"available": True, "node": "test-node", "slots": [{"id": 0, "prompt": "hi"}]}
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_slots",
+            lambda port: payload,
+        )
+        response = client.get("/server-slots/8081")
+        assert response.status_code == 200
+        assert response.json() == payload
+
+    def test_slots_disabled_maps_to_404(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_slots",
+            lambda port: {"available": False, "reason": "slots_disabled"},
+        )
+        response = client.get("/server-slots/8081")
+        assert response.status_code == 404
+        assert response.json() == {"detail": "slots_disabled"}
+
+    def test_unreachable_is_200_degraded_not_404(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "llauncher.core.server_metrics.get_slots",
+            lambda port: {"available": False, "reason": "unreachable"},
+        )
+        response = client.get("/server-slots/8081")
+        assert response.status_code == 200
+        assert response.json() == {"available": False, "reason": "unreachable"}

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -251,6 +251,26 @@ class TestBuildCommand:
         cmd = build_command(minimal_config, port=8080)
         assert "--metrics" not in cmd
 
+    def test_slots_default_off_emits_no_slots(self, minimal_config):
+        """Issue #179 SP-1: slots defaults to False and emits --no-slots.
+
+        llama-server's own binary default for --slots is ENABLED (PM-2
+        de-risk finding) — the opposite of a safe default, since /slots
+        exposes per-slot prompt text. The launcher must emit the flag
+        explicitly rather than rely on the binary default.
+        """
+        assert minimal_config.slots is False
+        cmd = build_command(minimal_config, port=8080)
+        assert "--no-slots" in cmd
+        assert "--slots" not in cmd
+
+    def test_slots_enabled_emits_slots_flag(self, minimal_config):
+        """Issue #179 SP-1: slots=True emits --slots, not --no-slots."""
+        minimal_config.slots = True
+        cmd = build_command(minimal_config, port=8080)
+        assert "--slots" in cmd
+        assert "--no-slots" not in cmd
+
 
 def _alias_value(cmd: list[str]) -> str:
     """Return the argv token immediately following ``--alias``."""

--- a/tests/unit/test_server_metrics.py
+++ b/tests/unit/test_server_metrics.py
@@ -1,0 +1,419 @@
+"""Unit tests for the server-metrics reader (ADR-LLNCH-019, issue #179).
+
+Covers the Prometheus-text parser, the aggregate-tier degraded envelopes
+and happy path, phase derivation, the TTL cache, and the sensitive
+slots-tier reader — all against the injected fetch seam
+(``server_metrics._fetch_url``), never a live server.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from llauncher.core import server_metrics
+
+
+# ─── Fakes ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResponse:
+    status_code: int
+    text: str = ""
+    _json: Any = None
+    _raise_on_json: bool = False
+
+    def json(self) -> Any:
+        if self._raise_on_json:
+            raise ValueError("not JSON")
+        return self._json
+
+
+@dataclass(frozen=True)
+class _FakeLockfile:
+    model: str
+    started_at: str = "2026-07-01T00:00:00+00:00"
+    port: int = 8081
+    pid: int = 111
+    llauncher_pid: int = 1
+
+
+@dataclass(frozen=True)
+class _FakeModelConfig:
+    parallel: int = 1
+
+
+class _FetchRouter:
+    """Routes ``_fetch_url(url)`` calls to per-path canned responses.
+
+    ``responses`` maps a substring (``"/health"``, ``"/metrics"``,
+    ``"/slots"``) to either a ``_FakeResponse`` or ``None`` (transport
+    failure). Records every URL requested for call-count assertions.
+    """
+
+    def __init__(self, **responses: _FakeResponse | None):
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> _FakeResponse | None:
+        self.calls.append(url)
+        for key, resp in self.responses.items():
+            if key in url:
+                return resp
+        raise AssertionError(f"unexpected fetch URL: {url}")
+
+
+_PROM_TEXT = """\
+# HELP llamacpp:prompt_tokens_total Number of prompt tokens processed.
+# TYPE llamacpp:prompt_tokens_total counter
+llamacpp:prompt_tokens_total 12
+llamacpp:tokens_predicted_total 34
+llamacpp:prompt_tokens_seconds 5.5
+llamacpp:predicted_tokens_seconds 22.1
+llamacpp:requests_processing 1
+llamacpp:requests_deferred 0
+"""
+
+_PROM_TEXT_IDLE = """\
+llamacpp:prompt_tokens_total 12
+llamacpp:tokens_predicted_total 34
+llamacpp:prompt_tokens_seconds 5.5
+llamacpp:predicted_tokens_seconds 22.1
+llamacpp:requests_processing 0
+llamacpp:requests_deferred 0
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    server_metrics.clear_cache()
+    yield
+    server_metrics.clear_cache()
+
+
+@pytest.fixture
+def patch_fetch(monkeypatch):
+    def _apply(**responses: _FakeResponse | None) -> _FetchRouter:
+        router = _FetchRouter(**responses)
+        monkeypatch.setattr(server_metrics, "_fetch_url", router)
+        return router
+
+    return _apply
+
+
+@pytest.fixture
+def patch_disk(monkeypatch):
+    def _apply(lockfile: _FakeLockfile | None, config: _FakeModelConfig | None = None):
+        monkeypatch.setattr(server_metrics, "read_lockfile", lambda port: lockfile)
+        monkeypatch.setattr(
+            server_metrics.ConfigStore,
+            "get_model",
+            classmethod(lambda cls, name: config),
+        )
+
+    return _apply
+
+
+@pytest.fixture(autouse=True)
+def _patch_node_identity(monkeypatch):
+    """Patch the underlying resolver, not ``node_identity`` itself, so the
+    real ``node_identity`` code path (including its #174 swap-point
+    delegation) is exercised by every test in this module.
+    """
+    monkeypatch.setattr("llauncher.core.node_info.get_node_name", lambda: "test-node")
+
+
+# ─── Prometheus text parser ─────────────────────────────────────────
+
+
+class TestParsePrometheusText:
+    def test_parses_counters_and_gauges(self):
+        values = server_metrics._parse_prometheus_text(_PROM_TEXT)
+        assert values["prompt_tokens_total"] == 12
+        assert values["tokens_predicted_total"] == 34
+        assert values["prompt_tokens_seconds"] == 5.5
+        assert values["predicted_tokens_seconds"] == 22.1
+        assert values["requests_processing"] == 1
+        assert values["requests_deferred"] == 0
+
+    def test_skips_comment_and_blank_lines(self):
+        text = "# HELP x\n# TYPE x\n\nllamacpp:requests_processing 2\n"
+        values = server_metrics._parse_prometheus_text(text)
+        assert values == {"requests_processing": 2}
+
+    def test_skips_non_llamacpp_namespace(self):
+        text = "process_start_time_seconds 12345\nllamacpp:requests_processing 1\n"
+        values = server_metrics._parse_prometheus_text(text)
+        assert values == {"requests_processing": 1}
+
+    def test_skips_malformed_lines(self):
+        text = "llamacpp:weird line with extra tokens\nllamacpp:requests_processing 1\n"
+        values = server_metrics._parse_prometheus_text(text)
+        assert values == {"requests_processing": 1}
+
+    def test_skips_non_numeric_value(self):
+        text = "llamacpp:requests_processing not-a-number\n"
+        values = server_metrics._parse_prometheus_text(text)
+        assert values == {}
+
+    def test_empty_text_yields_empty_dict(self):
+        assert server_metrics._parse_prometheus_text("") == {}
+
+
+# ─── Aggregate tier: degraded envelopes ─────────────────────────────
+
+
+class TestAggregateDegraded:
+    def test_health_unreachable(self, patch_fetch):
+        patch_fetch(**{"/health": None})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "unreachable"}
+
+    def test_health_loading(self, patch_fetch):
+        patch_fetch(**{"/health": _FakeResponse(503)})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "loading"}
+
+    def test_health_unexpected_status_is_unreachable(self, patch_fetch):
+        patch_fetch(**{"/health": _FakeResponse(500)})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "unreachable"}
+
+    def test_metrics_transport_failure(self, patch_fetch):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": None})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "unreachable"}
+
+    def test_metrics_disabled_flag(self, patch_fetch):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(501)})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "no-metrics-flag"}
+
+    def test_metrics_unexpected_status_is_unreachable(self, patch_fetch):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(500)})
+        result = server_metrics.get_aggregate_metrics(8081)
+        assert result == {"available": False, "reason": "unreachable"}
+
+
+# ─── Aggregate tier: happy path + identity stamping ─────────────────
+
+
+class TestAggregateHappyPath:
+    def test_full_snapshot_with_lockfile_and_config(self, patch_fetch, patch_disk):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT)})
+        patch_disk(_FakeLockfile(model="qwen-canonical"), _FakeModelConfig(parallel=4))
+
+        result = server_metrics.get_aggregate_metrics(8081)
+
+        assert result["available"] is True
+        assert result["state"] == "ok"
+        assert result["gen_tok_s"] == 22.1
+        assert result["prompt_tok_s"] == 5.5
+        assert result["slots_busy"] == 1
+        assert result["slots_total"] == 4
+        assert result["requests_deferred"] == 0
+        assert result["started_at"] == "2026-07-01T00:00:00+00:00"
+        assert result["canonical_name"] == "qwen-canonical"
+        assert result["node"] == "test-node"
+
+    def test_no_lockfile_degrades_identity_fields_not_availability(self, patch_fetch, patch_disk):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+        patch_disk(None, None)
+
+        result = server_metrics.get_aggregate_metrics(8081)
+
+        assert result["available"] is True
+        assert result["started_at"] is None
+        assert result["canonical_name"] is None
+        assert result["slots_total"] is None
+
+    def test_lockfile_present_but_config_missing(self, patch_fetch, patch_disk):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+        patch_disk(_FakeLockfile(model="ghost"), None)
+
+        result = server_metrics.get_aggregate_metrics(8081)
+
+        assert result["canonical_name"] == "ghost"
+        assert result["slots_total"] is None
+
+
+# ─── Phase derivation ────────────────────────────────────────────────
+
+
+class TestPhaseDerivation:
+    def test_idle_when_no_requests_processing(self, patch_fetch, patch_disk):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+        patch_disk(None, None)
+        result = server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+        assert result["phase"] == "idle"
+
+    def test_first_busy_poll_defaults_to_generating(self, patch_fetch, patch_disk):
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT)})
+        patch_disk(None, None)
+        result = server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+        assert result["phase"] == "generating"
+
+    def test_predicted_delta_yields_generating(self, patch_fetch, patch_disk):
+        patch_disk(None, None)
+        first = "llamacpp:prompt_tokens_total 10\nllamacpp:tokens_predicted_total 10\nllamacpp:requests_processing 1\n"
+        second = "llamacpp:prompt_tokens_total 10\nllamacpp:tokens_predicted_total 20\nllamacpp:requests_processing 1\n"
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=first)})
+        server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=second)})
+        result = server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+        assert result["phase"] == "generating"
+
+    def test_prompt_only_delta_yields_prompt(self, patch_fetch, patch_disk):
+        patch_disk(None, None)
+        first = "llamacpp:prompt_tokens_total 10\nllamacpp:tokens_predicted_total 10\nllamacpp:requests_processing 1\n"
+        second = "llamacpp:prompt_tokens_total 40\nllamacpp:tokens_predicted_total 10\nllamacpp:requests_processing 1\n"
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=first)})
+        server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=second)})
+        result = server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+        assert result["phase"] == "prompt"
+
+    def test_busy_with_no_counter_movement_falls_back_to_generating(self, patch_fetch, patch_disk):
+        patch_disk(None, None)
+        same = "llamacpp:prompt_tokens_total 10\nllamacpp:tokens_predicted_total 10\nllamacpp:requests_processing 1\n"
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=same)})
+        server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=same)})
+        result = server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+        assert result["phase"] == "generating"
+
+    def test_phase_delta_is_keyed_per_port(self, patch_fetch, patch_disk):
+        """A second port's first poll must not see the first port's history."""
+        patch_disk(None, None)
+        busy = "llamacpp:prompt_tokens_total 10\nllamacpp:tokens_predicted_total 20\nllamacpp:requests_processing 1\n"
+
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=busy)})
+        server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+
+        idle_other_port = _PROM_TEXT_IDLE
+        patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=idle_other_port)})
+        result = server_metrics.get_aggregate_metrics(9999, force_refresh=True)
+        assert result["phase"] == "idle"
+
+
+# ─── TTL cache ────────────────────────────────────────────────────────
+
+
+class TestAggregateCache:
+    def test_second_call_within_ttl_is_cached(self, patch_fetch, patch_disk, monkeypatch):
+        monkeypatch.setattr(server_metrics.settings, "LLAUNCHER_METRICS_CACHE_S", 5.0)
+        patch_disk(None, None)
+        router = patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+
+        first = server_metrics.get_aggregate_metrics(8081)
+        second = server_metrics.get_aggregate_metrics(8081)
+
+        assert first == second
+        assert len(router.calls) == 2  # one /health + one /metrics — cached, not refetched
+
+    def test_force_refresh_bypasses_cache(self, patch_fetch, patch_disk, monkeypatch):
+        monkeypatch.setattr(server_metrics.settings, "LLAUNCHER_METRICS_CACHE_S", 5.0)
+        patch_disk(None, None)
+        router = patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+
+        server_metrics.get_aggregate_metrics(8081)
+        server_metrics.get_aggregate_metrics(8081, force_refresh=True)
+
+        assert len(router.calls) == 4  # two full probes, no cache hit
+
+    def test_ttl_le_zero_disables_caching(self, patch_fetch, patch_disk, monkeypatch):
+        monkeypatch.setattr(server_metrics.settings, "LLAUNCHER_METRICS_CACHE_S", 0.0)
+        patch_disk(None, None)
+        router = patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+
+        server_metrics.get_aggregate_metrics(8081)
+        server_metrics.get_aggregate_metrics(8081)
+
+        assert len(router.calls) == 4
+
+    def test_clear_cache_drops_cached_entry(self, patch_fetch, patch_disk, monkeypatch):
+        monkeypatch.setattr(server_metrics.settings, "LLAUNCHER_METRICS_CACHE_S", 5.0)
+        patch_disk(None, None)
+        router = patch_fetch(**{"/health": _FakeResponse(200), "/metrics": _FakeResponse(200, text=_PROM_TEXT_IDLE)})
+
+        server_metrics.get_aggregate_metrics(8081)
+        server_metrics.clear_cache()
+        server_metrics.get_aggregate_metrics(8081)
+
+        assert len(router.calls) == 4
+
+
+class TestDefaultFetch:
+    """Exercises the real (unpatched) production fetch seam."""
+
+    def test_returns_response_on_success(self, monkeypatch):
+        sentinel = _FakeResponse(200)
+        monkeypatch.setattr(server_metrics.httpx, "get", lambda url, timeout: sentinel)
+        assert server_metrics._default_fetch("http://127.0.0.1:1/health") is sentinel
+
+    def test_returns_none_on_request_error(self, monkeypatch):
+        import httpx as real_httpx
+
+        def _raise(url, timeout):
+            raise real_httpx.ConnectError("refused")
+
+        monkeypatch.setattr(server_metrics.httpx, "get", _raise)
+        assert server_metrics._default_fetch("http://127.0.0.1:1/health") is None
+
+
+# ─── Slots tier ───────────────────────────────────────────────────────
+
+
+class TestGetSlots:
+    def test_unreachable(self, patch_fetch):
+        patch_fetch(**{"/slots": None})
+        assert server_metrics.get_slots(8081) == {"available": False, "reason": "unreachable"}
+
+    def test_slots_disabled(self, patch_fetch):
+        patch_fetch(**{"/slots": _FakeResponse(501)})
+        assert server_metrics.get_slots(8081) == {"available": False, "reason": "slots_disabled"}
+
+    def test_unexpected_status_is_unreachable(self, patch_fetch):
+        patch_fetch(**{"/slots": _FakeResponse(500)})
+        assert server_metrics.get_slots(8081) == {"available": False, "reason": "unreachable"}
+
+    def test_happy_path_returns_slots_payload(self, patch_fetch):
+        payload = [{"id": 0, "prompt": "hello"}]
+        patch_fetch(**{"/slots": _FakeResponse(200, _json=payload)})
+        result = server_metrics.get_slots(8081)
+        assert result == {"available": True, "node": "test-node", "slots": payload}
+
+    def test_non_json_body_is_unreachable(self, patch_fetch):
+        patch_fetch(**{"/slots": _FakeResponse(200, _raise_on_json=True)})
+        result = server_metrics.get_slots(8081)
+        assert result == {"available": False, "reason": "unreachable"}
+
+
+# ─── node_identity + misc helpers ──────────────────────────────────────
+
+
+def test_node_identity_delegates_to_get_node_name(monkeypatch):
+    """``node_identity`` resolves via ``core.node_info.get_node_name`` — the
+    single #174 swap point (module docstring / ADR §4).
+    """
+    monkeypatch.setattr(
+        "llauncher.core.node_info.get_node_name", lambda: "the-real-node"
+    )
+    assert server_metrics.node_identity() == "the-real-node"
+
+
+def test_to_int_passthrough_none():
+    assert server_metrics._to_int(None) is None
+
+
+def test_to_int_converts_float():
+    assert server_metrics._to_int(3.0) == 3


### PR DESCRIPTION
## What

Implements ADR-LLNCH-019 (`docs/adrs/accepted/adr-llnch-019-server-metrics-surface.md`) per issue #179, build order SP-1 through SP-6. SP-7 (cross-repo handshake) is a written finding posted on harness-tools#45 — it blocks that repo's issue, not this build, per the ADR's own scoping.

- **SP-1 (remainder)** — `ModelConfig.slots: bool = False`; `core/process.py::build_command` now always emits `--slots`/`--no-slots` explicitly (llama-server's own binary default is the inverse — ENABLED — per the issue's PM-2 de-risk finding); both spellings registered in `MANAGED_NATIVE_FLAG_TO_FIELD`. (`--metrics` was already landed via #261/#169.)
- **SP-2** — new `core/server_metrics.py`: stateless-per-poll collector, peer to `core/gpu.py`. Two physically-separate tiers (`get_aggregate_metrics`, `get_slots`), `LLAUNCHER_METRICS_CACHE_S` TTL cache (default 2s), injectable fetch seam, degraded envelopes (`loading`/`no-metrics-flag`/`unreachable`/`slots_disabled`). Degraded-reason HTTP codes (503/501) were verified against the live llama-server source (`tools/server/server-context.cpp`), not assumed. `phase` (idle/prompt/generating) derives from a one-sample-per-port counter delta, gated by `requests_processing`.
- **SP-3/SP-4** — agent endpoints `GET /server-metrics/{port}` (always 200, degraded envelope carries failure) and `GET /server-slots/{port}` (`404 slots_disabled` when not started with `--slots`; otherwise 200). Neither path is in the auth-exempt set.
- **SP-5** — MCP tools `server_metrics(port)` / `server_slots(port)`, stateless, local-node, wired into `list_tools`/`_dispatch_tool`. Tier separation is which tool a client is granted, not a flag.
- **SP-6** — full unit coverage (100% on every new/changed module) plus an integration test: a stub-mode wiring proof (real subprocess + real port, runs in CI, deterministic "unreachable" outcome) and a real-`llama-server` variant gated behind `LLAUNCHER_INTEGRATION_REAL=1` (matches `test_self_swap.py`'s convention) that polls until `phase`/tok-s are populated and grounds the `--no-slots` default live.

## Gates

- Full `pytest`: 1 pre-existing baseline failure (`tests/unit/test_cli.py::test_config_path_printed`, unrelated — present on `origin/main` before this branch), 1416 passed, 12 skipped (11 baseline + 1 new opt-in real-mode skip).
- Coverage: 100% (floor 93%).
- Every new/changed non-UI file individually verified at 100% line coverage.

## Notes

- ADR status line updated to reflect SP-1–SP-6 landed via this PR.
- SP-7 finding (harness-tools `footer-budget/index.ts::fetchFooterContext` shape compatibility) posted separately on harness-tools#45 — no mismatch found; the consumer's existing "200 + null sub-fields" degradation convention already composes with `/server-metrics`'s `{available:false, reason:...}` envelope.

DO NOT MERGE per dispatch contract — awaiting review.

Closes #179.