### PR TITLE
fix(deploy): migrate pre-#139 LAUNCHER_AGENT_* env keys at the door, fail loud on missing token

### DIFF
--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -29,6 +29,30 @@ Re-running the installer is safe: env files are preserved, unit/service
 config is refreshed. This is the right way to pick up a `git pull` that
 touches the unit template.
 
+### Migrating from pre-#139 installs
+
+Commit `9f098d9` (#138/#139) renamed the agent's env vars from
+`LAUNCHER_AGENT_*` to `LLAUNCHER_AGENT_*` (double-L). If your env file
+(`~/.config/llauncher/agent.env` on Linux,
+`%USERPROFILE%\.llauncher\agent.env` on Windows) predates that rename,
+it still carries the old single-L keys. Both installers now detect and
+migrate these keys **in place, automatically, on re-run**: matching
+`LAUNCHER_AGENT_*` lines are rewritten to `LLAUNCHER_AGENT_*` with
+values preserved byte-for-byte, and the installer reports which keys it
+migrated. If no usable `LLAUNCHER_AGENT_TOKEN` line remains after
+migration, the installer refuses to proceed (exits non-zero) rather than
+installing a service with a broken token — see
+[#281](https://github.com/shanevcantwell/llauncher/issues/281). Simply
+re-running `install.sh` / `install.ps1` is enough to migrate an existing
+deployment; no manual edit is required unless the installer tells you
+one is missing.
+
+As defense in depth, the agent itself also refuses to start (exit code
+2) if it finds a legacy `LAUNCHER_AGENT_TOKEN` in its environment with
+no `LLAUNCHER_AGENT_TOKEN` — that combination only ever means a stale
+pre-#139 environment, and starting anyway would silently mint a token
+the operator never configured (see the troubleshooting entry below).
+
 ## Security note up front
 
 The agent's only auth layer is the `X-Api-Key` token in
@@ -260,6 +284,37 @@ curl -sS -H "X-Api-Key: $LLAUNCHER_AGENT_TOKEN" \
 A 200 on `/status` confirms the service is up, the token matches, and the
 bind interface is reachable. A 401/403 there means the token is missing or
 wrong (`/health` would still return 200 — it skips auth).
+
+## Troubleshooting
+
+### 403 on `/node-info` or `/start` while `/health` returns 200
+
+This is a token mismatch, not a reachability problem — `/health` skips
+auth entirely, so its 200 only proves the process is up and reachable.
+The distinction between 401 and 403 tells you what the client sent:
+
+- **401** = the client sent no `X-Api-Key` header at all.
+- **403** = the client sent a header, but the value doesn't match the
+  agent's token.
+
+A 403 with a working `/health` almost always means the UI/client and the
+agent resolved to *different* tokens. Check, in order:
+
+1. **Legacy env keys.** Open the agent's env file
+   (`~/.config/llauncher/agent.env` on Linux,
+   `%USERPROFILE%\.llauncher\agent.env` on Windows) and look for
+   pre-#139 `LAUNCHER_AGENT_*` (single-L) key names instead of
+   `LLAUNCHER_AGENT_*`. Re-run the installer to migrate them
+   automatically (see "Migrating from pre-#139 installs" above).
+2. **A self-generated token under the wrong profile.** When the agent
+   can't resolve a token from the environment, it auto-generates one at
+   `~/.llauncher/agent.token` under `Path.home()` **of the account the
+   agent process runs as** — for a Windows service that's the service
+   account, not the interactively logged-in operator. If the service is
+   silently minting its own token under a profile you never look at,
+   the UI's configured token will never match it. Confirm the service's
+   token source (env var vs. auto-generated file) and which account's
+   home directory it actually wrote to.
 
 ## Token rotation
 

--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -25,8 +25,10 @@ from __future__ import annotations
 import sys  # noqa: F401  (re-exported for legacy ``auth_mod.sys`` patch sites)
 
 from llauncher.core.agent_token import (  # noqa: F401
+    LEGACY_ENV_VAR,
     _read_token_file,  # imported directly by tests/unit/test_agent_auth_token_file.py
     default_token_path,
+    legacy_token_env_misconfigured,
     resolve_agent_token,
 )
 

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -25,7 +25,11 @@ from fastapi import FastAPI
 
 from llauncher import __version__
 from llauncher import operations as ops
-from llauncher.agent.auth import is_loopback, resolve_agent_token
+from llauncher.agent.auth import (
+    is_loopback,
+    legacy_token_env_misconfigured,
+    resolve_agent_token,
+)
 from llauncher.agent.config import AgentConfig
 from llauncher.agent.middleware import (
     AuthenticationMiddleware,
@@ -339,15 +343,39 @@ def run_agent(config: AgentConfig) -> None:
     ``~/.llauncher/agent.token`` on the first loopback start with no
     env-provided token.
 
+    Also enforces a pre-#139 legacy-env guard (#281, defense in depth
+    for deployments that bypass the installers' own migration): refuses
+    to start when the pre-rename ``LAUNCHER_AGENT_TOKEN`` is set but the
+    current ``LLAUNCHER_AGENT_TOKEN`` is not, since that combination only
+    ever means a stale env file whose token nothing reads any more — the
+    agent would otherwise silently fall through to the token-file /
+    auto-generate path and mint a token the operator never configured.
+
     Args:
         config: Agent configuration.
 
     Raises:
         SystemExit: With code 2 when binding non-loopback without an
-            available authentication token. The error message names
-            both remediation paths (set ``LLAUNCHER_AGENT_TOKEN`` or
-            bind loopback).
+            available authentication token, or when a pre-#139 legacy
+            env var is the only token source present. The error message
+            names the remediation paths.
     """
+    if legacy_token_env_misconfigured():
+        sys.stderr.write(
+            "[llauncher-agent] ERROR: found legacy LAUNCHER_AGENT_TOKEN in "
+            "the environment but no LLAUNCHER_AGENT_TOKEN.\n"
+            "[llauncher-agent] Commit 9f098d9 (#138/#139) renamed "
+            "LAUNCHER_AGENT_* env vars to LLAUNCHER_AGENT_* (double-L); "
+            "nothing reads the old name any more, and starting anyway "
+            "would silently auto-generate a different token than the one "
+            "you configured (#281).\n"
+            "[llauncher-agent] Remediation: rename LAUNCHER_AGENT_* keys "
+            "to LLAUNCHER_AGENT_* in your env file, or re-run the "
+            "installer (install.ps1 / install.sh) to migrate them "
+            "automatically.\n"
+        )
+        raise SystemExit(2)
+
     env_token = os.environ.get("LLAUNCHER_AGENT_TOKEN")
     loopback = is_loopback(config.host)
 

--- a/llauncher/core/agent_token.py
+++ b/llauncher/core/agent_token.py
@@ -39,7 +39,36 @@ import os
 import secrets
 import stat
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+
+#: Pre-rename token env var name (single-L ``LAUNCHER``), retired by the
+#: #138/#139 rename (commit 9f098d9). Nothing reads it any more; its
+#: presence is only ever a marker of a pre-rename deployment (#281).
+LEGACY_ENV_VAR = "LAUNCHER_AGENT_TOKEN"
+
+
+def legacy_token_env_misconfigured(environ: Mapping[str, str] | None = None) -> bool:
+    """Return True when only the pre-rename token env var carries a value.
+
+    Commit 9f098d9 (#138/#139) renamed ``LAUNCHER_AGENT_TOKEN`` →
+    ``LLAUNCHER_AGENT_TOKEN``, but live deployments (env files written
+    from the pre-rename template, service configs that re-inject them)
+    can still export the legacy single-L name. Since nothing reads it,
+    the agent would fall through to the token-file/auto-generate path
+    and silently mint a *different* token than the one the operator
+    configured — the UI-403 split-brain of issue #281.
+
+    True iff ``LAUNCHER_AGENT_TOKEN`` is set non-empty AND
+    ``LLAUNCHER_AGENT_TOKEN`` is absent or empty (empty counts as
+    absent). That combination only ever means a pre-#139 deployment,
+    so callers should fail loud rather than proceed.
+    """
+    if environ is None:
+        environ = os.environ
+    return bool(environ.get(LEGACY_ENV_VAR)) and not environ.get(
+        "LLAUNCHER_AGENT_TOKEN"
+    )
 
 
 def default_token_path() -> Path:

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -11,7 +11,9 @@
 #
 # Idempotent: safe to re-run after a `git pull` to pick up unit-file
 # changes. Will NOT overwrite an existing env file (so your token and
-# host config survive reinstalls).
+# host config survive reinstalls), but pre-#139 legacy LAUNCHER_AGENT_*
+# key names ARE migrated in place to LLAUNCHER_AGENT_* (values
+# preserved; issue #281).
 #
 # Usage:
 #   ./scripts/systemd/install.sh                    # user: install+enable+start
@@ -177,6 +179,25 @@ else
     chmod "$FILE_MODE" "$ENV_FILE"  # repair perms if they drifted
     [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$ENV_FILE"
     say "Env file already exists at $ENV_FILE — leaving it untouched."
+
+    # --- Migrate pre-#139 legacy keys (issue #281) ----------------------
+    # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* → LLAUNCHER_AGENT_*,
+    # but env files written from the pre-rename template still carry the
+    # single-L keys — which nothing reads any more, so the agent silently
+    # auto-generates its own token and the UI 403s on every authed endpoint.
+    # PARSE-AT-THE-DOOR: rewrite the key prefix in place, once,
+    # deterministically, preserving each value byte-for-byte. Comment lines
+    # start with '#' and never match the key-anchored pattern. Line order is
+    # preserved, so systemd's last-wins EnvironmentFile semantics (and the
+    # `tail -n1` mirror below) are unaffected.
+    legacy_keys="$(grep -E '^[[:space:]]*LAUNCHER_AGENT_' "$ENV_FILE" \
+        | sed -E 's/^[[:space:]]*(LAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
+        | sort -u || true)"
+    if [ -n "$legacy_keys" ]; then
+        sed -i -E 's/^([[:space:]]*)LAUNCHER_AGENT_/\1LLAUNCHER_AGENT_/' "$ENV_FILE"
+        renames="$(echo "$legacy_keys" | sed 's/^\(.*\)$/\1 -> L\1/' | paste -sd ', ' -)"
+        say "Migrated pre-#139 legacy keys in $ENV_FILE: $renames"
+    fi
 fi
 
 # --- Token mirror (issue #131) -----------------------------------------
@@ -198,9 +219,11 @@ if [ "$MODE" != "system" ]; then
 fi
 # `|| true` keeps a grep miss (no matching line) from tripping `set -e`
 # via the failing command-substitution — an empty TOKEN_VALUE then routes
-# to the informative else-branch below instead of a silent exit 1. This
-# is the failure mode when a pre-rename env file still uses the old
-# single-L (LAUNCHER, not LLAUNCHER) token key (see #138/#139).
+# to the fail-loud else-branch below instead of a silent exit 1. Legacy
+# single-L (LAUNCHER, not LLAUNCHER; #138/#139) key names have already
+# been migrated in place above, so reaching the else-branch here means
+# the env file genuinely has no usable token — never a shape we
+# trust-and-degrade on (issue #281).
 TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]' || true)"
 if [ -n "$TOKEN_VALUE" ]; then
     # printf '%s' (no trailing newline) matches the byte-shape of
@@ -210,7 +233,14 @@ if [ -n "$TOKEN_VALUE" ]; then
     [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$TOKEN_FILE"
     say "Mirrored token to $TOKEN_FILE (mode $FILE_MODE) so the UI can authenticate."
 else
-    info "No LLAUNCHER_AGENT_TOKEN line found in $ENV_FILE; skipping token file mirror."
+    err "No usable LLAUNCHER_AGENT_TOKEN line found in $ENV_FILE (missing or empty value)."
+    err "Refusing to install the service without a mirrored, non-empty token — the agent"
+    err "would silently auto-generate its own token and the UI could never authenticate."
+    err "Fix one of:"
+    err "  - Add a line to $ENV_FILE:  LLAUNCHER_AGENT_TOKEN=<token>"
+    err "    (generate one:  python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+    err "  - Or delete $ENV_FILE and re-run this installer to regenerate it from the template."
+    exit 1
 fi
 
 # --- Unit file ---------------------------------------------------------

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -8,7 +8,9 @@
 #   - This script must run elevated (right-click "Run as Administrator").
 #
 # Idempotent: re-running picks up env-file edits and a new venv path.
-# Will NOT overwrite an existing env file (your token survives).
+# Will NOT overwrite an existing env file (your token survives), but pre-#139
+# legacy LAUNCHER_AGENT_* key names ARE migrated in place to LLAUNCHER_AGENT_*
+# (values preserved; issue #281).
 #
 # Usage:
 #   .\scripts\windows\install.ps1
@@ -91,6 +93,34 @@ if (-not (Test-Path $EnvFile)) {
     Info "Edit it to set LLAUNCHER_AGENT_NODE_NAME / HOST / PORT as needed."
 } else {
     Say "Env file already exists at $EnvFile - leaving it untouched."
+
+    # --- Migrate pre-#139 legacy keys (issue #281) --------------------
+    # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* to
+    # LLAUNCHER_AGENT_*, but env files written from the pre-rename
+    # template still carry the single-L keys — which nothing reads any
+    # more, so the agent silently auto-generates its own token under the
+    # SERVICE account's profile and the UI 403s on every authed endpoint.
+    # PARSE-AT-THE-DOOR: rewrite the key prefix in place, once,
+    # deterministically, preserving each value byte-for-byte. Comment
+    # lines start with '#' and never match the key-anchored pattern.
+    $lines = @(Get-Content $EnvFile)
+    $migratedKeys = @()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^\s*LAUNCHER_AGENT_') {
+            $oldKey = ($lines[$i] -split '=', 2)[0].Trim()
+            $lines[$i] = $lines[$i] -replace '^(\s*)LAUNCHER_AGENT_', '${1}LLAUNCHER_AGENT_'
+            $newKey = ($lines[$i] -split '=', 2)[0].Trim()
+            $migratedKeys += "$oldKey -> $newKey"
+        }
+    }
+    if ($migratedKeys.Count -gt 0) {
+        # IMPORTANT: write WITHOUT a UTF-8 BOM — same reasoning as the
+        # token-mirror write below (PS 5.1 `Set-Content -Encoding utf8`
+        # prepends EF BB BF, which would corrupt the first key name).
+        [System.IO.File]::WriteAllLines(
+            $EnvFile, $lines, (New-Object System.Text.UTF8Encoding($false)))
+        Say ("Migrated pre-#139 legacy keys in ${EnvFile}: " + ($migratedKeys -join ', '))
+    }
 }
 
 # Lock the env file: remove inheritance, grant current user only.
@@ -118,8 +148,8 @@ Say "Locked ACL on $EnvFile (current user only)."
 # but the auth source still needs to be discoverable for other reads
 # /writes and for the remote-node case.
 $tokenLine = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -First 1
-if ($tokenLine) {
-    $tokenValue = ($tokenLine -replace '^LLAUNCHER_AGENT_TOKEN=', '').Trim()
+$tokenValue = if ($tokenLine) { ($tokenLine -replace '^LLAUNCHER_AGENT_TOKEN=', '').Trim() } else { '' }
+if ($tokenValue) {
     # IMPORTANT: write WITHOUT a UTF-8 BOM. Windows PowerShell 5.1's
     # `Set-Content -Encoding utf8` prepends EF BB BF, which decodes to
     # U+FEFF and (since str.strip() doesn't strip it) leaks into the
@@ -135,7 +165,17 @@ if ($tokenLine) {
     Set-OwnerOnlyAcl $TokenFile
     Say "Mirrored token to $TokenFile (ACL: current user only) so the UI can authenticate."
 } else {
-    Info "No LLAUNCHER_AGENT_TOKEN line found in ${EnvFile}; skipping token file mirror."
+    # Fail loud, never trust-and-degrade (issue #281): without a mirrored,
+    # non-empty token the service comes up "green" but the agent silently
+    # auto-generates its own token under the SERVICE account's profile,
+    # and the UI gets 403 on every authed endpoint.
+    Die @"
+No usable LLAUNCHER_AGENT_TOKEN line found in ${EnvFile} (missing or empty value).
+Refusing to install the service without a mirrored, non-empty token. Fix one of:
+  - Add a line to ${EnvFile}:  LLAUNCHER_AGENT_TOKEN=<token>
+    (generate one:  python -c "import secrets; print(secrets.token_urlsafe(32))")
+  - Or delete ${EnvFile} and re-run this script to regenerate it from the template.
+"@
 }
 
 # --- Parse env file into NSSM AppEnvironmentExtra format --------------

--- a/tests/integration/test_agent_security_c1_c2.py
+++ b/tests/integration/test_agent_security_c1_c2.py
@@ -100,6 +100,43 @@ def test_run_agent_refuses_non_loopback_without_token(monkeypatch, tmp_path):
     assert "127.0.0.1" in err or "loopback" in err
 
 
+# ─────── #281: refuse to start on pre-#139 legacy-only env ─────────────────
+
+
+def test_run_agent_refuses_legacy_only_token_env(monkeypatch, tmp_path):
+    """#281: agent exits non-zero (code 2) when only the pre-#139
+    single-L ``LAUNCHER_AGENT_TOKEN`` is set and ``LLAUNCHER_AGENT_TOKEN``
+    is absent — even on an otherwise-healthy loopback bind. This is
+    defense in depth for deployments that bypass the installers' own
+    migration (scripts/windows/install.ps1, scripts/systemd/install.sh)."""
+    from llauncher.agent.config import AgentConfig
+    from llauncher.agent import server as agent_srv
+
+    monkeypatch.setenv("LAUNCHER_AGENT_TOKEN", "stale-pre-rename-token")
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+    # uvicorn.run must never be reached.
+    called = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **kw: called.append((a, kw)))
+
+    buf = io.StringIO()
+    monkeypatch.setattr("sys.stderr", buf)
+
+    # Loopback bind — proves the guard fires independent of the C1-d
+    # non-loopback check, which this legacy-env guard runs ahead of.
+    cfg = AgentConfig(host="127.0.0.1", port=8765)
+
+    with pytest.raises(SystemExit) as excinfo:
+        agent_srv.run_agent(cfg)
+
+    assert excinfo.value.code == 2
+    assert not called
+    err = buf.getvalue()
+    assert "LAUNCHER_AGENT_TOKEN" in err
+    assert "LLAUNCHER_AGENT_TOKEN" in err
+    assert "138" in err or "139" in err
+
+
 # ─────── C1-e: auto-generate token file on first loopback start ────────────
 
 

--- a/tests/unit/test_agent_token_legacy_env.py
+++ b/tests/unit/test_agent_token_legacy_env.py
@@ -1,0 +1,68 @@
+"""Unit tests for ``llauncher.core.agent_token.legacy_token_env_misconfigured``.
+
+Covers the pre-#139 legacy-env detection (issue #281): commit 9f098d9
+(#138/#139) renamed ``LAUNCHER_AGENT_TOKEN`` -> ``LLAUNCHER_AGENT_TOKEN``,
+but live env files written from the pre-rename template can still carry
+the single-L key. The function is a pure predicate over an explicit
+environ mapping (defaulting to ``os.environ``) so callers (and tests)
+never need to touch real process environment state.
+"""
+
+from __future__ import annotations
+
+from llauncher.core.agent_token import (
+    LEGACY_ENV_VAR,
+    legacy_token_env_misconfigured,
+)
+
+
+def test_legacy_absent_new_absent_is_not_misconfigured() -> None:
+    """Neither var set: nothing to detect, not misconfigured."""
+    assert legacy_token_env_misconfigured({}) is False
+
+
+def test_legacy_absent_new_present_is_not_misconfigured() -> None:
+    """Only the current key is set: the normal, healthy case."""
+    environ = {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+    assert legacy_token_env_misconfigured(environ) is False
+
+
+def test_legacy_present_new_absent_is_misconfigured() -> None:
+    """Only the legacy key is set: the #281 pre-#139 split-brain shape."""
+    environ = {LEGACY_ENV_VAR: "abc123"}
+    assert legacy_token_env_misconfigured(environ) is True
+
+
+def test_legacy_present_new_present_is_not_misconfigured() -> None:
+    """Both set: the current key wins downstream, so not misconfigured.
+
+    (A stray legacy key alongside a valid current key is harmless — only
+    the current key is ever read for auth — so this is not flagged.)
+    """
+    environ = {LEGACY_ENV_VAR: "abc123", "LLAUNCHER_AGENT_TOKEN": "def456"}
+    assert legacy_token_env_misconfigured(environ) is False
+
+
+def test_empty_string_new_value_counts_as_absent() -> None:
+    """An empty LLAUNCHER_AGENT_TOKEN does not satisfy the 'present' check."""
+    environ = {LEGACY_ENV_VAR: "abc123", "LLAUNCHER_AGENT_TOKEN": ""}
+    assert legacy_token_env_misconfigured(environ) is True
+
+
+def test_empty_string_legacy_value_counts_as_absent() -> None:
+    """An empty legacy key is not a signal of a pre-#139 deployment."""
+    environ = {LEGACY_ENV_VAR: ""}
+    assert legacy_token_env_misconfigured(environ) is False
+
+
+def test_both_empty_is_not_misconfigured() -> None:
+    """Both present but empty: no usable signal either way."""
+    environ = {LEGACY_ENV_VAR: "", "LLAUNCHER_AGENT_TOKEN": ""}
+    assert legacy_token_env_misconfigured(environ) is False
+
+
+def test_defaults_to_os_environ(monkeypatch) -> None:
+    """No explicit environ argument reads the real process environment."""
+    monkeypatch.setenv(LEGACY_ENV_VAR, "abc123")
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+    assert legacy_token_env_misconfigured() is True

--- a/tests/unit/test_env_var_naming_regression.py
+++ b/tests/unit/test_env_var_naming_regression.py
@@ -40,6 +40,17 @@ The allowlist is the set of paths where matches are *expected*:
       message includes the legacy token by construction (the
       split-string trick covers the search pattern but the message
       formatting may still emit the literal).
+    - ``scripts/windows/install.ps1``, ``scripts/systemd/install.sh``,
+      ``llauncher/core/agent_token.py``, ``llauncher/agent/server.py``,
+      ``tests/integration/test_agent_security_c1_c2.py``, and
+      ``docs/operations/run-as-a-service.md`` are allowlisted for issue
+      #281: the pre-#139 legacy-key *migration and detection* logic
+      necessarily names the old key to recognize and rewrite/refuse it.
+      This is the opposite failure mode from the one this guard exists
+      to catch — #138 was the typo silently *reappearing as the active
+      read path*; #281's references are inert string literals used only
+      to detect and migrate away from that old shape at the door
+      (PARSE-AT-THE-DOOR), never a fallback read.
 """
 
 from __future__ import annotations
@@ -231,6 +242,14 @@ ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     "docs/v2-handoff.md",
     "CHANGELOG.md",
     "tests/unit/test_env_var_naming_regression.py",
+    # #281: pre-#139 legacy-key migration (installers) and detection
+    # (agent-side fail-loud guard) — see module docstring rationale.
+    "scripts/windows/install.ps1",
+    "scripts/systemd/install.sh",
+    "llauncher/core/agent_token.py",
+    "llauncher/agent/server.py",
+    "tests/integration/test_agent_security_c1_c2.py",
+    "docs/operations/run-as-a-service.md",
 )
 
 

--- a/tests/unit/test_env_var_naming_regression.py
+++ b/tests/unit/test_env_var_naming_regression.py
@@ -42,7 +42,8 @@ The allowlist is the set of paths where matches are *expected*:
       formatting may still emit the literal).
     - ``scripts/windows/install.ps1``, ``scripts/systemd/install.sh``,
       ``llauncher/core/agent_token.py``, ``llauncher/agent/server.py``,
-      ``tests/integration/test_agent_security_c1_c2.py``, and
+      ``tests/integration/test_agent_security_c1_c2.py``,
+      ``tests/unit/test_agent_token_legacy_env.py``, and
       ``docs/operations/run-as-a-service.md`` are allowlisted for issue
       #281: the pre-#139 legacy-key *migration and detection* logic
       necessarily names the old key to recognize and rewrite/refuse it.
@@ -249,6 +250,7 @@ ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     "llauncher/core/agent_token.py",
     "llauncher/agent/server.py",
     "tests/integration/test_agent_security_c1_c2.py",
+    "tests/unit/test_agent_token_legacy_env.py",
     "docs/operations/run-as-a-service.md",
 )
 


### PR DESCRIPTION
Closes #281.

## Root cause

#139 renamed `LAUNCHER_AGENT_*` → `LLAUNCHER_AGENT_*` but never taught the deployment door to recognize the legacy shape. `install.ps1` preserves existing env files by design, greps only the new name, and **Info-skips** the token mirror when it finds nothing — exiting green with a service whose UI gets 403 on every authed endpoint (agent silently auto-generates its own token under the service account's profile; UI sends a different one). Field-confirmed on the operator's Windows box 2026-07-10. `install.sh` had the identical trust-and-degrade branch. `PARSE-AT-THE-DOOR` violation per repo CLAUDE.md.

## Changes (4 parts)

1. **`scripts/windows/install.ps1`** — migrates `^LAUNCHER_AGENT_*` key lines in place (values byte-preserved, no-BOM UTF-8 rewrite), reports which keys were migrated; the token-mirror branch now `Die`s on a missing/empty `LLAUNCHER_AGENT_TOKEN` with both remediations named. Never exits green without a mirrored, non-empty token.
2. **`scripts/systemd/install.sh`** — symmetric sed-based migration preserving the `tail -n1` last-wins semantics; `err` + `exit 1` replaces the info-skip.
3. **Agent-side guard (defense in depth)** — `core/agent_token.py` gains `LEGACY_ENV_VAR` + pure predicate `legacy_token_env_misconfigured()`; `run_agent` refuses to start (`SystemExit(2)`, stderr message naming #138/#139 and the remediation) when the legacy var is set and the new one absent. Re-exported via `agent/auth.py` per that module's contract.
4. **`docs/operations/run-as-a-service.md`** — "Migrating from pre-#139 installs" note + troubleshooting entry (401-vs-403 semantics, legacy-key check, service-account auto-generated-token trap).

## Gates (readback from the implementation run)

- `pytest`: **1457 passed, 12 skipped** — full green
- Coverage: **100.00%** (`--cov-fail-under=93` via pytest.ini)
- New tests: 8 unit tests for the predicate (all set/absent × empty combinations), integration test for the `run_agent` refusal (matches existing C1 patterns)

## Reviewer attention

`tests/unit/test_env_var_naming_regression.py` (the #138 repo-grep guard) required an allowlist extension: migration/detection code must *name* the legacy var to recognize it. The docstring now distinguishes "typo reappearing as an active fallback read" (what the guard polices) from "inert string literal used to detect/migrate away from the old shape" (this PR). This was a design judgment resolved inline — please scrutinize that the allowlist prefixes don't over-grant.

## Verification

- `.sh`: `bash -n` clean. `.ps1`: **no local PowerShell available** — operator verifies on the Windows box post-merge: `git pull`, re-run `.\install.ps1`, expect a "migrated pre-#139 legacy keys" line followed by `[OK] Mirrored token ...`, then `/node-info` → 200.