### PR TITLE
fix(cli): soft-wrap config path so a long path never breaks mid-atom (#256)

### DIFF
--- a/llauncher/cli.py
+++ b/llauncher/cli.py
@@ -494,7 +494,11 @@ def config_path() -> None:
     """Print the path to the llauncher configuration file."""
     from llauncher.core.config import CONFIG_PATH
 
-    console.print(f"[green]{CONFIG_PATH}[/green]")
+    # soft_wrap: a filesystem path is a single atom — never soft-wrap it. Rich's
+    # default width (80 cols, and no TTY under pytest) would otherwise insert a
+    # mid-path newline once the path exceeds the console width, corrupting the
+    # emitted value for both a narrow terminal and substring-checking callers (#256).
+    console.print(f"[green]{CONFIG_PATH}[/green]", soft_wrap=True)
 
 
 @config_app.command("validate")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import typer
+from rich.console import Console
 from typer.testing import CliRunner
 
 from llauncher import cli
@@ -560,6 +561,28 @@ def test_config_path_printed(mock_config_store):
         result = runner.invoke(app, ["config", "path"])
     assert result.exit_code == 0
     assert str(cfg_path) in result.stdout
+
+
+def test_config_path_not_wrapped_when_wider_than_console():
+    """Path output must not be soft-wrapped: a long path on a narrow console
+    must still emit as a single unbroken atom (#256).
+
+    Regression guard — with a forced 80-column, non-TTY console (Rich's default
+    under pytest) and a path longer than 80 chars, the pre-fix code inserted a
+    mid-path newline, so the full path was no longer a substring of stdout.
+    """
+    long_path = Path(
+        "/tmp/pytest-of-someuser/pytest-999999/"
+        "test_config_path_not_wrapped0/.llauncher/config.json"
+    )
+    assert len(str(long_path)) > 80  # must exceed the default console width to bite
+
+    with patch("llauncher.core.config.CONFIG_PATH", long_path), \
+            patch.object(cli, "console", Console(width=80)):
+        result = runner.invoke(app, ["config", "path"])
+
+    assert result.exit_code == 0
+    assert str(long_path) in result.stdout
 
 
 def test_config_validate_valid(mock_config_store):


### PR DESCRIPTION
Closes #256.

## Problem
`config path` printed the path via `console.print(f"[green]{CONFIG_PATH}[/green]")`.
Rich's `Console()` has no attached TTY under pytest (and no explicit width), so it
falls back to 80 columns and soft-wraps the line, inserting a hard newline mid-path
once the printed path exceeds 80 chars. The pytest tmp counter (`pytest-<N>`) grows
monotonically over the life of the machine, so `test_config_path_printed` flipped from
pass to fail once `N` widened the total path past 80 chars. This is also a real
user-facing defect: a narrow terminal shows the same broken, wrapped path.

## Fix
Print the path with `soft_wrap=True` so a filesystem path is emitted as a single
unbroken atom regardless of console width. The fix is at the source (production output
correctness), not a strip-the-newlines patch in the assertion.

## Test coverage
Adds `test_config_path_not_wrapped_when_wider_than_console`: forces an 80-column
console and a >80-char path, asserts the full path survives in stdout. Verified this
guard FAILS on the pre-fix code and PASSES with the fix. Width-independent (does not
depend on the real terminal / tmp-counter value).

## Gate
- Full suite: 1357 passed, 11 skipped, 0 failed (baseline F0=[] preserved).
- Coverage: 100% total; `llauncher/cli.py` 100%. Changed line covered.
- Surface: confined to `cli.py` (Endpoints layer) + its test — one Rich kwarg, no new
  imports, no layer edges touched. Pre-existing tracked violations (#170, #171) untouched.

Do not merge — draft for review per lane.