### PR TITLE
fix(remote): scope per-entry validation failure in NodeRegistry._load

### DIFF
--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -52,38 +52,49 @@ class NodeRegistry:
         try:
             data = json.loads(NODES_FILE.read_text())
             for name, node_data in data.items():
-                # Backward compat: old files use "api_key", new files use "has_api_key"
-                raw_key = node_data.get("api_key")
-                host = node_data["host"]
-                port = node_data.get("port", 8765)
-                if isinstance(host, str) and host.count(":") == 1:
-                    # Issue #27: a prior UI bug let an embedded port slip
-                    # into the host field (e.g. "192.168.137.2:8765") on
-                    # top of a separate port field, producing a malformed
-                    # base_url. Migrate once, at the door (PARSE-AT-THE-DOOR):
-                    # split the embedded port out and prefer it as the
-                    # real port, then persist the corrected shape below.
-                    fixed_host, _, port_str = host.rpartition(":")
-                    if port_str.isdigit():
-                        port = int(port_str)
-                    logger.warning(
-                        f"Migrated corrupted host for node '{name}': "
-                        f"{host!r} -> host={fixed_host!r}, port={port}"
+                try:
+                    # Backward compat: old files use "api_key", new files use "has_api_key"
+                    raw_key = node_data.get("api_key")
+                    host = node_data["host"]
+                    port = node_data.get("port", 8765)
+                    if isinstance(host, str) and host.count(":") == 1:
+                        # Issue #27: a prior UI bug let an embedded port slip
+                        # into the host field (e.g. "192.168.137.2:8765") on
+                        # top of a separate port field, producing a malformed
+                        # base_url. Migrate once, at the door (PARSE-AT-THE-DOOR):
+                        # split the embedded port out and prefer it as the
+                        # real port, then persist the corrected shape below.
+                        fixed_host, _, port_str = host.rpartition(":")
+                        if port_str.isdigit():
+                            port = int(port_str)
+                        logger.warning(
+                            f"Migrated corrupted host for node '{name}': "
+                            f"{host!r} -> host={fixed_host!r}, port={port}"
+                        )
+                        host = fixed_host
+                        migrated = True
+                    self._nodes[name] = RemoteNode(
+                        name=node_data["name"],
+                        host=host,
+                        port=port,
+                        timeout=node_data.get("timeout", 5.0),
+                        api_key=raw_key,
                     )
-                    host = fixed_host
-                    migrated = True
-                self._nodes[name] = RemoteNode(
-                    name=node_data["name"],
-                    host=host,
-                    port=port,
-                    timeout=node_data.get("timeout", 5.0),
-                    api_key=raw_key,
-                )
+                except (KeyError, ValueError) as e:
+                    # Issue #273: a single entry that fails NodeConfig
+                    # validation (or is missing a required key) after the
+                    # embedded-port migration above must not take the
+                    # whole pass down with it. Scope the failure to this
+                    # entry — log and drop only ``name``, keep the rest.
+                    logger.warning(
+                        f"Skipping node '{name}' in {NODES_FILE}: {e}"
+                    )
+                    continue
         except (json.JSONDecodeError, KeyError, ValueError):
-            # Corrupted file (bad JSON/shape), or an entry that still
-            # fails NodeConfig validation after the embedded-port
-            # migration above (issue #27) — start fresh rather than
-            # crash UI startup.
+            # Whole-file corruption (bad JSON, or a non-dict top-level
+            # shape whose per-entry iteration itself raises before the
+            # inner try can scope it) — start fresh rather than crash UI
+            # startup.
             self._nodes.clear()
             migrated = False
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -785,6 +785,65 @@ class TestNodeRegistry:
 
         assert registry.get_node("bad-node") is None
 
+    def test_load_skips_invalid_entry_keeps_valid_siblings(self, temp_nodes_file, caplog):
+        """Issue #273: NodeRegistry._load() used to fold a single bad
+        entry's ``ValueError`` into the whole-file-corruption ``except``,
+        silently discarding every other valid node in the pass. A
+        multi-node file with one invalid entry (out-of-range port) must
+        drop only that entry — all valid nodes survive — and a WARN
+        naming the offending node is logged."""
+        temp_nodes_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_nodes_file.write_text(
+            json.dumps(
+                {
+                    "good-node": {
+                        "name": "good-node",
+                        "host": "192.168.1.50",
+                        "port": 8765,
+                    },
+                    "bad-node": {
+                        "name": "bad-node",
+                        "host": "192.168.1.100",
+                        # Out-of-range port (NodeConfig requires 1024-65535).
+                        "port": 80,
+                    },
+                    "another-good-node": {
+                        "name": "another-good-node",
+                        "host": "192.168.1.51",
+                        "port": 9000,
+                    },
+                }
+            )
+        )
+
+        with caplog.at_level("WARNING", logger="llauncher.remote.registry"):
+            registry = NodeRegistry()
+
+        assert registry.get_node("bad-node") is None
+        good = registry.get_node("good-node")
+        assert good is not None
+        assert good.host == "192.168.1.50"
+        another_good = registry.get_node("another-good-node")
+        assert another_good is not None
+        assert another_good.host == "192.168.1.51"
+
+        assert any(
+            "bad-node" in record.message for record in caplog.records
+        ), "expected a WARN naming the dropped 'bad-node' entry"
+
+    def test_load_whole_file_corruption_starts_fresh(self, temp_nodes_file):
+        """Whole-file corruption (malformed JSON) is a distinct concern
+        from a single bad entry (issue #273): it still falls back to
+        starting fresh with an empty registry, rather than crashing UI
+        startup or being conflated with the now per-entry-scoped
+        validation failure path."""
+        temp_nodes_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_nodes_file.write_text("{not valid json")
+
+        registry = NodeRegistry()
+
+        assert len(registry) == 0
+
     def test_refresh_all(self, temp_nodes_file):
         """Test refreshing all nodes."""
         registry = NodeRegistry()


### PR DESCRIPTION
## Defect

`NodeRegistry._load()` (`llauncher/remote/registry.py`) wrapped the entire per-node loop in one `try`. PR #266 folded the new single-entry `ValueError` (raised by `NodeConfig`/`RemoteNode` validation on one bad node) into the same `except` that catches whole-file corruption (`JSONDecodeError`/`KeyError`) — and that branch logs nothing and clears the whole registry. Effect: **one invalid entry in `nodes.json` silently discarded every other valid node** in the pass.

## Fix

Scope the per-entry failure to the per-entry construction:

- The `RemoteNode(...)` build for a single node is now wrapped in its own `try`/`except (KeyError, ValueError)`.
- On failure, log a WARN naming the offending node and its file, then `continue` — only that entry is dropped, all others survive.
- Whole-file corruption (`JSONDecodeError` / structural `KeyError`) remains the separate outer concern it was — same clear-and-start-fresh behavior, unchanged.

## Tests

- `test_load_skips_invalid_entry_keeps_valid_siblings` (new): a `nodes.json` with one valid node, one invalid node (out-of-range port), and a second valid node — asserts the invalid entry is dropped, both valid nodes survive, and a WARN naming `bad-node` is logged (via `caplog`).
- `test_load_whole_file_corruption_starts_fresh` (new): malformed JSON still falls back to an empty registry — keeps that branch covered now that the previously-existing `test_load_unrecoverable_entry_starts_fresh` (single-node file, unchanged, still passing) no longer exercises it via the per-entry path.

## Gate

Full suite (`.venv`, `pip install -e ".[test,ui]"` already satisfied — streamlit present, no UI collection errors):

```
1429 passed, 12 skipped, 61 warnings in ~32s
llauncher/remote/registry.py: 100% (was 98% pre-fix-test-rebalance)
TOTAL coverage: 100.00% (floor 93%)
```

## Note

This is the deploy-hold clearance for the #266 batch — closes the silent-data-loss gap that batch introduced.

Closes #273