### PR TITLE
fix(config): remove dead, mislabeled ModelConfig.np field

### DIFF
--- a/llauncher/agent/routing.py
+++ b/llauncher/agent/routing.py
@@ -261,7 +261,6 @@ def list_models() -> list[dict]:
                 "mmproj_path": config.mmproj_path,
                 "n_gpu_layers": config.n_gpu_layers,
                 "ctx_size": config.ctx_size,
-                "np": config.np,
                 "running": running_port is not None,
                 "running_port": running_port,
             }

--- a/llauncher/models/config.py
+++ b/llauncher/models/config.py
@@ -179,7 +179,6 @@ class ModelConfig(BaseModel):
     mmproj_path: str | None = None
     n_gpu_layers: int = Field(default=255, ge=0)
     ctx_size: int = Field(default=131072, gt=0)
-    np: int | None = Field(default=None, ge=1, description="Number of KV cache pages")
     threads: int | None = None
     threads_batch: int = Field(default=8, gt=0)
     ubatch_size: int = Field(default=512, gt=0)
@@ -305,6 +304,9 @@ class ModelConfig(BaseModel):
         - Drops ``default_port`` (per ADR-010: port is a call-site concern).
         - Drops ``port`` (legacy synonym, same reason).
         - Drops ``host`` (legacy; defaults handled at start time).
+        - Drops ``np`` (issue #235: dead, mislabeled duplicate of
+          ``parallel`` — never rendered by ``build_command``; live store
+          audit confirmed every persisted value was already null).
         - Migrates ``extra_args`` from ``list[str]`` to ``str``.
         """
         data = data.copy()
@@ -312,6 +314,7 @@ class ModelConfig(BaseModel):
         data.pop("default_port", None)
         data.pop("port", None)
         data.pop("host", None)
+        data.pop("np", None)  # #235: dead field, superseded by `parallel`
         # Migrate extra_args from list[str] to str (legacy v1 shape).
         if "extra_args" in data and isinstance(data["extra_args"], list):
             data["extra_args"] = " ".join(data["extra_args"])

--- a/tests/unit/mcp/test_models_tools.py
+++ b/tests/unit/mcp/test_models_tools.py
@@ -18,14 +18,12 @@ def mock_state():
         "name": "running-model",
         "model_path": "/path/to/running.gguf",
         "ctx_size": 32768,
-        "np": 4,
     })
 
     stopped_config = ModelConfig.from_dict_unvalidated({
         "name": "stopped-model",
         "model_path": "/path/to/stopped.gguf",
         "ctx_size": 65536,
-        "np": None,
     })
 
     state.models = {
@@ -97,22 +95,13 @@ class TestListModels:
 
     @pytest.mark.asyncio
     async def test_get_model_config_returns_full_config(self, mock_state):
-        """get_model_config returns configuration dict with ctx_size and np."""
+        """get_model_config returns configuration dict with ctx_size."""
         result = await get_model_config(mock_state, {"name": "running-model"})
 
         config = result["configuration"]
         assert "ctx_size" in config
-        assert "np" in config
+        assert "np" not in config  # Removed per #235
         assert config["ctx_size"] == 32768
-        assert config["np"] == 4
-
-    @pytest.mark.asyncio
-    async def test_get_model_config_np_none(self, mock_state):
-        """get_model_config handles np=None correctly."""
-        result = await get_model_config(mock_state, {"name": "stopped-model"})
-
-        config = result["configuration"]
-        assert config["np"] is None
 
 
 class TestGetModelConfig:

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -143,7 +143,7 @@ class TestStatusEndpoint:
         assert data["total_running"] == len(data["running_servers"])
 
     def test_status_includes_model_config_per_server(self, client):
-        """Test that /status includes model_config with ctx_size and np per server."""
+        """Test that /status includes model_config with ctx_size per server."""
         from llauncher.agent import routing
 
         # Clear any state from other tests
@@ -155,7 +155,6 @@ class TestStatusEndpoint:
                 name='test-model',
                 model_path='/fake/model.gguf',
                 ctx_size=2048,
-                np=4,
                 n_gpu_layers=32,
             ),
         }
@@ -178,14 +177,13 @@ class TestStatusEndpoint:
         assert data["total_running"] == 1
         server = data["running_servers"][0]
 
-        # model_config should be present with np and ctx_size
+        # model_config should be present with ctx_size
         assert "model_config" in server
         assert server["model_config"] is not None
         mc = server["model_config"]
         assert "ctx_size" in mc
-        assert "np" in mc
+        assert "np" not in mc
         assert mc["ctx_size"] == 2048
-        assert mc["np"] == 4
 
     def test_status_model_config_none_for_unknown_server(self, client):
         """Test that model_config is None when config lookup fails."""
@@ -283,9 +281,9 @@ class TestModelsEndpoint:
             assert "kind" in model  # Per ADR-010 + #42 scaffolding
             assert "n_gpu_layers" in model
             assert "ctx_size" in model
-            assert "np" in model
             assert "running" in model
             assert "default_port" not in model  # Removed per ADR-010
+            assert "np" not in model  # Removed per #235 (dead, mislabeled duplicate of `parallel`)
 
 
 class TestStartServerEndpoint:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -90,7 +90,6 @@ class TestModelConfigFieldRoundtrip:
             "mmproj_path": "/fake/path/mmproj.gguf",
             "n_gpu_layers": 100,
             "ctx_size": 32768,
-            "np": 4,
             "threads": 8,
             "threads_batch": 16,
             "ubatch_size": 1024,
@@ -137,7 +136,6 @@ class TestModelConfigFieldRoundtrip:
         assert restored.reverse_prompt == original_data["reverse_prompt"]
         assert restored.mlock == original_data["mlock"]
         assert restored.extra_args == original_data["extra_args"]
-        assert restored.np == original_data["np"]
 
     def test_optional_fields_defaults(self):
         """Test optional fields have correct defaults when not specified."""
@@ -168,7 +166,6 @@ class TestModelConfigFieldRoundtrip:
         assert config.reverse_prompt is None
         assert config.mlock is False
         assert config.extra_args == ""
-        assert config.np is None
 
 
 class TestModelConfigLegacyFieldDrop:
@@ -205,6 +202,20 @@ class TestModelConfigLegacyFieldDrop:
         config = ModelConfig.from_dict_unvalidated(old_format)
         # Should not raise, and host should not be in output
         assert "host" not in config.to_dict()
+
+    def test_np_field_dropped(self):
+        """Issue #235: ``np`` was a dead, mislabeled duplicate of
+        ``parallel`` — never rendered by ``build_command``. It is removed
+        entirely; a persisted config carrying a (always-null, per live
+        store audit) legacy ``np`` key loads without error and drops it."""
+        old_format = {
+            "name": "old-model",
+            "model_path": "/fake/path/model.gguf",
+            "np": 4,
+        }
+        config = ModelConfig.from_dict_unvalidated(old_format)
+        assert not hasattr(config, "np")
+        assert "np" not in config.to_dict()
 
 
 class TestModelConfigFieldValidators:
@@ -251,47 +262,6 @@ class TestModelConfigFieldValidators:
         }
         with pytest.raises(ValueError):
             ModelConfig.from_dict_unvalidated(data)
-
-    def test_np_valid_values(self):
-        """Test valid np values are accepted."""
-        for value in [1, 2, 4, 8]:
-            data = {
-                "name": "test-model",
-                "model_path": "/fake/path/model.gguf",
-                "np": value,
-            }
-            config = ModelConfig.from_dict_unvalidated(data)
-            assert config.np == value
-
-    def test_np_invalid_values(self):
-        """Test invalid np values raise errors."""
-        for value in [0, -1]:
-            data = {
-                "name": "test-model",
-                "model_path": "/fake/path/model.gguf",
-                "np": value,
-            }
-            with pytest.raises(ValueError):
-                ModelConfig.from_dict_unvalidated(data)
-
-    def test_np_defaults_to_none(self):
-        """Test np defaults to None when not specified."""
-        data = {
-            "name": "test-model",
-            "model_path": "/fake/path/model.gguf",
-        }
-        config = ModelConfig.from_dict_unvalidated(data)
-        assert config.np is None
-
-    def test_np_none_serializes_to_none(self):
-        """Test that np=None serializes to null/None in to_dict()."""
-        data = {
-            "name": "test-model",
-            "model_path": "/fake/path/model.gguf",
-        }
-        config = ModelConfig.from_dict_unvalidated(data)
-        serialized = config.to_dict()
-        assert serialized["np"] is None
 
     def test_flash_attn_valid_values(self):
         """Test valid flash_attn values."""


### PR DESCRIPTION
## Summary
- `ModelConfig.np` (described "Number of KV cache pages") was never referenced by `core/process.py::build_command` — setting it in a config was a silent no-op.
- It also duplicated the live `parallel` field, which already renders llama.cpp's `--parallel` (`-np`) flag under its correct name.
- Field removed. Live store audit (`/var/lib/llauncher/config.json` + backup + `~/.llauncher/config.json`) confirmed every persisted `np` value was already `null`, so no data migration is needed. A legacy `np` key on a persisted config is now silently dropped at the door (`ModelConfig.from_dict_unvalidated`), matching the existing `port` / `default_port` / `host` pattern (`PARSE-AT-THE-DOOR`).
- Dropped the now-dead `"np": config.np` emission from the agent `/models` and `/status` (`model_config`) responses, and from the MCP `get_model_config` tool output (both derive from `ModelConfig.to_dict()`).

Closes #235.

## Test plan
- [x] `tests/unit/test_models.py` — replaced the np-specific validator tests with a `TestModelConfigLegacyFieldDrop::test_np_field_dropped` case (same shape as the existing `port`/`default_port`/`host` legacy-drop tests); removed `np` from the full-field roundtrip and defaults tests.
- [x] `tests/unit/test_agent.py` — updated `/status` and `/models` structure tests to assert `np` is absent instead of present.
- [x] `tests/unit/mcp/test_models_tools.py` — updated `get_model_config` tests to assert `np` is absent; dropped the now-moot `np=None` fixture case.
- [x] Full `pytest` run: 1355 passed, 11 skipped, 1 pre-existing failure (`tests/unit/test_cli.py::test_config_path_printed`, baseline F0 — unrelated to this change).
- [x] Coverage: 100% (gate `--cov-fail-under=93`).