### PR TITLE
docs(readme): document volume-mountable state paths for Docker (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,31 @@ Example config entry:
 
 Per ADR-010, port is supplied at every call site (UI port picker, CLI `--port`, MCP `port` arg, HTTP `/start/{port}` route) and is **not** persisted in the config. Legacy `default_port` entries in `config.json` are silently dropped on load.
 
+### State Paths & Volume Mounts (Docker)
+
+Per ADR-008, the lockfile directory and audit log are env-configurable so a container can mount host state as a volume — letting an in-container agent (e.g. `pi-coding-agent`) introspect the state of llauncher running on the host.
+
+| Env var | Default | Holds |
+|---------|---------|-------|
+| `LAUNCHER_STATE_DIR` | `~/.llauncher` | Base for every derived path below |
+| `LAUNCHER_RUN_DIR` | `$LAUNCHER_STATE_DIR/run` | Per-server lockfiles (`{port}.lock`) and swap markers |
+| `LAUNCHER_AUDIT_PATH` | `$LAUNCHER_STATE_DIR/audit.jsonl` | Append-only JSON Lines audit log |
+
+Precedence for each path is the explicit per-path var (`LAUNCHER_RUN_DIR` / `LAUNCHER_AUDIT_PATH`) > the `LAUNCHER_STATE_DIR`-derived default. With every var unset the paths are byte-identical to the legacy `~/.llauncher/*` layout, so setting them is opt-in.
+
+To let a container read the host's live llauncher state, mount the host paths in read-only and point the in-container env vars at the mount:
+
+```bash
+docker run \
+  -v "$HOME/.llauncher/run:/host-llauncher/run:ro" \
+  -v "$HOME/.llauncher/audit.jsonl:/host-llauncher/audit.jsonl:ro" \
+  -e LAUNCHER_RUN_DIR=/host-llauncher/run \
+  -e LAUNCHER_AUDIT_PATH=/host-llauncher/audit.jsonl \
+  my-agent-image
+```
+
+Mount read-only (`:ro`) when the container only introspects; drop `:ro` if the containerized process is the one commanding llauncher and must write lockfiles/audit entries. The audit log is a single file, so bind-mount the file itself (not its parent dir) to avoid masking sibling state.
+
 ## Change Management
 
 llauncher includes validation rules to prevent problematic actions:


### PR DESCRIPTION
Closes #38.

## What was already done (no change needed)
The env-var plumbing for #38 was already present and tested on `main`:
- `LAUNCHER_RUN_DIR` (default `~/.llauncher/run`) and `LAUNCHER_AUDIT_PATH`
  (default `~/.llauncher/audit.jsonl`) live in `llauncher/core/settings.py`,
  derived from the `LAUNCHER_STATE_DIR` base (#196) with explicit-per-path
  precedence.
- All lockfile + audit-log I/O routes through them: `core/lockfile.py`,
  `core/marker.py` (run dir) and `core/audit_log.py` (audit path).
- Env-override + precedence behavior is covered by
  `tests/unit/test_state_dir.py` (defaults, `LAUNCHER_STATE_DIR` redirect,
  per-path override-wins for RUN_DIR/AUDIT_PATH/LOG_DIR, no-fs-touch-at-import).

## What this PR adds
The one unmet scope item: the **README docker-volume setup example**
(scope bullet 4). New `### State Paths & Volume Mounts (Docker)` subsection
under `## Configuration`:
- env-var table (base + per-path overrides) with defaults and precedence,
- a `docker run -v ... -e LAUNCHER_RUN_DIR/LAUNCHER_AUDIT_PATH` example for an
  in-container agent introspecting host llauncher state,
- read-only vs. read-write and single-file-bind-mount guidance.

Grounded strictly in ADR-008 §"Volume-Mountable Paths" and the existing
settings schema — no new config schema is introduced.

## Scope / boundaries
Docs-only. No code paths change; does not touch the ARCHITECTURE.md layer
edges, so it cannot affect the pre-existing tracked violations #170/#171.

## Gate
- `pytest` (repo `.venv`): 1356 passed, 11 skipped, 0 failed
  (baseline `origin/main` @ 8dcb047: 1355 passed, 12 skipped, 0 failed —
  the 1-test skip/pass delta is ambient host-config-dependent integration
  noise in `test_swap`/`test_self_swap`, not from this change).
- Coverage: 100% (floor 93%).
- Changed paths: `README.md` only.
