### PR TITLE
Carry ctx_size/parallel in start/swap tool-results

### DIFF
--- a/llauncher/operations/start.py
+++ b/llauncher/operations/start.py
@@ -39,6 +39,8 @@ class StartResult:
     pid: int | None = None
     message: str = ""
     cancel_ignored_post_commit: bool = False
+    ctx_size: int | None = None
+    parallel: int | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -75,6 +77,10 @@ def start(
         recon = lf.reconcile_lockfile(existing)
         if recon.pid_alive:
             if existing.model == model_name:
+                # Idempotent short-circuit predates the config lookup below;
+                # fetch it here too so a consumer folding this result still
+                # sees ctx_size/parallel refreshed on a no-op start (issue #267).
+                existing_config = ConfigStore.get_model(model_name)
                 return StartResult(
                     success=True,
                     action="already_running",
@@ -82,6 +88,12 @@ def start(
                     model=model_name,
                     pid=existing.pid,
                     message=f"{model_name} already running on port {port}",
+                    ctx_size=(
+                        existing_config.ctx_size if existing_config is not None else None
+                    ),
+                    parallel=(
+                        existing_config.parallel if existing_config is not None else None
+                    ),
                 )
             # Different model — caller should use swap, not start.
             al.record(
@@ -278,6 +290,8 @@ def start(
             pid=popen.pid,
             message=f"{model_name} started on port {port}",
             cancel_ignored_post_commit=cancel_ignored,
+            ctx_size=config.ctx_size,
+            parallel=config.parallel,
         )
     finally:
         mk.release_marker(port)

--- a/llauncher/operations/swap.py
+++ b/llauncher/operations/swap.py
@@ -68,6 +68,8 @@ class SwapResult:
     message: str = ""
     startup_logs: list[str] = field(default_factory=list)
     cancel_ignored_post_commit: bool = False
+    ctx_size: int | None = None
+    parallel: int | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -296,6 +298,11 @@ def swap(
                 pid=previous_pid,
             )
         mk.release_marker(port)
+        # Idempotent short-circuit predates the config lookup used by the
+        # differing-model path below; fetch it here too so a consumer
+        # folding this result still sees ctx_size/parallel refreshed on a
+        # no-op swap (issue #267).
+        existing_config = ConfigStore.get_model(model_name)
         return SwapResult(
             success=True,
             action="already_running",
@@ -305,6 +312,12 @@ def swap(
             previous_model=previous_model_name,
             pid=previous_pid,
             message=f"{model_name} is already running on port {port}",
+            ctx_size=(
+                existing_config.ctx_size if existing_config is not None else None
+            ),
+            parallel=(
+                existing_config.parallel if existing_config is not None else None
+            ),
         )
 
     # 1c. New model must exist in config.
@@ -485,6 +498,8 @@ def swap(
                 ),
                 startup_logs=startup_logs,
                 cancel_ignored_post_commit=cancel_ignored,
+                ctx_size=new_config.ctx_size,
+                parallel=new_config.parallel,
             )
 
         # New model failed — record the failed start and fall through to rollback.

--- a/tests/unit/test_operations.py
+++ b/tests/unit/test_operations.py
@@ -86,6 +86,9 @@ def test_start_on_empty_port(
     assert result.port == 8081
     assert result.model == "mistral-7b"
     assert result.pid == 99999
+    # ctx_size/parallel folded in from the ConfigStore lookup (issue #267).
+    assert result.ctx_size == sample_config.ctx_size
+    assert result.parallel == sample_config.parallel
 
     # Lockfile written.
     written = lf.read_lockfile(8081, run_dir=run_dir)
@@ -118,6 +121,10 @@ def test_start_idempotent_when_same_model_running(
     assert result.action == "already_running"
     assert result.model == "mistral-7b"
     assert result.pid == os.getpid()
+    # ctx_size/parallel folded in even on the idempotent no-op path
+    # (issue #267): the short-circuit fetches config too.
+    assert result.ctx_size == sample_config.ctx_size
+    assert result.parallel == sample_config.parallel
     # Process should NOT be launched.
     start_proc.assert_not_called()
 
@@ -610,6 +617,8 @@ def test_start_result_to_dict_envelope() -> None:
         model="mistral-7b",
         pid=12345,
         message="ok",
+        ctx_size=32768,
+        parallel=2,
     )
     d = result.to_dict()
     assert d["success"] is True
@@ -618,6 +627,22 @@ def test_start_result_to_dict_envelope() -> None:
     assert d["model"] == "mistral-7b"
     assert d["pid"] == 12345
     assert d["message"] == "ok"
+    assert d["ctx_size"] == 32768
+    assert d["parallel"] == 2
+
+
+def test_start_result_to_dict_envelope_defaults_ctx_and_parallel_to_none() -> None:
+    """Non-success actions (e.g. rejections) don't carry config; both
+    fields default to ``None`` rather than requiring every call site to
+    pass them explicitly."""
+    result = ops.StartResult(
+        success=False,
+        action="rejected_occupied",
+        port=8081,
+    )
+    d = result.to_dict()
+    assert d["ctx_size"] is None
+    assert d["parallel"] is None
 
 
 def test_stop_result_to_dict_envelope() -> None:
@@ -719,9 +744,14 @@ def test_swap_same_model_short_circuits_already_running(
     import os
 
     lf.write_lockfile(8081, "mistral-7b", os.getpid(), run_dir=run_dir)
+    existing_config = _make_config("mistral-7b")
 
     with patch("llauncher.operations.proc.stop_server_by_port") as stop_proc, \
-         patch("llauncher.operations.proc.start_server") as start_proc:
+         patch("llauncher.operations.proc.start_server") as start_proc, \
+         patch(
+             "llauncher.operations.ConfigStore.get_model",
+             return_value=existing_config,
+         ):
         result = ops.swap("mistral-7b", 8081, caller="test")
 
     assert result.success is True
@@ -730,6 +760,10 @@ def test_swap_same_model_short_circuits_already_running(
     assert result.model == "mistral-7b"
     assert result.previous_model == "mistral-7b"
     assert result.pid == os.getpid()
+    # ctx_size/parallel folded in even on the idempotent no-op path
+    # (issue #267): the short-circuit fetches config too.
+    assert result.ctx_size == existing_config.ctx_size
+    assert result.parallel == existing_config.parallel
     # No teardown / relaunch on same-model swap.
     stop_proc.assert_not_called()
     start_proc.assert_not_called()
@@ -991,6 +1025,11 @@ def test_swap_full_success(
     assert result.model == "new-model"
     assert result.previous_model == "old"
     assert result.pid == 99999
+    # ctx_size/parallel folded in from the new model's ConfigStore lookup
+    # (issue #267).
+    new_config = _make_config("new-model")
+    assert result.ctx_size == new_config.ctx_size
+    assert result.parallel == new_config.parallel
 
     # Lockfile reflects the new claim.
     written = lf.read_lockfile(8081, run_dir=run_dir)
@@ -1191,6 +1230,8 @@ def test_swap_result_to_dict_envelope() -> None:
         pid=12345,
         message="ok",
         startup_logs=["a", "b"],
+        ctx_size=65536,
+        parallel=4,
     )
     d = result.to_dict()
     assert d["success"] is True
@@ -1201,6 +1242,22 @@ def test_swap_result_to_dict_envelope() -> None:
     assert d["previous_model"] == "old"
     assert d["pid"] == 12345
     assert d["startup_logs"] == ["a", "b"]
+    assert d["ctx_size"] == 65536
+    assert d["parallel"] == 4
+
+
+def test_swap_result_to_dict_envelope_defaults_ctx_and_parallel_to_none() -> None:
+    """Non-success actions (e.g. rejections/rollbacks) don't carry config;
+    both fields default to ``None``."""
+    result = ops.SwapResult(
+        success=False,
+        action="rejected_empty",
+        port_state="unchanged",
+        port=8081,
+    )
+    d = result.to_dict()
+    assert d["ctx_size"] is None
+    assert d["parallel"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `StartResult` (`llauncher/operations/start.py`) and `SwapResult` (`llauncher/operations/swap.py`) gain two new optional fields: `ctx_size: int | None = None` and `parallel: int | None = None`.
- Populated on the success actions (`started` / `swapped`) from the `ModelConfig` already fetched via `ConfigStore.get_model(...)` in scope — the same derivation `/footer-context` uses (`agent/footer_cache.py`). Not re-derived or hardcoded.
- **The wrinkle:** the `already_running` idempotent short-circuit branches (`start.py`'s "same model already running" check, `swap.py`'s Phase 1b same-model check) return *before* the existing config lookup, so those fields weren't in hand there. Each branch now does its own minimal `ConfigStore.get_model(model_name)` lookup (matching the existing pattern) so an idempotent no-op start/swap still carries refreshed `ctx_size`/`parallel` — required for a consumer folding these into a persistent view (e.g. a footer) to see current values even when nothing actually changed.
- Both fields default to `None` for non-success actions (rejections, rollbacks, etc.) that don't carry a resolved config.
- `mcp_server/` and `agent/routing.py` are untouched by design — both just forward `result.to_dict()` unchanged, so the new fields flow through automatically. Verified by inspection (no other reference to `StartResult`/`SwapResult` construction outside `operations/`).

## Test coverage

Added/extended in `tests/unit/test_operations.py`:
- `test_start_on_empty_port` — asserts `ctx_size`/`parallel` on the success path.
- `test_start_idempotent_when_same_model_running` — asserts `ctx_size`/`parallel` on the `already_running` path.
- `test_start_result_to_dict_envelope` — asserts the fields serialize through `to_dict()`.
- `test_start_result_to_dict_envelope_defaults_ctx_and_parallel_to_none` (new) — non-success actions default both fields to `None`.
- `test_swap_full_success` — asserts `ctx_size`/`parallel` on the success path.
- `test_swap_same_model_short_circuits_already_running` — now patches `ConfigStore.get_model` and asserts `ctx_size`/`parallel` on the `already_running` path.
- `test_swap_result_to_dict_envelope` — asserts the fields serialize through `to_dict()`.
- `test_swap_result_to_dict_envelope_defaults_ctx_and_parallel_to_none` (new) — non-success actions default both fields to `None`.

Full suite: `1358 passed, 11 skipped`, coverage 100% (floor 93%).

## Follow-up (not in this PR)

- Deploy is a follow-up the operator owns: Windows node service restart + `inference-host` pull.
- The paired second half is the harness-tools footer fold that consumes these new fields to stop making its own HTTP call to a node for context — tracked as harness-tools#133.

Closes #267. Enables harness-tools#133.