### PR TITLE
fix(remote): validate node host/port/timeout with a Pydantic NodeConfig

### DIFF
--- a/llauncher/remote/node.py
+++ b/llauncher/remote/node.py
@@ -18,10 +18,50 @@ from datetime import datetime
 from enum import Enum
 
 import httpx
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from llauncher.core.delegation import is_agent_process
 
 logger = logging.getLogger(__name__)
+
+
+class NodeConfig(BaseModel):
+    """Validated connection parameters for a :class:`RemoteNode` (issue #27).
+
+    Single source of truth for the shape a node's connection parameters
+    must satisfy — host/port/timeout — so ``RemoteNode`` and
+    ``NodeRegistry`` validate identically instead of each hand-rolling
+    checks. The bug this closes: a host field with an embedded port
+    (``"192.168.137.2:8765"``) plus a *separate* port field produced a
+    malformed ``base_url`` (``http://192.168.137.2:8765:8765``) with no
+    error until the request failed.
+    """
+
+    name: str = Field(min_length=1)
+    host: str = Field(min_length=1)
+    port: int = Field(default=8765, ge=1024, le=65535)
+    timeout: float = Field(default=5.0, gt=0)
+
+    @field_validator("host")
+    @classmethod
+    def _reject_embedded_port(cls, value: str) -> str:
+        """Reject a host carrying a single embedded ``:port`` suffix.
+
+        Exactly one colon is the ``host:port`` shape (the #27 bug);
+        IPv6 literals (``::1``, ``2001:db8::1``) carry two-or-more and
+        are left alone rather than mis-flagged.
+        """
+        if value.count(":") == 1:
+            raise ValueError(
+                f"host {value!r} must not embed a port — use the separate "
+                "port field instead"
+            )
+        return value
+
+    @property
+    def base_url(self) -> str:
+        """Base URL for this node's agent."""
+        return f"http://{self.host}:{self.port}"
 
 
 def _local_host_names() -> frozenset[str]:
@@ -113,10 +153,18 @@ class RemoteNode:
         timeout: float = 5.0,
         api_key: str | None = None,
     ):
-        self.name = name
-        self.host = host
-        self.port = port
-        self.timeout = timeout
+        try:
+            config = NodeConfig(name=name, host=host, port=port, timeout=timeout)
+        except ValidationError as e:
+            # Collapse pydantic's multi-line error into the first,
+            # most-relevant message so callers (registry, UI) can
+            # surface a single readable line rather than a traceback.
+            raise ValueError(e.errors()[0]["msg"]) from e
+        self._config = config
+        self.name = config.name
+        self.host = config.host
+        self.port = config.port
+        self.timeout = config.timeout
         self.api_key: str | None = api_key if api_key else None
         self.status = NodeStatus.OFFLINE
         self.last_seen: datetime | None = None
@@ -125,7 +173,7 @@ class RemoteNode:
     @property
     def base_url(self) -> str:
         """Get the base URL for this node's agent."""
-        return f"http://{self.host}:{self.port}"
+        return self._config.base_url
 
     def __str__(self) -> str:
         return f"RemoteNode({self.name}@{self.host}:{self.port}, status={self.status.value})"

--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -48,24 +48,52 @@ class NodeRegistry:
             self._populate_local_token()
             return
 
+        migrated = False
         try:
             data = json.loads(NODES_FILE.read_text())
             for name, node_data in data.items():
                 # Backward compat: old files use "api_key", new files use "has_api_key"
                 raw_key = node_data.get("api_key")
+                host = node_data["host"]
+                port = node_data.get("port", 8765)
+                if isinstance(host, str) and host.count(":") == 1:
+                    # Issue #27: a prior UI bug let an embedded port slip
+                    # into the host field (e.g. "192.168.137.2:8765") on
+                    # top of a separate port field, producing a malformed
+                    # base_url. Migrate once, at the door (PARSE-AT-THE-DOOR):
+                    # split the embedded port out and prefer it as the
+                    # real port, then persist the corrected shape below.
+                    fixed_host, _, port_str = host.rpartition(":")
+                    if port_str.isdigit():
+                        port = int(port_str)
+                    logger.warning(
+                        f"Migrated corrupted host for node '{name}': "
+                        f"{host!r} -> host={fixed_host!r}, port={port}"
+                    )
+                    host = fixed_host
+                    migrated = True
                 self._nodes[name] = RemoteNode(
                     name=node_data["name"],
-                    host=node_data["host"],
-                    port=node_data.get("port", 8765),
+                    host=host,
+                    port=port,
                     timeout=node_data.get("timeout", 5.0),
                     api_key=raw_key,
                 )
-        except (json.JSONDecodeError, KeyError):  # pragma: no cover - defensive recovery from a corrupted/partial nodes.json; start fresh rather than crash UI startup
-            # Corrupted file, start fresh
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Corrupted file (bad JSON/shape), or an entry that still
+            # fails NodeConfig validation after the embedded-port
+            # migration above (issue #27) — start fresh rather than
+            # crash UI startup.
             self._nodes.clear()
+            migrated = False
 
         self._populate_local_token()
         self._populate_remote_tokens()
+
+        if migrated:
+            # Persist the corrected shape once so the migration doesn't
+            # re-run (and re-log) on every subsequent load.
+            self._save()
 
     def _resolve_local_token(self) -> str | None:
         """Resolve the local agent's auth token, or return ``None``.
@@ -289,13 +317,21 @@ class NodeRegistry:
         if name in self._nodes and not overwrite:
             return False, f"Node '{name}' already exists. Use overwrite=True to replace."
 
-        self._nodes[name] = RemoteNode(
-            name=name,
-            host=host,
-            port=port,
-            timeout=timeout,
-            api_key=api_key,
-        )
+        try:
+            node = RemoteNode(
+                name=name,
+                host=host,
+                port=port,
+                timeout=timeout,
+                api_key=api_key,
+            )
+        except ValueError as e:
+            # NodeConfig validation failure (issue #27) — surface as a
+            # normal (success, message) failure rather than an
+            # exception, matching the rest of this method's contract.
+            return False, str(e)
+
+        self._nodes[name] = node
         self._save()
         return True, f"Node '{name}' added successfully"
 

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -194,7 +194,11 @@ def render_add_node_form(registry: NodeRegistry) -> None:
         )
         node_host = st.text_input(
             "Host",
-            help="Hostname or IP address (e.g., '192.168.1.100' or 'server.local')",
+            help=(
+                "Hostname or IP address only — no port (e.g., '192.168.1.100' "
+                "or 'server.local'). Set the port separately below; "
+                "'192.168.1.100:8765' will be rejected."
+            ),
         )
         col1, col2 = st.columns(2)
         with col1:
@@ -245,13 +249,17 @@ def render_add_node_form(registry: NodeRegistry) -> None:
             else:
                 from llauncher.remote.node import RemoteNode
 
-                test_node = RemoteNode(
-                    node_name,
-                    node_host,
-                    node_port,
-                    timeout,
-                    api_key=api_key or None,
-                )
+                try:
+                    test_node = RemoteNode(
+                        node_name,
+                        node_host,
+                        node_port,
+                        timeout,
+                        api_key=api_key or None,
+                    )
+                except ValueError as e:
+                    st.error(str(e))
+                    return
                 result = test_node.ping()
                 if result:
                     st.success(

--- a/tests/ui/test_nodes_tab.py
+++ b/tests/ui/test_nodes_tab.py
@@ -48,6 +48,14 @@ def _button_by_key(at, key):
                          f"{[e.key for e in at.button]}")
 
 
+def _button_by_label(at, label):
+    for el in at.button:
+        if el.label == label:
+            return el
+    raise AssertionError(f"no button labelled {label!r}; saw "
+                         f"{[e.label for e in at.button]}")
+
+
 class TestNodesTabRender:
     """The tab renders headlessly through the engine facades only."""
 
@@ -104,6 +112,34 @@ class TestAddNodeFormSmoke:
         assert "LLAUNCHER_AGENT_TOKEN" in help_text
         assert "agent.token" in help_text
         assert "ADR-003" in help_text
+
+
+class TestAddNodeFormHostValidation:
+    """Issue #27: the form surfaces ``NodeConfig`` host validation as an
+    ``st.error``, never an uncaught exception, and documents the rule
+    up front in the field's help text.
+    """
+
+    def test_host_help_warns_against_embedded_port(
+        self, tab_harness, mock_registry, mock_aggregator
+    ):
+        at = tab_harness(render_nodes_tab, mock_registry, mock_aggregator)
+
+        help_text = _input_by_label(at, "Host").help
+        assert "no port" in help_text.lower()
+
+    def test_embedded_port_host_shows_error_not_exception(
+        self, tab_harness, mock_registry, mock_aggregator
+    ):
+        at = tab_harness(render_nodes_tab, mock_registry, mock_aggregator)
+
+        _input_by_label(at, "Node Name").set_value("gpu-rig")
+        _input_by_label(at, "Host").set_value("192.168.1.50:8765")
+        _button_by_label(at, "🔍 Test Connection").click()
+        at.run()
+
+        assert not at.exception
+        assert any("port" in e.value for e in at.error)
 
 
 class TestNodesTabRemoteIO:

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -9,9 +9,47 @@ from unittest.mock import MagicMock, patch
 import pytest
 import httpx
 
-from llauncher.remote.node import RemoteNode, NodeStatus, RemoteServerInfo
+from llauncher.remote.node import NodeConfig, RemoteNode, NodeStatus, RemoteServerInfo
 from llauncher.remote.registry import NodeRegistry, NODES_FILE
 from llauncher.remote.state import RemoteAggregator
+
+
+class TestNodeConfig:
+    """Tests for the ``NodeConfig`` pydantic model (issue #27)."""
+
+    def test_defaults(self):
+        config = NodeConfig(name="n", host="192.168.1.100")
+
+        assert config.port == 8765
+        assert config.timeout == 5.0
+
+    def test_base_url(self):
+        config = NodeConfig(name="n", host="192.168.1.100", port=9000)
+
+        assert config.base_url == "http://192.168.1.100:9000"
+
+    def test_rejects_host_with_embedded_port(self):
+        with pytest.raises(ValueError, match="must not embed a port"):
+            NodeConfig(name="n", host="192.168.137.2:8765")
+
+    def test_allows_ipv6_literal_with_multiple_colons(self):
+        # "::1" and full IPv6 literals carry 2+ colons — the #27 bug
+        # was specifically the *single*-colon host:port shape.
+        config = NodeConfig(name="n", host="::1")
+
+        assert config.host == "::1"
+
+    def test_rejects_port_out_of_range(self):
+        with pytest.raises(ValueError):
+            NodeConfig(name="n", host="192.168.1.100", port=80)
+
+    def test_rejects_non_positive_timeout(self):
+        with pytest.raises(ValueError):
+            NodeConfig(name="n", host="192.168.1.100", timeout=0)
+
+    def test_rejects_empty_host(self):
+        with pytest.raises(ValueError):
+            NodeConfig(name="n", host="")
 
 
 class TestRemoteNode:
@@ -40,6 +78,12 @@ class TestRemoteNode:
         node = RemoteNode("test-node", "192.168.1.100", port=9000)
 
         assert node.base_url == "http://192.168.1.100:9000"
+
+    def test_rejects_host_with_embedded_port(self):
+        """Issue #27: constructing a node with a corrupted host raises
+        a single-line ``ValueError``, not a raw pydantic traceback."""
+        with pytest.raises(ValueError, match="must not embed a port"):
+            RemoteNode("test-node", "192.168.137.2:8765")
 
     def test_str_representation(self):
         """Test string representation."""
@@ -629,6 +673,18 @@ class TestNodeRegistry:
         assert success is False
         assert "already exists" in message
 
+    def test_add_node_rejects_embedded_port_host(self, temp_nodes_file):
+        """Issue #27: NodeConfig validation failures surface as a normal
+        ``(False, message)`` result, not an uncaught exception, and the
+        node is not registered."""
+        registry = NodeRegistry()
+
+        success, message = registry.add_node("test-node", "192.168.1.100:8765", 8765)
+
+        assert success is False
+        assert "port" in message
+        assert registry.get_node("test-node") is None
+
     def test_add_node_overwrite(self, temp_nodes_file):
         """Test adding duplicate node with overwrite."""
         registry = NodeRegistry()
@@ -676,6 +732,58 @@ class TestNodeRegistry:
         assert node is not None
         assert node.host == "192.168.1.100"
         assert node.port == 9000
+
+    def test_load_migrates_corrupted_embedded_port_host(self, temp_nodes_file):
+        """Issue #27: a pre-existing corrupted ``nodes.json`` entry with a
+        host carrying an embedded port is migrated once, at load time,
+        rather than producing a broken ``RemoteNode`` or crashing.
+        """
+        temp_nodes_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_nodes_file.write_text(
+            json.dumps(
+                {
+                    "gpu-rig": {
+                        "name": "gpu-rig",
+                        "host": "192.168.137.2:8765",
+                        "port": 8765,
+                        "timeout": 5.0,
+                    }
+                }
+            )
+        )
+
+        registry = NodeRegistry()
+
+        node = registry.get_node("gpu-rig")
+        assert node is not None
+        assert node.host == "192.168.137.2"
+        assert node.port == 8765
+        assert node.base_url == "http://192.168.137.2:8765"
+
+        # The migration is persisted so a reload doesn't need to re-fix it.
+        on_disk = json.loads(temp_nodes_file.read_text())
+        assert on_disk["gpu-rig"]["host"] == "192.168.137.2"
+
+    def test_load_unrecoverable_entry_starts_fresh(self, temp_nodes_file):
+        """An entry that still fails validation after migration (e.g. an
+        out-of-range port) falls back to the existing corrupted-file
+        behavior — start fresh — rather than crashing UI startup."""
+        temp_nodes_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_nodes_file.write_text(
+            json.dumps(
+                {
+                    "bad-node": {
+                        "name": "bad-node",
+                        "host": "192.168.1.100",
+                        "port": 80,
+                    }
+                }
+            )
+        )
+
+        registry = NodeRegistry()
+
+        assert registry.get_node("bad-node") is None
 
     def test_refresh_all(self, temp_nodes_file):
         """Test refreshing all nodes."""


### PR DESCRIPTION
Closes #27.

## Summary
- Adds `NodeConfig` (pydantic) in `llauncher/remote/node.py` as the single validated shape for a node's connection parameters: `host` (rejects an embedded `host:port` — the #27 bug — while leaving IPv6 literals alone), `port` (1024-65535), `timeout` (>0), plus a computed `base_url`.
- `RemoteNode.__init__` validates through `NodeConfig` and re-raises pydantic's `ValidationError` as a single-line `ValueError` so callers get a readable message, not a traceback.
- `NodeRegistry.add_node` catches that `ValueError` and returns `(False, message)`, matching its existing contract, instead of propagating.
- `NodeRegistry._load` migrates a pre-existing corrupted `nodes.json` entry (embedded-port host) once, at the door — splits the port back out, logs a warning, and persists the corrected shape so the fix-up doesn't repeat on every load. An entry that still fails validation after migration falls back to the existing "corrupted file → start fresh" behavior.
- `ui/tabs/nodes.py`'s Add Node form documents the host-has-no-port rule in the field's help text and catches the `RemoteNode` construction `ValueError` on "Test Connection" so it surfaces as `st.error` rather than crashing the tab.

## Test plan
- [x] `pytest tests/unit/test_remote.py tests/unit/test_remote_node_extended.py tests/unit/test_remote_node_auth.py tests/ui/test_nodes_tab.py` — new `NodeConfig` unit tests, `RemoteNode`/`NodeRegistry.add_node` rejection tests, a `NodeRegistry._load` migration test and an unrecoverable-entry test, and two `AppTest`-driven UI tests (help text + Test Connection error surfacing).
- [x] Full `pytest` suite: 1368 passed, 11 skipped, 1 pre-existing failure (`tests/unit/test_cli.py::test_config_path_printed`, the declared baseline F0, unrelated to this change).
- [x] Non-UI coverage: 100% (floor is 93%); `llauncher/remote/node.py` and `llauncher/remote/registry.py` both at 100%.