### PR TITLE
fix(deploy): single live env source — agent.env read directly by both processes, mirror retired (#284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ run.bat agent
 - `LLAUNCHER_AGENT_HOST`: Host to bind to (default: `127.0.0.1`). Set to `0.0.0.0` or a specific LAN IP to expose the agent to other hosts — see "Security Notes" below.
 - `LLAUNCHER_AGENT_PORT`: Port to listen on (default: `8765`)
 - `LLAUNCHER_AGENT_NODE_NAME`: Friendly name for the node
-- `LLAUNCHER_AGENT_TOKEN`: The agent's `X-Api-Key` token. The agent **always** enforces a token (auth is never off, even on loopback); this var lets you supply it explicitly. *Required* when binding to anything other than loopback — the agent refuses to start on a non-loopback host without it. Special value `-` reads the token from stdin (one line). On a loopback start with no value set, a fresh token is auto-generated and written to `~/.llauncher/agent.token` (mode 0600). For the full token/auth model (which consumers need a token, exempt paths, resolution order), see [`docs/auth.md`](docs/auth.md).
+- `LLAUNCHER_AGENT_TOKEN`: The agent's `X-Api-Key` token. The agent **always** enforces a token (auth is never off, even on loopback); this var lets you supply it explicitly and always wins over the file below. *Required* when binding to anything other than loopback — the agent refuses to start on a non-loopback host without it. Special value `-` reads the token from stdin (one line). On a loopback start with no value set (and no `LLAUNCHER_AGENT_TOKEN=` line in `agent.env`), a fresh token is auto-generated and appended into `~/.llauncher/agent.env` (mode 0600 if newly created). For the full token/auth model (which consumers need a token, exempt paths, resolution order), see [`docs/auth.md`](docs/auth.md).
 
 #### 3. Start the Dashboard on the Head Machine
 
@@ -502,30 +502,32 @@ In the dashboard:
 A remote agent **always** enforces a token (auth is never off, even on
 loopback). To pair the head with a remote node you copy that token by hand —
 it currently is **not** issued automatically (session-token issuance is
-tracked under #137). Each platform keeps the token in a known file:
+tracked under #137). The token lives in a single live file per platform —
+`agent.env`, parsed directly by the agent and the local UI (issue #284):
 
-| Platform | Token file | Mirrored from | By |
-| --- | --- | --- | --- |
-| Linux | `~/.llauncher/agent.token` | `~/.config/llauncher/agent.env` | `scripts/systemd/install.sh` |
-| Windows | `%USERPROFILE%\.llauncher\agent.token` | `agent.env` | `scripts/windows/install.ps1` |
+| Platform | Live source (`agent.env`) | Seeded (once) by |
+| --- | --- | --- |
+| Linux | `~/.config/llauncher/agent.env` | `scripts/systemd/install.sh` |
+| Windows | `%USERPROFILE%\.llauncher\agent.env` | `scripts/windows/install.ps1` |
 
 Step by step:
 
 1. **Get on the remote box.** SSH to a Linux node, or RDP to a Windows node.
 2. **Read the token.** The portable way is the agent's own subcommand, which
-   resolves the token from env / stdin / the token file and prints it to
+   resolves the token from env / stdin / `agent.env` and prints it to
    stdout:
    ```bash
    llauncher-agent print-token
    ```
-   If you prefer to read the file directly:
+   If you prefer to read the file directly, look for the
+   `LLAUNCHER_AGENT_TOKEN=` line:
    ```bash
    # Linux
-   cat ~/.llauncher/agent.token
+   grep LLAUNCHER_AGENT_TOKEN= ~/.config/llauncher/agent.env
    ```
    ```powershell
    # Windows (PowerShell)
-   Get-Content $env:USERPROFILE\.llauncher\agent.token
+   Select-String LLAUNCHER_AGENT_TOKEN= $env:USERPROFILE\.llauncher\agent.env
    ```
    Over SSH you can do both in one shot: `ssh windows-box llauncher-agent print-token`.
 3. **Copy the value.** It is a single `secrets.token_urlsafe(32)` string on
@@ -534,7 +536,7 @@ Step by step:
    into the **API Key** field of the **Add New Node** form (step 3 above).
 
 The token is stored on the head at `~/.llauncher/node_tokens.json` (mode 0600);
-the `local` node is excluded because its token already lives in `agent.token`.
+the `local` node is excluded because its token already lives in `agent.env`.
 
 ### Network Configuration
 
@@ -561,7 +563,7 @@ New-NetFirewallRule -DisplayName "llauncher Agent" -Direction Inbound -LocalPort
 #### Security Notes
 
 - **Loopback by default**: The agent binds to `127.0.0.1` unless `LLAUNCHER_AGENT_HOST` is set explicitly. Set it to a LAN IP (or `0.0.0.0`) to expose the agent to other hosts on the network.
-- **Token required for non-loopback binds**: Binding to anything other than `127.0.0.1` / `::1` / `localhost` requires `LLAUNCHER_AGENT_TOKEN` to be set. The agent refuses to start otherwise. On loopback first-run with no token configured, a fresh token is generated at `~/.llauncher/agent.token` (mode 0600) and printed once to stderr.
+- **Token required for non-loopback binds**: Binding to anything other than `127.0.0.1` / `::1` / `localhost` requires `LLAUNCHER_AGENT_TOKEN` to be set. The agent refuses to start otherwise. On loopback first-run with no token configured, a fresh token is generated and appended into `~/.llauncher/agent.env` (mode 0600 if newly created) and printed once to stderr.
 - **Trusted LAN Only**: Even with a token, only expose the agent on networks you trust — the transport is plain HTTP (no TLS). Tailscale is the recommended option for cross-host trust.
 - **Firewall**: Restrict port 8765 to your LAN subnet.
 - **Full auth model**: For the token/auth reference — the two planes (token-bearing HTTP agent vs. tokenless local MCP/CLI), the `X-Api-Key` header, exempt paths, resolution precedence, and file locations/modes — see [`docs/auth.md`](docs/auth.md).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -61,15 +61,24 @@ read leaks something (running models, OS/IP/process info):
 
 ## Token resolution precedence
 
-`resolve_agent_token()` (`llauncher/agent/auth.py`) resolves in this order:
+`resolve_agent_token()` (`llauncher/core/agent_token.py`, re-exported from
+`llauncher/agent/auth.py`) resolves in this order:
 
 1. **Env** `LLAUNCHER_AGENT_TOKEN` — used if set, non-empty, and not `"-"`.
+   An explicit override always wins.
 2. **Stdin** — if the env value is exactly `"-"`, read one line from stdin
    (lets you pipe from a secret manager without leaving the token in the
    environment). Empty stdin here is a fatal error, not a fallback.
-3. **Token file** — `agent.token` (see locations below), read verbatim.
-4. **Auto-generate** — `secrets.token_urlsafe(32)`, written to the token
-   file (mode 0600, parent 0700) and printed to stderr **once**.
+3. **`agent.env`** (see locations below) — the `LLAUNCHER_AGENT_TOKEN=`
+   line, parsed directly with `parse_env_file()`. This is the **single
+   live source** (issue #284): both the agent service and the UI/client
+   parse this exact file at startup — there is no installer-time
+   snapshot and no separate token-mirror file. Parsing matches systemd's
+   `EnvironmentFile=` semantics: blank lines and `#`-comments are
+   skipped, and a duplicate key's **last** line wins.
+4. **Auto-generate** — `secrets.token_urlsafe(32)`, appended to `agent.env`
+   as a new `LLAUNCHER_AGENT_TOKEN=` line (file created at mode 0600,
+   parent 0700, if it doesn't exist yet) and printed to stderr **once**.
 
 Step 4 only happens when `allow_generate=True`. The agent
 (`server.py:run_agent`) permits auto-generation **only on a loopback
@@ -79,24 +88,30 @@ auto-generating a secret nobody outside the host has seen is meaningless
 for LAN exposure. Consumers that must never mint a token (the UI, the
 registry) also pass `allow_generate=False`.
 
+**Retired (issue #284):** the `agent.token` mirror file. It used to be a
+separate on-disk copy an installer had to keep in sync with `agent.env` —
+that installer step being skipped/stale was the direct cause of issue
+#281's UI-403 split-brain. Nothing in the runtime reads `agent.token` any
+more; installers migrate a pre-existing one into `agent.env` once, at the
+door, then delete it (`PARSE-AT-THE-DOOR`).
+
 ## File locations & modes
 
 | File | Default path | Mode | Purpose |
 |------|--------------|------|---------|
-| `agent.token` | `~/.llauncher/agent.token` | `0600` (parent `0700`) | The agent's own static token. Read by the agent and by the local UI. |
-| `node_tokens.json` | `~/.llauncher/node_tokens.json` | `0600` (parent `0700`) | Per-**remote**-node tokens, operator-supplied. The `local` entry is excluded by design (its token lives in `agent.token`). |
+| `agent.env` | `~/.llauncher/agent.env` | `0600` (parent `0700`) | The **single live source** for the agent's token and other service-facing config. Parsed directly by both the agent and the local UI. |
+| `node_tokens.json` | `~/.llauncher/node_tokens.json` | `0600` (parent `0700`) | Per-**remote**-node tokens, operator-supplied. The `local` entry is excluded by design (its token lives in `agent.env`). |
 | `nodes.json` | `~/.llauncher/nodes.json` | — | Peer registry. **Never** carries `api_key` (control C10/#83); tokens live in the sidecar above. |
 
-`~/.llauncher/` is the live default. In systemd `--system` mode (ADR-018,
-in flight via #196/#197) state is meant to relocate under
-`LAUNCHER_STATE_DIR=/var/lib/llauncher`, with the token mirrored to
-`/var/lib/llauncher/agent.token` at mode `0640`, group `inference`, so the
-operator UI and a non-admin agent account can read it in place without
-copying secrets. **Caveat:** as of this writing `default_token_path()`
-still hardcodes `~/.llauncher/agent.token` and does not yet consult
-`LAUNCHER_STATE_DIR`; the Python-side honoring of that knob is pending
-#197 (ADR-018 Consequences). Treat `/var/lib/llauncher/agent.token` as the
-target state, not the current read path.
+`~/.llauncher/` is the live default, overridable via `LAUNCHER_STATE_DIR`
+(issue #196). In systemd `--system` mode (ADR-018) state relocates under
+`LAUNCHER_STATE_DIR=/var/lib/llauncher`; `agent.env` there is mode `0640`,
+group `inference`, so the operator UI and a non-admin agent account can
+read it in place without copying secrets. On Windows, `install.ps1`
+injects `LAUNCHER_STATE_DIR=<installing user's %USERPROFILE%\.llauncher>`
+into the NSSM service environment so a service running under
+`LocalSystem` (whose `Path.home()` does not resolve to the operator's
+profile) still resolves the *same* `agent.env` the operator's UI reads.
 
 ## Who needs a token — by consumer
 
@@ -104,7 +119,7 @@ target state, not the current read path.
 |----------|--------|--------|
 | **MCP server / local CLI** | No | n/a — in-process, tokenless |
 | **CLI targeting a remote node** | Yes | `node_tokens.json` entry for that node |
-| **Streamlit UI → local agent** | Yes | `resolve_agent_token(allow_generate=False)` → env, then `agent.token`. The UI is a *separate* process and does **not** inherit the agent's `LLAUNCHER_AGENT_TOKEN` / systemd `EnvironmentFile`; it reads the token file directly. Launched via `ui/launch.py` → `streamlit run app.py`. |
+| **Streamlit UI → local agent** | Yes | `resolve_agent_token(allow_generate=False)` → env, then `agent.env`. The UI is a *separate* process and does **not** inherit the agent's `LLAUNCHER_AGENT_TOKEN` / systemd `EnvironmentFile`; it parses `agent.env` directly. Launched via `ui/launch.py` → `streamlit run app.py`. |
 | **Remote UI/CLI (another machine)** | Yes | env `LLAUNCHER_AGENT_TOKEN`, or the per-node `node_tokens.json` |
 | **`curl` / scripts → agent** | Yes (unless hitting an exempt path) | send `X-Api-Key` |
 
@@ -115,25 +130,26 @@ llauncher." It isn't. A second local user (e.g. `claude`) drives via its
 **own in-process MCP server**, which is tokenless. What that second user
 needs is **shared access to the state** — lockfiles, `config.json`, the
 run dir — which is exactly what `LAUNCHER_STATE_DIR=/var/lib/llauncher`
-(group `inference`) provides (ADR-018). The group-readable `agent.token`
+(group `inference`) provides (ADR-018). The group-readable `agent.env`
 (0640, group `inference`) is for the *other* plane: the UI and any
 remote/HTTP clients that do cross the network boundary.
 
 So in system mode there are two distinct enablers, often conflated:
 
 - **Shared state dir** → enables a second *local* user's MCP/CLI (tokenless).
-- **Group-readable token** → enables the UI / remote HTTP clients (token-bearing).
+- **Group-readable `agent.env`** → enables the UI / remote HTTP clients (token-bearing).
 
 ## Operating notes
 
 - **Loopback is not "no auth."** Even on `127.0.0.1` the agent enforces
   the token; it just generates one for you on first run (printed once to
-  stderr; persisted at `agent.token`).
+  stderr; persisted into `agent.env`).
 - **Token is not TLS.** The transport is plain HTTP. Only expose the agent
   on trusted networks (LAN / Tailscale / VPN / SSH tunnel). See README
   "Security Notes" and `docs/operations/run-as-a-service.md`.
-- **Rotation:** change `LLAUNCHER_AGENT_TOKEN` (or the token file),
-  restart the agent, and update clients. See the run-as-a-service doc.
+- **Rotation:** edit the `LLAUNCHER_AGENT_TOKEN=` line in `agent.env` (or
+  export `LLAUNCHER_AGENT_TOKEN` to override), restart the agent, and
+  update clients. See the run-as-a-service doc.
 - **Roadmap:** ADR-017 (draft) adds opt-in trusted-host *session-token*
   issuance (`POST /session`) on top of this static-token model — it does
   not replace it. Static-token auth remains the fallback.
@@ -143,7 +159,7 @@ So in system mode there are two distinct enablers, often conflated:
 | Concern | Code |
 |---------|------|
 | Header check, exempt paths | `llauncher/agent/middleware.py` |
-| Token resolution precedence | `llauncher/agent/auth.py` (`resolve_agent_token`) |
+| Token resolution precedence + env-file parser | `llauncher/core/agent_token.py` (`resolve_agent_token`, `parse_env_file`) |
 | Loopback / refuse-to-start guard | `llauncher/agent/server.py` (`run_agent`) |
 | Local-UI / remote-node token sourcing | `llauncher/remote/registry.py` |
 | Rationale | ADR-003 (static token), ADR-018 (system mode), ADR-017 (session tokens, draft) |

--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -18,16 +18,46 @@ token/auth model across both planes see [`../auth.md`](../auth.md).)
 Both installers do the same work in OS-appropriate idioms:
 
 1. Render a service definition pointing at the venv's `llauncher-agent`.
-2. Create an env file at a per-user location with mode 0600 / restricted
-   ACL, seeded from `*.env.example` with a freshly generated token.
+2. Seed `agent.env` at a per-user location with mode 0600 / restricted
+   ACL, from `agent.env.example`, with a freshly generated token — but
+   **only once**. On every later run, if `agent.env` already exists the
+   installer skips the seed step and says so loudly, naming the live
+   path. Editing `agent.env.example` after first install is a silent
+   no-op; it is a template, never live config.
 3. Configure auto-restart on failure with a backoff (so a transient port
    collision doesn't lock you out, but a misconfigured token doesn't
    crash-loop forever).
 4. Enable + start.
 
-Re-running the installer is safe: env files are preserved, unit/service
+Re-running the installer is safe: `agent.env` is preserved, unit/service
 config is refreshed. This is the right way to pick up a `git pull` that
 touches the unit template.
+
+### Single live source (issue #284)
+
+`agent.env` is parsed **directly** by both the agent service and the
+Streamlit UI at their own startup (`llauncher.core.agent_token.resolve_agent_token`)
+— there is no installer-time snapshot into a separate mirror file.
+Editing `agent.env` and restarting the agent (`systemctl --user restart
+llauncher-agent`, or a Windows service restart) changes the effective
+token for **both** the service and the UI immediately; no reinstall
+needed on Linux. On Windows, NSSM holds the env in its own service config
+rather than re-reading the file live, so re-run `install.ps1` after an
+edit to push the new value into NSSM (see "Pick up env-file edits"
+below) — the UI side, which parses `agent.env` directly, picks up the
+edit immediately either way.
+
+The `agent.token` mirror file that used to exist alongside `agent.env` is
+**retired**. It was a second on-disk copy of the token that an installer
+had to keep in sync — a skipped or stale refresh of that copy was the
+direct cause of issue #281's UI-403 split-brain (operator edits the
+template or the env file; the mirror silently keeps the old value; the UI
+403s against a token the agent no longer expects). Both installers now
+delete a stale `agent.token` on sight, announcing it loudly
+("retired by #284; live source is `<path>`"). If `agent.token` exists and
+`agent.env` has **no** token line yet, the installer moves the token
+value into `agent.env` before deleting the mirror — a live credential is
+never silently discarded.
 
 ### Migrating from pre-#139 installs
 
@@ -141,9 +171,9 @@ system unit, never root.
    `/usr/local/bin`.
 
 2. **`inference`-group membership** for your account. The UI reads the
-   system agent's token (`/var/lib/llauncher/agent.token`, mode `0640`
-   `root:inference`) in place via group membership — no copy. Group
-   provisioning is a host step (harness-tools
+   system agent's live env file (`/var/lib/llauncher/agent.env`, mode
+   `0640` `root:inference`) in place via group membership — no copy.
+   Group provisioning is a host step (harness-tools
    `setup-inference-lane.sh`):
 
    ```bash
@@ -220,8 +250,16 @@ journalctl --user -u llauncher-ui -f      # live logs
 The installer:
 
 - Locates NSSM, fails fast with install instructions if missing.
-- Writes the env file to `%USERPROFILE%\.llauncher\agent.env` with an
-  ACL restricting access to the current user.
+- Seeds `%USERPROFILE%\.llauncher\agent.env` from the template with an
+  ACL restricting access to the current user — **only if it doesn't
+  already exist**; otherwise it skips the seed and says so loudly.
+- Migrates a stale `agent.token` mirror (pre-#284 installs) into
+  `agent.env`, then deletes it, announcing both steps.
+- Injects `LAUNCHER_STATE_DIR=%USERPROFILE%\.llauncher` into the NSSM
+  service environment (the **LocalSystem wrinkle**: NSSM defaults new
+  services to the LocalSystem account, whose `Path.home()` does not
+  resolve to the installing operator's profile — without this pointer
+  the service would resolve a different `agent.env` than the UI reads).
 - Registers the service via `nssm install`, pointing at
   `.\.venv\Scripts\llauncher-agent.exe`.
 - Configures auto-start, restart-on-failure with a 5 s backoff,
@@ -307,14 +345,25 @@ agent resolved to *different* tokens. Check, in order:
    `LLAUNCHER_AGENT_*`. Re-run the installer to migrate them
    automatically (see "Migrating from pre-#139 installs" above).
 2. **A self-generated token under the wrong profile.** When the agent
-   can't resolve a token from the environment, it auto-generates one at
-   `~/.llauncher/agent.token` under `Path.home()` **of the account the
-   agent process runs as** — for a Windows service that's the service
-   account, not the interactively logged-in operator. If the service is
-   silently minting its own token under a profile you never look at,
-   the UI's configured token will never match it. Confirm the service's
-   token source (env var vs. auto-generated file) and which account's
-   home directory it actually wrote to.
+   can't resolve a token from `agent.env` or the environment, it
+   auto-generates one and appends it into `agent.env` under
+   `Path.home()` **of the account the agent process runs as** — for a
+   Windows service that's the service account, not the interactively
+   logged-in operator. `install.ps1` injects `LAUNCHER_STATE_DIR` to
+   prevent this (see the LocalSystem wrinkle above), but a manually
+   configured service or a non-standard service account can still miss
+   it. If the service is silently minting its own token under a
+   profile you never look at, the UI's configured token will never
+   match it. Confirm the service's token source (env var vs.
+   auto-generated `agent.env`) and which account's home directory it
+   actually wrote to.
+3. **Editing the template instead of the live file.** `agent.env.example`
+   is a seed-once template — after first install, nothing reads it again.
+   If you edited the `.example` and re-ran the installer expecting the
+   new value to propagate, it won't: edit the live `agent.env` directly
+   (paths above), then restart the service (Linux: `systemctl --user
+   restart llauncher-agent`; Windows: re-run `install.ps1` to push the
+   change into NSSM).
 
 ## Token rotation
 

--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -8,10 +8,10 @@ public token-resolution names are re-exported below so existing
 ``from llauncher.agent.auth import resolve_agent_token`` callers keep
 working unchanged.
 
-Note for test authors: monkeypatching ``default_token_path`` /
+Note for test authors: monkeypatching ``default_env_path`` /
 ``resolve_agent_token`` must target the canonical home
 (``llauncher.core.agent_token``), because the implementations resolve their
-collaborators (e.g. ``default_token_path``) through *that* module's
+collaborators (e.g. ``default_env_path``) through *that* module's
 namespace. Patching the re-exported name here has no effect on the
 implementation's internal lookups.
 """
@@ -26,9 +26,10 @@ import sys  # noqa: F401  (re-exported for legacy ``auth_mod.sys`` patch sites)
 
 from llauncher.core.agent_token import (  # noqa: F401
     LEGACY_ENV_VAR,
-    _read_token_file,  # imported directly by tests/unit/test_agent_auth_token_file.py
-    default_token_path,
+    _read_env_file_token,  # imported directly by tests/unit/test_agent_auth_token_file.py
+    default_env_path,
     legacy_token_env_misconfigured,
+    parse_env_file,
     resolve_agent_token,
 )
 

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -339,9 +339,10 @@ def run_agent(config: AgentConfig) -> None:
 
     Enforces the security hardening §3 C1 guard: refuses to start
     when binding to a non-loopback interface without an authentication
-    token configured. Auto-generates a token file at
-    ``~/.llauncher/agent.token`` on the first loopback start with no
-    env-provided token.
+    token configured. Auto-generates a token and persists it into
+    ``~/.llauncher/agent.env`` on the first loopback start with no
+    env-provided token (issue #284 — single live source, no separate
+    token-mirror file).
 
     Also enforces a pre-#139 legacy-env guard (#281, defense in depth
     for deployments that bypass the installers' own migration): refuses
@@ -445,7 +446,7 @@ def main() -> None:
         choices=["print-token"],
         help=(
             "Optional subcommand. 'print-token' resolves this node's agent "
-            "token (env > stdin > ~/.llauncher/agent.token) and prints it to "
+            "token (env > stdin > ~/.llauncher/agent.env) and prints it to "
             "stdout, then exits — so an operator can copy it into the head's "
             "Add Node form without file-archaeology (issue #134)."
         ),
@@ -462,8 +463,8 @@ def main() -> None:
         if token is None:
             sys.stderr.write(
                 "[llauncher-agent] ERROR: no agent token found. Start the "
-                "agent once on loopback to generate ~/.llauncher/agent.token, "
-                "or set LLAUNCHER_AGENT_TOKEN.\n"
+                "agent once on loopback to generate one into "
+                "~/.llauncher/agent.env, or set LLAUNCHER_AGENT_TOKEN.\n"
             )
             sys.exit(1)
             return

--- a/llauncher/core/agent_token.py
+++ b/llauncher/core/agent_token.py
@@ -12,20 +12,37 @@ issue #171; hoisting the token logic here retires it.
 existing ``from llauncher.agent.auth import resolve_agent_token`` callers
 keep working unchanged.
 
+**Single live source (issue #284).** The agent service and the UI/client
+token resolution both parse ``LAUNCHER_STATE_DIR/agent.env`` directly at
+startup — there is no separate ``agent.token`` mirror file any more. The
+mirror class (a second file an installer had to keep in sync with the env
+file) was the root cause of issue #281's UI-403 split-brain: an operator
+edit to the env file was inert unless the installer also refreshed the
+mirror. Per the repo's ``PARSE-AT-THE-DOOR`` local rule there is no
+dual-read fallback onto the old file shape — nothing in this module reads
+``agent.token`` any more.
+
 The policy in precedence order:
 
 1. ``LLAUNCHER_AGENT_TOKEN`` env var, when set to a non-empty value
-   that is *not* the literal ``"-"``. Used directly.
+   that is *not* the literal ``"-"``. Used directly — an explicit
+   override always wins.
 2. ``LLAUNCHER_AGENT_TOKEN=-`` is the explicit opt-in trigger to read
    the token from standard input (one line, stripped). Lets operators
    pipe a token from a secret manager without leaving it in the
    environment.
-3. The token file ``agent.token`` under ``LAUNCHER_STATE_DIR``
-   (default ``~/.llauncher``; see issue #196), when present. Read
-   verbatim (stripped).
-4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token,
-   write it to that ``agent.token`` path with mode 0600 (parent
-   dir 0700), print it to stderr *once*, and return it.
+3. The ``LLAUNCHER_AGENT_TOKEN=`` line inside ``agent.env`` under
+   ``LAUNCHER_STATE_DIR`` (default ``~/.llauncher``; see issue #196).
+   Parsed with :func:`parse_env_file`, a simple ``KEY=VALUE`` reader
+   (see that function's docstring for the exact semantics — last-wins
+   on duplicate keys, matching systemd's ``EnvironmentFile=`` parser so
+   both installers agree with the runtime on which line wins; see
+   issue #285).
+4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token and
+   persist it *into* ``agent.env`` (appending a
+   ``LLAUNCHER_AGENT_TOKEN=`` line — creating the file with mode 0600,
+   parent dir 0700, if it does not yet exist), print it to stderr
+   *once*, and return it.
 
 The auto-generation path is only safe to silently take when the
 agent is bound to a loopback interface. The refuse-to-start guard
@@ -71,18 +88,27 @@ def legacy_token_env_misconfigured(environ: Mapping[str, str] | None = None) -> 
     )
 
 
-def default_token_path() -> Path:
-    """Return the agent token path under ``LAUNCHER_STATE_DIR``.
+#: The key line format written by :func:`_generate_and_persist_token` and
+#: read by :func:`parse_env_file`.
+_TOKEN_KEY = "LLAUNCHER_AGENT_TOKEN"
+
+
+def default_env_path() -> Path:
+    """Return the live ``agent.env`` path under ``LAUNCHER_STATE_DIR``.
 
     Derived from the single durable-state base (issue #196). With
     ``LAUNCHER_STATE_DIR`` unset this resolves to
-    ``~/.llauncher/agent.token`` exactly as before. Imported lazily so
-    importing this module stays filesystem-free and avoids any import
-    ordering concerns.
+    ``~/.llauncher/agent.env``. Imported lazily so importing this module
+    stays filesystem-free and avoids any import ordering concerns.
+
+    This is the single live source of the agent's configuration
+    (issue #284): both the agent service and the UI/client token
+    resolution parse this exact file directly at startup. There is no
+    installer-time snapshot and no separate token-mirror file.
     """
     from llauncher.core.settings import LAUNCHER_STATE_DIR
 
-    return LAUNCHER_STATE_DIR / "agent.token"
+    return LAUNCHER_STATE_DIR / "agent.env"
 
 
 def _read_stdin_token() -> str:
@@ -102,57 +128,138 @@ def _read_stdin_token() -> str:
     return token
 
 
-def _read_token_file(path: Path) -> str | None:
-    """Return the stripped token from ``path``, or None if missing/empty.
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a ``KEY=VALUE`` env file into a dict, or ``{}`` if missing.
+
+    A minimal, hand-rolled reader matching systemd's ``EnvironmentFile=``
+    semantics (see ``man systemd.exec``), so the installers and the
+    runtime agree on which value wins. ``python-dotenv`` (already a hard
+    dependency; see ``llauncher/__init__.py``'s ``load_dotenv()``) was
+    considered and rejected here: ``dotenv_values()`` prints a parser
+    warning to stderr and yields a ``None``-valued key for a malformed
+    line (e.g. one with no ``=``) rather than silently skipping it — a
+    behavior mismatch with the "tolerant, silent skip" contract this
+    function is specified to have (a hand-edited ``agent.env`` with a
+    stray line must not spam stderr on every agent start). The overlap
+    that *does* match (last-wins on duplicate keys, ``utf-8-sig``
+    decoding) is small enough that duplicating it here, fully pinned by
+    the tests below, was judged cheaper than papering over
+    ``dotenv_values``'s edge-case differences at every call site.
+
+    - Blank lines are skipped.
+    - Comment lines (first non-whitespace character is ``#``) are
+      skipped.
+    - Each remaining line is split on the first ``=`` into a key and a
+      value; the key is stripped of surrounding whitespace, the value
+      is stripped of a trailing newline only (leading/trailing spaces
+      inside the value are preserved verbatim, matching systemd — quote
+      your value in the file if you need to pad it).
+    - A line with no ``=`` is skipped (not a fatal error — matches
+      systemd's tolerant parsing rather than failing the whole file
+      over one malformed line).
+    - **Last-wins** on a duplicate key: a later line silently
+      overwrites an earlier line's value for the same key. This is
+      systemd's ``EnvironmentFile=`` behavior exactly; both installers
+      must agree with this reader on that point (issue #285).
 
     Decoded as ``utf-8-sig`` so that a leading byte-order mark — which
     Windows PowerShell 5.1 prepends when writing with ``-Encoding utf8``
-    — is consumed at decode time rather than leaking into the token as
-    a ``\\ufeff`` character. ``str.strip()`` does NOT remove ``\\ufeff``
-    (it's classified as zero-width non-breaking space, not whitespace),
-    so a BOM left in the token used to surface downstream as an
-    ``ascii``-codec ``UnicodeEncodeError`` when httpx serialized the
-    token into the ``X-Api-Key`` request header. ``utf-8-sig`` is a
+    — is consumed at decode time rather than leaking a ``\\ufeff``
+    character into the first key's name or value. ``utf-8-sig`` is a
     strict superset of ``utf-8`` for BOM-less input, so this is a
     defensive widening with no behavior change for the BOM-free case.
+
+    Returns ``{}`` (not an error) when ``path`` does not exist — a
+    missing env file is a normal pre-first-run state, not a fault.
     """
     try:
-        data = path.read_text(encoding="utf-8-sig").strip()
+        text = path.read_text(encoding="utf-8-sig")
     except FileNotFoundError:
-        return None
-    return data or None
+        return {}
+
+    result: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        result[key] = value.strip()
+    return result
+
+
+def _read_env_file_token(path: Path) -> str | None:
+    """Return the ``LLAUNCHER_AGENT_TOKEN`` value from ``path``, or None.
+
+    Thin wrapper over :func:`parse_env_file` scoped to the one key this
+    module cares about; an empty value (``LLAUNCHER_AGENT_TOKEN=`` with
+    nothing after the ``=``) counts as absent, matching the env-var
+    precedence step above it.
+    """
+    return parse_env_file(path).get(_TOKEN_KEY) or None
 
 
 def _generate_and_persist_token(path: Path) -> str:
-    """Generate a fresh token and persist it at ``path`` with mode 0600.
+    """Generate a fresh token and append it to the ``agent.env`` at ``path``.
 
-    Parent directory is created with mode 0700 if missing. The token
-    is printed to stderr once so the operator can copy it into their
-    client config; we deliberately avoid the regular logger because
-    the operator may have a structured log pipeline that would
+    If ``path`` does not exist yet, it is created (mode 0600, parent
+    dir 0700) containing just the token line. If it already exists (but
+    has no usable ``LLAUNCHER_AGENT_TOKEN=`` line — the only way this
+    function is reached), the token line is appended, preserving every
+    existing line verbatim; the file's mode is left as-is in that case
+    since it presumably already carries whatever permissions the
+    installer or a previous run set — e.g. systemd ``--system`` mode's
+    0640/group-``inference`` ``agent.env``, which the UI's group-read
+    access depends on. Tightening it to 0600 here would silently break
+    that cross-process read path; the new-file case has no such prior
+    permission to preserve, so it gets the same 0600/0700 hardening as
+    before.
+
+    The append guards against a missing trailing newline on the last
+    existing line, which would otherwise fuse onto the appended key and
+    make the file unparseable by :func:`parse_env_file`.
+
+    The token is printed to stderr once so the operator can copy it
+    into their client config; we deliberately avoid the regular logger
+    because the operator may have a structured log pipeline that would
     otherwise capture and retain the secret indefinitely.
     """
+    token = secrets.token_urlsafe(32)
+    is_new_file = not path.exists()
+
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)
-    try:
-        parent.chmod(stat.S_IRWXU)  # 0700
-    except OSError:
-        # Best-effort; on some filesystems (e.g. Windows-on-NTFS via
-        # WSL) chmod is a no-op. The 0600 on the file itself is the
-        # load-bearing protection.
-        pass
+    if is_new_file:
+        try:
+            parent.chmod(stat.S_IRWXU)  # 0700
+        except OSError:
+            # Best-effort; on some filesystems (e.g. Windows-on-NTFS via
+            # WSL) chmod is a no-op. The 0600 on the file itself is the
+            # load-bearing protection.
+            pass
 
-    token = secrets.token_urlsafe(32)
-    # Write then chmod — open() honors umask, so we restrict
-    # explicitly after creation.
-    path.write_text(token + "\n", encoding="utf-8")
-    try:
-        path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-    except OSError:
-        pass
+    line = f"{_TOKEN_KEY}={token}\n"
+    if is_new_file:
+        path.write_text(line, encoding="utf-8")
+        try:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        except OSError:
+            pass
+    else:
+        existing = path.read_text(encoding="utf-8-sig")
+        needs_separator = existing and not existing.endswith("\n")
+        with path.open("a", encoding="utf-8") as fh:
+            if needs_separator:
+                fh.write("\n")
+            fh.write(line)
 
     print(
-        f"[llauncher-agent] Generated new auth token at {path} (mode 0600).\n"
+        f"[llauncher-agent] Generated new auth token and wrote it to {path} "
+        f"(LLAUNCHER_AGENT_TOKEN=...).\n"
         f"[llauncher-agent] Token: {token}\n"
         f"[llauncher-agent] Set LLAUNCHER_AGENT_TOKEN or use this token in your client.",
         file=sys.stderr,
@@ -163,7 +270,7 @@ def _generate_and_persist_token(path: Path) -> str:
 def resolve_agent_token(
     *,
     env_value: str | None = None,
-    token_path: Path | None = None,
+    env_path: Path | None = None,
     allow_generate: bool = True,
 ) -> str | None:
     """Resolve the agent auth token per the precedence chain.
@@ -174,10 +281,13 @@ def resolve_agent_token(
         Raw value of ``LLAUNCHER_AGENT_TOKEN`` (or ``None`` if unset).
         When ``None`` (the default kwarg), the env is read at call
         time. Pass an explicit value (including ``""``/``None``) to
-        bypass the env read — used by tests.
-    token_path:
-        Override the on-disk token file location. Defaults to
-        :func:`default_token_path`.
+        bypass the env read — used by tests. This is the explicit
+        override step (precedence 1) and always wins when non-empty.
+    env_path:
+        Override the on-disk ``agent.env`` location. Defaults to
+        :func:`default_env_path`. This is the single live source
+        (issue #284) both the agent and the UI/client parse directly;
+        there is no separate token-mirror file.
     allow_generate:
         When False, the auto-generate-and-write step is suppressed
         and the function returns ``None`` if no token is found via
@@ -198,8 +308,8 @@ def resolve_agent_token(
     if env_value:
         return env_value
 
-    path = token_path or default_token_path()
-    existing = _read_token_file(path)
+    path = env_path or default_env_path()
+    existing = _read_env_file_token(path)
     if existing:
         return existing
 

--- a/llauncher/remote/registry.py
+++ b/llauncher/remote/registry.py
@@ -115,9 +115,10 @@ class NodeRegistry:
         environment. We source via
         :func:`llauncher.core.agent_token.resolve_agent_token` with
         ``allow_generate=False`` — that reads the env var first, then
-        the on-disk ``~/.llauncher/agent.token``. ``allow_generate=False``
-        because only the agent itself should ever materialize a fresh
-        token; the UI must be a pure consumer.
+        parses the on-disk ``~/.llauncher/agent.env`` directly (issue
+        #284 — single live source, no separate token-mirror file).
+        ``allow_generate=False`` because only the agent itself should
+        ever materialize a fresh token; the UI must be a pure consumer.
 
         The token resolver lives in :mod:`llauncher.core.agent_token`
         (issue #171) precisely so ``remote`` can read it without
@@ -168,20 +169,20 @@ class NodeRegistry:
         each match onto the corresponding ``RemoteNode.api_key``.
 
         Missing entries leave ``api_key=None`` — we do NOT synthesize
-        from ``agent.token`` (which is the local agent's token);
+        from ``agent.env`` (which carries the local agent's token);
         cross-pollinating a local token onto a remote node would be a
         credential-confusion bug, symmetric to
         :meth:`_populate_local_token`'s "only touches ``local``" guard.
 
         The ``local`` entry is also skipped here even if it happens to
         appear in ``node_tokens.json``: its canonical source is
-        ``agent.token`` via ``_populate_local_token``, and trusting
+        ``agent.env`` via ``_populate_local_token``, and trusting
         ``node_tokens.json`` for ``local`` would create a drift
         opportunity.
         """
         tokens = self._load_node_tokens()
         for name, token in tokens.items():
-            if name == "local":  # pragma: no cover - C10 security guard: 'local' token is never sourced from the sidecar (canonical source is agent.token); skip to prevent credential confusion
+            if name == "local":  # pragma: no cover - C10 security guard: 'local' token is never sourced from the sidecar (canonical source is agent.env); skip to prevent credential confusion
                 continue
             node = self._nodes.get(name)
             if node is not None and not node.api_key:
@@ -193,11 +194,11 @@ class NodeRegistry:
         Full rewrite each call: any node that was removed from
         ``self._nodes`` or whose ``api_key`` was cleared automatically
         falls out of the file. The ``local`` entry is excluded
-        unconditionally — its token lives in ``agent.token``;
+        unconditionally — its token lives in ``agent.env``;
         duplicating it here would create drift.
 
         Mode 0600 on the file, 0700 on the parent dir — matching the
-        ``nodes.json`` and ``agent.token`` conventions.
+        ``nodes.json`` and ``agent.env`` conventions.
         """
         data = {
             name: node.api_key

--- a/llauncher/ui/tabs/nodes.py
+++ b/llauncher/ui/tabs/nodes.py
@@ -104,7 +104,7 @@ def render_node_list(registry: NodeRegistry, aggregator) -> None:
             st.divider()
 
             # Rotate API key (remote nodes only — the ``local`` entry
-            # sources its token from ``~/.llauncher/agent.token`` via
+            # sources its token from ``~/.llauncher/agent.env`` via
             # NodeRegistry._populate_local_token; manually setting one
             # here would only create drift).
             if node.name != "local":
@@ -231,8 +231,9 @@ def render_add_node_form(registry: NodeRegistry) -> None:
             type="password",
             help=(
                 "On the remote box, run `llauncher-agent print-token` (or "
-                "`cat ~/.llauncher/agent.token` on Linux / "
-                "`Get-Content $env:USERPROFILE\\.llauncher\\agent.token` on "
+                "read the `LLAUNCHER_AGENT_TOKEN=` line from "
+                "`~/.llauncher/agent.env` on Linux / "
+                "`$env:USERPROFILE\\.llauncher\\agent.env` on "
                 "Windows) and paste the value here. Required for non-loopback "
                 "agents (per ADR-003); leave blank only for unauthenticated "
                 "loopback agents."

--- a/scripts/systemd/agent.env.example
+++ b/scripts/systemd/agent.env.example
@@ -1,13 +1,30 @@
 # llauncher agent environment file.
 #
-# install.sh generates the live copy at:
-#   ~/.config/llauncher/agent.env  (mode 0600)
-# Edit the live copy to customize this host; this .example is a
-# reference template tracked in git.
+# ── This is a SEED-ONCE template, not live config ──────────────────────
+# install.sh copies this file into the live location EXACTLY ONCE, on
+# first install:
+#   --user mode   → ~/.config/llauncher/agent.env   (mode 0600)
+#   --system mode → /var/lib/llauncher/agent.env    (mode 0640, group inference)
+# From that point on, install.sh NEVER reads this .example again — if
+# agent.env already exists, the installer skips the seed step and says so
+# loudly, naming the live path. Editing THIS file after first install is a
+# silent no-op: nothing will ever read your edit. Edit the live agent.env
+# directly (systemd's EnvironmentFile= re-reads it on every service
+# (re)start, so no separate "push" step is needed the way NSSM requires on
+# Windows).
+#
+# Single live source (issue #284): agent.env is read DIRECTLY by both the
+# agent service (systemd EnvironmentFile=, below) and the Streamlit UI
+# (llauncher.core.agent_token.resolve_agent_token) at their own startup.
+# There is no separate agent.token mirror file any more — that mirror
+# class was retired by #284 (root cause of #281's UI-403 split-brain: an
+# edit to the mirror's source was inert unless the installer happened to
+# refresh the mirror too).
 #
 # Format: systemd EnvironmentFile syntax (KEY=VALUE, no `export`,
 # no shell expansion, no quoting needed unless the value contains
-# whitespace). systemd injects these into the agent's process
+# whitespace; blank/`#`-comment lines skipped, last-wins on a duplicate
+# key — see issue #285). systemd injects these into the agent's process
 # environment BEFORE `python` starts.
 #
 # ── Relationship to project-root `.env` ───────────────────────────────
@@ -21,18 +38,11 @@
 # templates currently have zero overlap, so in practice they compose
 # additively. See #129.
 #
-# Note: the Streamlit UI process is NOT managed by systemd and does NOT
-# see this file's vars — it only reads project `.env`. To bridge that,
-# install.sh mirrors LLAUNCHER_AGENT_TOKEN from this file into a token
-# file the UI reads directly (issue #131, symmetric with install.ps1):
-#   --user mode   → ~/.llauncher/agent.token            (mode 0600)
-#   --system mode → /var/lib/llauncher/agent.token      (mode 0640,
-#                   group `inference`, so the operator UI / non-admin
-#                   agent user can read it without copying secrets)
-# So the UI authenticates automatically after install. You do NOT need
-# to source this file into the UI's shell or duplicate the token into
-# project `.env`. Re-run install.sh after editing the token here to
-# refresh the mirror.
+# Note: the Streamlit UI process is NOT managed by systemd. It reads this
+# same agent.env file directly (not via systemd) to resolve the agent's
+# token — no separate copy involved. In `--system` mode, group `inference`
+# read access on agent.env (mode 0640) is what makes this work without
+# copying secrets.
 #
 # ── Interpreter-level variables belong HERE, not in `.env` ────────────
 # `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, and other

--- a/scripts/systemd/install-ui.sh
+++ b/scripts/systemd/install-ui.sh
@@ -85,12 +85,12 @@ fi
 
 if ! getent group inference >/dev/null 2>&1; then
     info "Group 'inference' does not exist on this host. The UI reads the system"
-    info "  agent's token (/var/lib/llauncher/agent.token, 0640 root:inference) via"
+    info "  agent's live env file (/var/lib/llauncher/agent.env, 0640 root:inference) via"
     info "  group membership; token reads will fail until the group is provisioned"
     info "  (host provisioning, out of installer scope)."
 elif ! id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx inference; then
     info "$USER is not a member of group 'inference'. The UI reads the system"
-    info "  agent's token (/var/lib/llauncher/agent.token, 0640 root:inference) via"
+    info "  agent's live env file (/var/lib/llauncher/agent.env, 0640 root:inference) via"
     info "  group membership; token reads will fail until you are added"
     info "    sudo usermod -aG inference $USER   # host provisioning, then re-login"
 fi

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -15,6 +15,15 @@
 # key names ARE migrated in place to LLAUNCHER_AGENT_* (values
 # preserved; issue #281).
 #
+# Single live source (issue #284): agent.env is read DIRECTLY by both the
+# agent service (systemd EnvironmentFile=) and the UI
+# (llauncher.core.agent_token.resolve_agent_token) at their own startup —
+# there is no agent.token mirror file any more. A stale agent.token from a
+# pre-#284 install is migrated into agent.env once, at the door, then
+# deleted; the installer announces this loudly. Editing
+# agent.env.example after first install does nothing — it is a seed-once
+# template, not live config.
+#
 # Usage:
 #   ./scripts/systemd/install.sh                    # user: install+enable+start
 #   ./scripts/systemd/install.sh --no-start         # user: render+enable only
@@ -32,7 +41,7 @@ VENV_BIN="$PROJECT_DIR/.venv/bin"
 UNIT_NAME="llauncher-agent.service"
 # Root oneshot that guarantees the agent venv (system mode only; ADR-023/#227).
 ENSURE_UNIT_NAME="llauncher-agent-ensure-venv.service"
-ENV_EXAMPLE="$SCRIPT_DIR/llauncher-agent.env.example"
+ENV_EXAMPLE="$SCRIPT_DIR/agent.env.example"
 
 # Colors
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
@@ -58,10 +67,12 @@ done
 # --- Mode-dependent locations -----------------------------------------
 # UI service posture: see ADR-022 (decided: per-operator systemd --user; implementation pending). UI is currently hand-launched.
 # The UI process (Streamlit) is separate from the systemd service and does
-# NOT inherit LLAUNCHER_AGENT_TOKEN from the unit's environment, so it can
-# only authenticate against the local agent by reading the mirrored token
-# from TOKEN_FILE. See issue #131 + the Windows counterpart in
-# scripts/windows/install.ps1.
+# NOT inherit LLAUNCHER_AGENT_TOKEN from the unit's environment, so it
+# authenticates against the local agent by parsing ENV_FILE directly
+# (llauncher.core.agent_token.resolve_agent_token; issue #284 — single
+# live source, no mirror). TOKEN_FILE below is retained only as the
+# pre-#284 mirror path this installer migrates from and then deletes. See
+# the Windows counterpart in scripts/windows/install.ps1.
 if [ "$MODE" = "system" ]; then
     UNIT_DIR="/etc/systemd/system"
     STATE_DIR="/var/lib/llauncher"
@@ -73,8 +84,8 @@ if [ "$MODE" = "system" ]; then
     SYSTEMCTL=(systemctl)
     JOURNALCTL=(journalctl)
     # Group-readable so the operator UI and a non-admin agent user can read
-    # the token without copying it. Group `inference` is provisioned by the
-    # host script (see preflight).
+    # agent.env (and therefore its token line) directly, without copying.
+    # Group `inference` is provisioned by the host script (see preflight).
     FILE_MODE=0640
     FILE_GROUP=inference
 else
@@ -112,7 +123,10 @@ uninstall() {
     fi
     "${SYSTEMCTL[@]}" daemon-reload
     info "Env file left in place at $ENV_FILE (delete manually if desired)."
-    info "Token file left in place at $TOKEN_FILE (delete manually if desired)."
+    if [ -f "$TOKEN_FILE" ]; then
+        info "Stale mirror file also left in place at $TOKEN_FILE (retired by #284;"
+        info "  live source is $ENV_FILE — delete $TOKEN_FILE manually if desired)."
+    fi
     say "Uninstalled."
     exit 0
 }
@@ -166,19 +180,43 @@ if [ "$MODE" != "system" ]; then
     chmod 700 "$ENV_DIR"
 fi
 
+# --- Migrate a pre-#284 agent.token mirror BEFORE any fresh seed -------
+# Ordering matters: if $ENV_FILE is absent but a stale agent.token mirror
+# still holds the operator's real, already-in-use token (e.g. agent.env
+# was deleted/never synced while the mirror survived), the seed-from-
+# template step below must NOT overwrite it with a newly generated
+# random token — that would silently orphan the live credential the
+# mirror was carrying. So: if the mirror exists and carries a value,
+# seed $ENV_FILE from THAT value instead of generating a fresh one.
+MIGRATED_MIRROR_TOKEN=""
+if [ -f "$TOKEN_FILE" ]; then
+    MIGRATED_MIRROR_TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE" || true)"
+fi
+
 if [ ! -f "$ENV_FILE" ]; then
-    info "Generating $ENV_FILE with a fresh token..."
-    TOKEN="$("$VENV_BIN/python" -c 'import secrets; print(secrets.token_urlsafe(32))')"
-    # Seed from the example, then substitute the placeholder token.
-    sed "s|replace-me-with-a-random-token|$TOKEN|" "$ENV_EXAMPLE" > "$ENV_FILE"
+    if [ -n "$MIGRATED_MIRROR_TOKEN" ]; then
+        info "Seeding $ENV_FILE from the template using the live token found in the stale agent.token mirror..."
+        sed "s|replace-me-with-a-random-token|$MIGRATED_MIRROR_TOKEN|" "$ENV_EXAMPLE" > "$ENV_FILE"
+        say "Wrote $ENV_FILE, carrying forward the token from $TOKEN_FILE (not overwritten with a fresh one)."
+    else
+        info "Seeding $ENV_FILE from the template (one-time; see agent.env.example header)..."
+        TOKEN="$("$VENV_BIN/python" -c 'import secrets; print(secrets.token_urlsafe(32))')"
+        # Seed from the example, then substitute the placeholder token.
+        sed "s|replace-me-with-a-random-token|$TOKEN|" "$ENV_EXAMPLE" > "$ENV_FILE"
+        say "Wrote $ENV_FILE (mode $FILE_MODE) with a generated 32-byte token."
+    fi
     chmod "$FILE_MODE" "$ENV_FILE"
     [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$ENV_FILE"
-    say "Wrote $ENV_FILE (mode $FILE_MODE) with a generated 32-byte token."
     info "Edit it to set LLAUNCHER_AGENT_NODE_NAME / HOST / PORT as needed."
 else
     chmod "$FILE_MODE" "$ENV_FILE"  # repair perms if they drifted
     [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$ENV_FILE"
-    say "Env file already exists at $ENV_FILE — leaving it untouched."
+    # Loud on skip (issue #284): edits to the template are never read again
+    # after this first-install seed — $ENV_FILE is the only file either
+    # process consults from here on.
+    info "agent.env already exists at $ENV_FILE — skipping template seed."
+    info "  Edits to $ENV_EXAMPLE are never read after first install;"
+    info "  edit $ENV_FILE directly (the live source) and re-run this installer."
 
     # --- Migrate pre-#139 legacy keys (issue #281) ----------------------
     # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* → LLAUNCHER_AGENT_*,
@@ -200,42 +238,51 @@ else
     fi
 fi
 
-# --- Token mirror (issue #131) -----------------------------------------
-# Mirror LLAUNCHER_AGENT_TOKEN from the env file into TOKEN_FILE so the UI
-# process — which does NOT share the systemd service env — can authenticate
-# against the local agent. In user mode this is ~/.llauncher/agent.token; in
-# system mode it is /var/lib/llauncher/agent.token, group-readable to
-# `inference` so the operator UI / non-admin agent user can read it without
-# copying. Symmetric with the Windows install.ps1 mirror block.
+# --- Retire the agent.token mirror (issue #284) -------------------------
+# agent.env is now the single live source, read DIRECTLY by both the
+# systemd service (EnvironmentFile=) and the UI
+# (llauncher.core.agent_token.resolve_agent_token) at their own startup —
+# no installer-maintained mirror file. A stale agent.token from a
+# pre-#284 install is migrated in place, once, at the door
+# (PARSE-AT-THE-DOOR): if $ENV_FILE has NO usable token line, the
+# mirror's value is appended to $ENV_FILE before the mirror is deleted, so
+# a live credential already in use is never silently discarded. If
+# $ENV_FILE already has a token, the mirror is simply retired (deleted)
+# since nothing reads it any more.
 #
 # `tail -n1` (not `head -n1`) matches systemd's EnvironmentFile parser
 # semantics ("last wins"); the value the agent actually runs with is the
-# last LLAUNCHER_AGENT_TOKEN= line, so the mirror must reflect that.
-# `tr -d '[:space:]'` defends against trailing whitespace or stray CRs
-# from hand-edited env files.
+# last LLAUNCHER_AGENT_TOKEN= line. `tr -d '[:space:]'` defends against
+# trailing whitespace or stray CRs from hand-edited env files. `|| true`
+# keeps a grep miss (no matching line) from tripping `set -e` via the
+# failing command-substitution.
 if [ "$MODE" != "system" ]; then
     mkdir -p "$LLAUNCHER_DIR"
     chmod 700 "$LLAUNCHER_DIR"
 fi
-# `|| true` keeps a grep miss (no matching line) from tripping `set -e`
-# via the failing command-substitution — an empty TOKEN_VALUE then routes
-# to the fail-loud else-branch below instead of a silent exit 1. Legacy
-# single-L (LAUNCHER, not LLAUNCHER; #138/#139) key names have already
-# been migrated in place above, so reaching the else-branch here means
-# the env file genuinely has no usable token — never a shape we
+if [ -f "$TOKEN_FILE" ]; then
+    EXISTING_TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]' || true)"
+    if [ -z "$EXISTING_TOKEN_VALUE" ]; then
+        MIRROR_TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE" || true)"
+        if [ -n "$MIRROR_TOKEN" ]; then
+            printf 'LLAUNCHER_AGENT_TOKEN=%s\n' "$MIRROR_TOKEN" >> "$ENV_FILE"
+            say "Migrated live token from $TOKEN_FILE into $ENV_FILE ($ENV_FILE had no token line)."
+        fi
+    fi
+    rm -f "$TOKEN_FILE"
+    info "Retired by #284; live source is $ENV_FILE. Removed stale mirror $TOKEN_FILE."
+fi
+
+# --- Fail loud if the env file still has no usable token (issue #281/#284) -
+# Legacy single-L (LAUNCHER, not LLAUNCHER; #138/#139) key names have
+# already been migrated in place above, so reaching this branch means the
+# env file genuinely has no usable token — never a shape we
 # trust-and-degrade on (issue #281).
 TOKEN_VALUE="$(grep -E '^LLAUNCHER_AGENT_TOKEN=' "$ENV_FILE" | tail -n1 | cut -d= -f2- | tr -d '[:space:]' || true)"
-if [ -n "$TOKEN_VALUE" ]; then
-    # printf '%s' (no trailing newline) matches the byte-shape of
-    # llauncher/agent/auth.py:_generate_and_persist_token after strip.
-    printf '%s' "$TOKEN_VALUE" > "$TOKEN_FILE"
-    chmod "$FILE_MODE" "$TOKEN_FILE"
-    [ "$MODE" = "system" ] && chgrp "$FILE_GROUP" "$TOKEN_FILE"
-    say "Mirrored token to $TOKEN_FILE (mode $FILE_MODE) so the UI can authenticate."
-else
+if [ -z "$TOKEN_VALUE" ]; then
     err "No usable LLAUNCHER_AGENT_TOKEN line found in $ENV_FILE (missing or empty value)."
-    err "Refusing to install the service without a mirrored, non-empty token — the agent"
-    err "would silently auto-generate its own token and the UI could never authenticate."
+    err "Refusing to install the service without a usable token in the live source — the"
+    err "agent would silently auto-generate its own token and the UI could never authenticate."
     err "Fix one of:"
     err "  - Add a line to $ENV_FILE:  LLAUNCHER_AGENT_TOKEN=<token>"
     err "    (generate one:  python -c 'import secrets; print(secrets.token_urlsafe(32))')"

--- a/scripts/systemd/llauncher-ui.service.user.in
+++ b/scripts/systemd/llauncher-ui.service.user.in
@@ -33,10 +33,11 @@ StartLimitIntervalSec=60
 [Service]
 Type=simple
 ; The single non-negotiable line: without it the UI reads ~/.llauncher and
-; misses the system agent's /var/lib/llauncher/agent.token (0640 root:inference),
-; which the caller reads in place via `inference`-group membership. The value is
-; fixed at process start — exactly when systemd injects the unit env. See
-; ADR-022 §Open Questions and core/agent_token.py::default_token_path().
+; misses the system agent's /var/lib/llauncher/agent.env (0640 root:inference,
+; single live source of the token as of #284), which the caller reads in
+; place via `inference`-group membership. The value is fixed at process
+; start — exactly when systemd injects the unit env. See ADR-022 §Open
+; Questions and core/agent_token.py::default_env_path().
 Environment=LAUNCHER_STATE_DIR=/var/lib/llauncher
 
 ; ADR-023 Phase B (issue #228): fail-loud backstop. ExecStart resolves

--- a/scripts/windows/agent.env.example
+++ b/scripts/windows/agent.env.example
@@ -1,14 +1,30 @@
 # llauncher agent environment file (Windows / NSSM).
 #
-# install.ps1 generates the live copy at:
+# ── This is a SEED-ONCE template, not live config ──────────────────────
+# install.ps1 copies this file into the live location EXACTLY ONCE, on
+# first install:
 #   %USERPROFILE%\.llauncher\agent.env  (ACL: current user only)
-# Edit the live copy to customize this host; this .example is a
-# reference template tracked in git.
+# From that point on, install.ps1 NEVER reads this .example again — if
+# agent.env already exists, the installer skips the seed step and says so
+# loudly, naming the live path. Editing THIS file after first install is a
+# silent no-op: nothing will ever read your edit. Edit the live agent.env
+# directly, then re-run install.ps1 to push the change into the NSSM
+# service config (see "Pick up env-file edits" in
+# docs/operations/run-as-a-service.md).
 #
-# Format: simple KEY=VALUE per line. install.ps1 parses this and
-# feeds it to NSSM via `nssm set <svc> AppEnvironmentExtra`. NSSM
-# injects these into the agent's process environment BEFORE
-# `python.exe` starts.
+# Single live source (issue #284): agent.env is parsed DIRECTLY by both
+# the agent service (via NSSM AppEnvironmentExtra, below) and the
+# Streamlit UI (llauncher.core.agent_token.resolve_agent_token) at their
+# own startup. There is no separate agent.token mirror file any more —
+# that mirror class was retired by #284 (root cause of #281's UI-403
+# split-brain: an edit to the mirror's source was inert unless the
+# installer happened to refresh the mirror too).
+#
+# Format: simple KEY=VALUE per line, systemd EnvironmentFile= semantics
+# (blank/`#`-comment lines skipped, last-wins on a duplicate key — see
+# issue #285). install.ps1 parses this and feeds it to NSSM via
+# `nssm set <svc> AppEnvironmentExtra`. NSSM injects these into the
+# agent's process environment BEFORE `python.exe` starts.
 #
 # ── Relationship to project-root `.env` ───────────────────────────────
 # This file is service-facing. A separate project-root `.env` (template:
@@ -21,10 +37,9 @@
 # templates currently have zero overlap, so in practice they compose
 # additively. See #129.
 #
-# Note: the Streamlit UI process is NOT managed by NSSM and does NOT
-# see this file's vars — it only reads project `.env`. The mirrored
-# token at ~/.llauncher/agent.token (written by install.ps1 below)
-# exists specifically to bridge that gap.
+# Note: the Streamlit UI process is NOT managed by NSSM. It reads this
+# same agent.env file directly (not via NSSM) to resolve the agent's
+# token — no separate copy involved.
 #
 # ── Interpreter-level variables belong HERE, not in `.env` ────────────
 # `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONDONTWRITEBYTECODE`, and other

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -12,6 +12,23 @@
 # legacy LAUNCHER_AGENT_* key names ARE migrated in place to LLAUNCHER_AGENT_*
 # (values preserved; issue #281).
 #
+# Single live source (issue #284): %USERPROFILE%\.llauncher\agent.env is
+# read DIRECTLY by both the agent service and the UI at startup — there is
+# no installer-time snapshot and no agent.token mirror file any more. This
+# script's job on every run is: seed agent.env ONCE if absent, migrate a
+# stale agent.token into it if found, inject LAUNCHER_STATE_DIR into the
+# NSSM service env (see the LocalSystem note below), and pass through
+# interpreter-level vars via NSSM AppEnvironmentExtra. Editing
+# agent.env.example after first install does nothing — it is a
+# seed-once template, not live config.
+#
+# LocalSystem wrinkle: NSSM defaults new services to the LocalSystem
+# account, whose Path.home() does NOT resolve to the installing operator's
+# profile. Without help, the service process would resolve a DIFFERENT
+# agent.env than the one the operator's UI reads. This script injects
+# LAUNCHER_STATE_DIR=<installing user's %USERPROFILE%\.llauncher> into
+# AppEnvironmentExtra so the service converges on the same file.
+#
 # Usage:
 #   .\scripts\windows\install.ps1
 #   .\scripts\windows\install.ps1 -NoStart
@@ -34,7 +51,7 @@ $EnvDir      = Join-Path $env:USERPROFILE '.llauncher'
 $EnvFile     = Join-Path $EnvDir 'agent.env'
 $TokenFile   = Join-Path $EnvDir 'agent.token'
 $LogDir      = Join-Path $env:USERPROFILE '.llauncher\logs'
-$EnvExample  = Join-Path $ScriptDir 'llauncher-agent.env.example'
+$EnvExample  = Join-Path $ScriptDir 'agent.env.example'
 
 function Say  ($msg) { Write-Host "[OK]  $msg" -ForegroundColor Green }
 function Info ($msg) { Write-Host "[..]  $msg" -ForegroundColor Yellow }
@@ -83,16 +100,46 @@ if (-not (Test-Path $VenvExe)) {
 if (-not (Test-Path $EnvDir))  { New-Item -ItemType Directory -Path $EnvDir  | Out-Null }
 if (-not (Test-Path $LogDir))  { New-Item -ItemType Directory -Path $LogDir  | Out-Null }
 
+# --- Migrate a pre-#284 agent.token mirror BEFORE any fresh seed ------
+# Ordering matters: if agent.env is absent but a stale agent.token mirror
+# still holds the operator's real, already-in-use token (e.g. agent.env
+# was deleted/never synced while the mirror survived), the seed-from-
+# template step below must NOT overwrite it with a newly generated
+# random token — that would silently orphan the live credential the
+# mirror was carrying. So: if the mirror exists and carries a value,
+# seed agent.env from THAT value instead of generating a fresh one, and
+# skip the generate-new-token seed entirely.
+$migratedMirrorToken = $null
+if (Test-Path $TokenFile) {
+    $mirrorToken = (Get-Content $TokenFile -Raw).Trim()
+    if ($mirrorToken) {
+        $migratedMirrorToken = $mirrorToken
+    }
+}
+
 if (-not (Test-Path $EnvFile)) {
-    Info "Generating $EnvFile with a fresh token..."
-    $token = & $VenvPython -c "import secrets; print(secrets.token_urlsafe(32))"
-    (Get-Content $EnvExample) `
-        -replace 'replace-me-with-a-random-token', $token.Trim() `
-        | Set-Content -Path $EnvFile -Encoding utf8
-    Say "Wrote $EnvFile with a generated 32-byte token."
+    if ($migratedMirrorToken) {
+        Info "Seeding $EnvFile from the template using the live token found in the stale agent.token mirror..."
+        (Get-Content $EnvExample) `
+            -replace 'replace-me-with-a-random-token', $migratedMirrorToken `
+            | Set-Content -Path $EnvFile -Encoding utf8
+        Say "Wrote $EnvFile, carrying forward the token from $TokenFile (not overwritten with a fresh one)."
+    } else {
+        Info "Seeding $EnvFile from the template (one-time; see agent.env.example header)..."
+        $token = & $VenvPython -c "import secrets; print(secrets.token_urlsafe(32))"
+        (Get-Content $EnvExample) `
+            -replace 'replace-me-with-a-random-token', $token.Trim() `
+            | Set-Content -Path $EnvFile -Encoding utf8
+        Say "Wrote $EnvFile with a generated 32-byte token."
+    }
     Info "Edit it to set LLAUNCHER_AGENT_NODE_NAME / HOST / PORT as needed."
 } else {
-    Say "Env file already exists at $EnvFile - leaving it untouched."
+    # Loud on skip (issue #284): edits to the template are never read again
+    # after this first-install seed — agent.env is the only file either
+    # process consults from here on.
+    Info "agent.env already exists at $EnvFile — skipping template seed."
+    Info "  Edits to ${EnvExample} are never read after first install;"
+    Info "  edit $EnvFile directly (the live source) and re-run this script."
 
     # --- Migrate pre-#139 legacy keys (issue #281) --------------------
     # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* to
@@ -114,9 +161,9 @@ if (-not (Test-Path $EnvFile)) {
         }
     }
     if ($migratedKeys.Count -gt 0) {
-        # IMPORTANT: write WITHOUT a UTF-8 BOM — same reasoning as the
-        # token-mirror write below (PS 5.1 `Set-Content -Encoding utf8`
-        # prepends EF BB BF, which would corrupt the first key name).
+        # IMPORTANT: write WITHOUT a UTF-8 BOM — Windows PowerShell 5.1's
+        # `Set-Content -Encoding utf8` prepends EF BB BF, which would
+        # corrupt the first key name.
         [System.IO.File]::WriteAllLines(
             $EnvFile, $lines, (New-Object System.Text.UTF8Encoding($false)))
         Say ("Migrated pre-#139 legacy keys in ${EnvFile}: " + ($migratedKeys -join ', '))
@@ -138,40 +185,47 @@ function Set-OwnerOnlyAcl($path) {
 Set-OwnerOnlyAcl $EnvFile
 Say "Locked ACL on $EnvFile (current user only)."
 
-# Mirror the token to ~/.llauncher/agent.token so the UI process
-# (separate from the NSSM service) can authenticate against the local
-# agent via llauncher.agent.auth.resolve_agent_token(). The UI does
-# not inherit LLAUNCHER_AGENT_TOKEN from the service's environment, so
-# without this file the UI sees 401 on every non-exempt endpoint
-# (/node-info, etc.). Issue #125 (self-loop short-circuit for
-# /node-info) would obviate the auth path for the local node entirely,
-# but the auth source still needs to be discoverable for other reads
-# /writes and for the remote-node case.
-$tokenLine = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -First 1
+# --- Retire the agent.token mirror (issue #284) ------------------------
+# agent.env is now the single live source, parsed directly by both the
+# service and the UI (llauncher.core.agent_token.resolve_agent_token) — no
+# installer-maintained mirror file. A stale agent.token from a pre-#284
+# install is migrated in place, once, at the door (PARSE-AT-THE-DOOR):
+# if agent.env has NO usable token line, the mirror's value is moved into
+# agent.env before the mirror is deleted, so a live credential already in
+# use is never silently discarded. If agent.env already has a token, the
+# mirror is simply retired (deleted) since it is no longer read by anything.
+if (Test-Path $TokenFile) {
+    # -Last 1 (not -First 1): matches systemd's EnvironmentFile= parser
+    # semantics ("last wins") and llauncher.core.agent_token.parse_env_file
+    # — a duplicate-key agent.env must resolve identically across the
+    # installer's own check and the runtime the installer is validating
+    # against (issue #285).
+    $tokenLineExisting = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -Last 1
+    $tokenValueExisting = if ($tokenLineExisting) { ($tokenLineExisting -replace '^LLAUNCHER_AGENT_TOKEN=', '').Trim() } else { '' }
+    if (-not $tokenValueExisting) {
+        $mirrorToken = (Get-Content $TokenFile -Raw).Trim()
+        if ($mirrorToken) {
+            Add-Content -Path $EnvFile -Value "LLAUNCHER_AGENT_TOKEN=$mirrorToken" -Encoding utf8
+            Say "Migrated live token from $TokenFile into $EnvFile (agent.env has no token line)."
+        }
+    }
+    Remove-Item -Path $TokenFile -Force
+    Info "Retired by #284; live source is $EnvFile. Removed stale mirror $TokenFile."
+}
+
+# --- Fail loud if agent.env still has no usable token (issue #281/#284) -
+# -Last 1: same last-wins rationale as above (issue #285) — this check
+# must agree with what the agent process will actually resolve.
+$tokenLine = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -Last 1
 $tokenValue = if ($tokenLine) { ($tokenLine -replace '^LLAUNCHER_AGENT_TOKEN=', '').Trim() } else { '' }
-if ($tokenValue) {
-    # IMPORTANT: write WITHOUT a UTF-8 BOM. Windows PowerShell 5.1's
-    # `Set-Content -Encoding utf8` prepends EF BB BF, which decodes to
-    # U+FEFF and (since str.strip() doesn't strip it) leaks into the
-    # X-Api-Key header on the UI side, blowing up httpx's ascii-only
-    # header encoder. The reader in llauncher/agent/auth.py is also
-    # being widened to utf-8-sig as belt-and-braces, but the file
-    # should not contain a BOM in the first place — the token is pure
-    # ASCII (secrets.token_urlsafe), so a no-BOM UTF-8 (== ASCII)
-    # write is the right shape. Using .NET WriteAllText with an
-    # explicit UTF8Encoding($false) works across both PS 5.1 and 7+.
-    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllText($TokenFile, $tokenValue, $utf8NoBom)
-    Set-OwnerOnlyAcl $TokenFile
-    Say "Mirrored token to $TokenFile (ACL: current user only) so the UI can authenticate."
-} else {
-    # Fail loud, never trust-and-degrade (issue #281): without a mirrored,
-    # non-empty token the service comes up "green" but the agent silently
-    # auto-generates its own token under the SERVICE account's profile,
-    # and the UI gets 403 on every authed endpoint.
+if (-not $tokenValue) {
+    # Fail loud, never trust-and-degrade (issue #281): without a usable
+    # token line in the live source the service comes up "green" but the
+    # agent silently auto-generates its own token under the SERVICE
+    # account's profile, and the UI gets 403 on every authed endpoint.
     Die @"
 No usable LLAUNCHER_AGENT_TOKEN line found in ${EnvFile} (missing or empty value).
-Refusing to install the service without a mirrored, non-empty token. Fix one of:
+Refusing to install the service without a usable token in the live source. Fix one of:
   - Add a line to ${EnvFile}:  LLAUNCHER_AGENT_TOKEN=<token>
     (generate one:  python -c "import secrets; print(secrets.token_urlsafe(32))")
   - Or delete ${EnvFile} and re-run this script to regenerate it from the template.
@@ -186,6 +240,18 @@ foreach ($line in Get-Content $EnvFile) {
     if (-not $trim -or $trim.StartsWith('#')) { continue }
     $envPairs += $trim
 }
+
+# --- LocalSystem wrinkle (issue #284) -----------------------------------
+# NSSM defaults new services to the LocalSystem account, whose Path.home()
+# does NOT resolve to the installing operator's %USERPROFILE%. Without
+# this, the service process would resolve a DIFFERENT (or nonexistent)
+# agent.env than $EnvFile above, silently diverging from what the
+# operator's UI reads. Inject the resolved state dir explicitly so both
+# processes converge on the same live file. This does NOT re-introduce a
+# token mirror — it is a pointer to the single live source, not a copy of
+# its contents.
+$envPairs += "LAUNCHER_STATE_DIR=$EnvDir"
+Say "Injecting LAUNCHER_STATE_DIR=$EnvDir into the service environment (LocalSystem wrinkle, #284)."
 
 # --- Install or refresh service ---------------------------------------
 if (Get-Service $ServiceName -ErrorAction SilentlyContinue) {

--- a/tests/integration/test_agent_security_c1_c2.py
+++ b/tests/integration/test_agent_security_c1_c2.py
@@ -4,12 +4,13 @@ Covers:
 
 - **C1-d**: ``run_agent`` refuses to start on a non-loopback host with no
   token configured (exit code 2, stderr names the remediation paths).
-- **C1-e**: On a loopback start with no env token and no existing file,
-  the agent writes a fresh token to ``$HOME/.llauncher/agent.token``
-  with mode 0600 (parent dir 0700) and that token authenticates the
+- **C1-e**: On a loopback start with no env token and no existing
+  ``agent.env``, the agent generates a fresh token and writes it into
+  ``$HOME/.llauncher/agent.env`` (mode 0600, parent dir 0700) as a
+  ``LLAUNCHER_AGENT_TOKEN=`` line, and that token authenticates the
   resulting app.
-- **C1-reuse**: On a second loopback start with the file already
-  present, the agent reads it rather than regenerating.
+- **C1-reuse**: On a second loopback start with ``agent.env`` already
+  carrying a token line, the agent reads it rather than regenerating.
 - **C1-stdin**: With ``LLAUNCHER_AGENT_TOKEN=-`` the token is read from
   stdin and used to authenticate the resulting app.
 - **C2-default**: With no env overrides, ``AgentConfig.from_env()``
@@ -21,6 +22,13 @@ the refuse-to-start guard at the ``run_agent`` entry. Real-bind coverage
 is out of scope (the C2-a hook in the plan calls for socket
 introspection in a real-binary environment, which we leave to manual
 or follow-up work).
+
+Issue #284 retired the standalone ``agent.token`` mirror file; the live
+source read by both the agent and the UI is now ``agent.env`` (a
+``KEY=VALUE`` file), resolved via ``core.agent_token.default_env_path``.
+These tests were updated in place to assert against that file/key shape
+— the resolution-precedence and persistence-guard behavior under test is
+unchanged.
 """
 
 from __future__ import annotations
@@ -71,13 +79,13 @@ def test_run_agent_refuses_non_loopback_without_token(monkeypatch, tmp_path):
     from llauncher.agent import server as agent_srv
 
     monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
-    # Force token-file lookup at a missing path so the operator's real
-    # ~/.llauncher/agent.token cannot accidentally satisfy the guard.
+    # Force env-file lookup at a missing path so the operator's real
+    # ~/.llauncher/agent.env cannot accidentally satisfy the guard.
     # Token resolution was hoisted to core.agent_token (#171); patch the
     # canonical home so the implementation's internal lookup is affected.
     monkeypatch.setattr(
-        "llauncher.core.agent_token.default_token_path",
-        lambda: tmp_path / "definitely-missing.token",
+        "llauncher.core.agent_token.default_env_path",
+        lambda: tmp_path / "definitely-missing.env",
     )
 
     # uvicorn.run must never be reached.
@@ -141,10 +149,10 @@ def test_run_agent_refuses_legacy_only_token_env(monkeypatch, tmp_path):
 
 
 def _isolate_home(monkeypatch, tmp_path):
-    """Point HOME at a tmp dir and patch default_token_path() to honor it.
+    """Point HOME at a tmp dir and patch default_env_path() to honor it.
 
     ``Path.home()`` consults HOME on POSIX; we also patch the module's
-    ``default_token_path`` to defeat any import-time caching.
+    ``default_env_path`` to defeat any import-time caching.
     """
     home = tmp_path / "home"
     home.mkdir()
@@ -154,14 +162,14 @@ def _isolate_home(monkeypatch, tmp_path):
 
     # Token resolution was hoisted to core.agent_token (#171); patch there.
     monkeypatch.setattr(
-        "llauncher.core.agent_token.default_token_path",
-        lambda: home / ".llauncher" / "agent.token",
+        "llauncher.core.agent_token.default_env_path",
+        lambda: home / ".llauncher" / "agent.env",
     )
     return home
 
 
 def test_loopback_first_run_generates_token_file(monkeypatch, tmp_path):
-    """C1-e: first loopback start with no env token writes 0600 file."""
+    """C1-e: first loopback start with no env token writes 0600 agent.env."""
     from llauncher.agent.config import AgentConfig
     from llauncher.agent import server as agent_srv
 
@@ -182,20 +190,22 @@ def test_loopback_first_run_generates_token_file(monkeypatch, tmp_path):
     cfg = AgentConfig(host="127.0.0.1", port=9000)
     agent_srv.run_agent(cfg)
 
-    # Token file exists at the expected path.
-    token_file = home / ".llauncher" / "agent.token"
-    assert token_file.exists(), "agent.token must be auto-generated on first run"
+    # agent.env exists at the expected path.
+    env_file = home / ".llauncher" / "agent.env"
+    assert env_file.exists(), "agent.env must be auto-generated on first run"
 
     # Mode 0600 on the file.
-    file_mode = stat.S_IMODE(token_file.stat().st_mode)
+    file_mode = stat.S_IMODE(env_file.stat().st_mode)
     assert file_mode == 0o600, f"expected 0600, got {oct(file_mode)}"
 
     # Parent dir 0700.
-    parent_mode = stat.S_IMODE(token_file.parent.stat().st_mode)
+    parent_mode = stat.S_IMODE(env_file.parent.stat().st_mode)
     assert parent_mode == 0o700, f"expected 0700 on parent, got {oct(parent_mode)}"
 
-    # File content is a non-trivial secret.
-    token = token_file.read_text(encoding="utf-8").strip()
+    # Content is a LLAUNCHER_AGENT_TOKEN= line with a non-trivial secret.
+    content = env_file.read_text(encoding="utf-8").strip()
+    assert content.startswith("LLAUNCHER_AGENT_TOKEN=")
+    token = content.split("=", 1)[1]
     assert len(token) >= 32
 
     # Stderr announced the token exactly once.
@@ -205,18 +215,18 @@ def test_loopback_first_run_generates_token_file(monkeypatch, tmp_path):
 
 
 def test_loopback_second_run_reuses_existing_token(monkeypatch, tmp_path):
-    """C1-reuse: an existing agent.token is honored rather than rewritten."""
+    """C1-reuse: an existing agent.env token line is honored, not rewritten."""
     from llauncher.agent.config import AgentConfig
     from llauncher.agent import server as agent_srv
 
     monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
     home = _isolate_home(monkeypatch, tmp_path)
 
-    # Pre-seed an existing token file.
-    seeded_path = home / ".llauncher" / "agent.token"
+    # Pre-seed an existing agent.env with a token line.
+    seeded_path = home / ".llauncher" / "agent.env"
     seeded_path.parent.mkdir(parents=True)
     seeded_path.parent.chmod(0o700)
-    seeded_path.write_text("preexisting-token-value\n", encoding="utf-8")
+    seeded_path.write_text("LLAUNCHER_AGENT_TOKEN=preexisting-token-value\n", encoding="utf-8")
     seeded_path.chmod(0o600)
 
     monkeypatch.setattr("uvicorn.run", lambda *a, **kw: None)
@@ -227,7 +237,10 @@ def test_loopback_second_run_reuses_existing_token(monkeypatch, tmp_path):
     agent_srv.run_agent(cfg)
 
     # File content unchanged.
-    assert seeded_path.read_text(encoding="utf-8").strip() == "preexisting-token-value"
+    assert (
+        seeded_path.read_text(encoding="utf-8").strip()
+        == "LLAUNCHER_AGENT_TOKEN=preexisting-token-value"
+    )
     # Stderr did NOT announce a new generated token (the announcement
     # message string is unique to the generate-and-write path).
     assert "Generated new auth token" not in buf.getvalue()

--- a/tests/ui/test_nodes_tab.py
+++ b/tests/ui/test_nodes_tab.py
@@ -117,8 +117,8 @@ class TestAddNodeFormSmoke:
 
         help_text = _input_by_label(at, "API Key").help
         assert "llauncher-agent print-token" in help_text
-        assert "cat ~/.llauncher/agent.token" in help_text
-        assert "Get-Content $env:USERPROFILE\\.llauncher\\agent.token" in help_text
+        assert "~/.llauncher/agent.env" in help_text
+        assert "$env:USERPROFILE\\.llauncher\\agent.env" in help_text
         assert "ADR-003" in help_text
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -987,7 +987,7 @@ class TestUtilityFunctions:
 
         # No token anywhere.
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
-        # Force the on-disk token file lookup to a missing path so the
+        # Force the on-disk env-file lookup to a missing path so the
         # refuse-to-start branch is exercised even if the operator's real
         # home has a file present.
         from pathlib import Path
@@ -995,8 +995,8 @@ class TestUtilityFunctions:
         # Token resolution was hoisted to core.agent_token (#171); patch the
         # canonical home so run_agent's resolver honors the missing path.
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path",
-            lambda: Path("/nonexistent/llauncher/agent.token"),
+            "llauncher.core.agent_token.default_env_path",
+            lambda: Path("/nonexistent/llauncher/agent.env"),
         )
 
         monkeypatch.setattr("socket.gethostname", lambda: "test-host")
@@ -1151,18 +1151,18 @@ class TestUtilityFunctions:
         assert exited_with == 0
 
     def test_main_print_token_from_file(self, monkeypatch, capsys, tmp_path):
-        """print-token falls back to the on-disk token file (#134)."""
+        """print-token falls back to the on-disk agent.env (#134)."""
         from llauncher.agent.server import main
         import sys
 
         monkeypatch.setattr("sys.argv", ["llauncher-agent", "print-token"])
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
-        token_file = tmp_path / "agent.token"
-        token_file.write_text("sekret-from-file\n", encoding="utf-8")
+        env_file = tmp_path / "agent.env"
+        env_file.write_text("LLAUNCHER_AGENT_TOKEN=sekret-from-file\n", encoding="utf-8")
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path",
-            lambda: token_file,
+            "llauncher.core.agent_token.default_env_path",
+            lambda: env_file,
         )
 
         exited_with = None
@@ -1187,11 +1187,11 @@ class TestUtilityFunctions:
         monkeypatch.setattr("sys.argv", ["llauncher-agent", "print-token"])
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
-        # Point at a non-existent token file so resolution returns None
+        # Point at a non-existent env file so resolution returns None
         # (allow_generate=False is enforced by the subcommand).
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path",
-            lambda: tmp_path / "does-not-exist.token",
+            "llauncher.core.agent_token.default_env_path",
+            lambda: tmp_path / "does-not-exist.env",
         )
 
         exited_with = None

--- a/tests/unit/test_agent_auth_token_file.py
+++ b/tests/unit/test_agent_auth_token_file.py
@@ -1,4 +1,4 @@
-"""Regression tests for ``llauncher.agent.auth._read_token_file``.
+"""Regression tests for ``llauncher.agent.auth._read_env_file_token``.
 
 Specifically guards the BOM-tolerance widening that landed after a
 Windows operator hit ``UnicodeEncodeError: 'ascii' codec can't encode
@@ -9,7 +9,7 @@ Failure chain that motivated the widening:
 
 1. Windows PowerShell 5.1's ``Set-Content -Encoding utf8`` writes
    ``EF BB BF`` at the head of the file.
-2. ``_read_token_file`` previously decoded as plain ``utf-8`` (so the
+2. The env-file reader previously decoded as plain ``utf-8`` (so the
    BOM survived as ``U+FEFF``) and called ``.strip()`` (which does NOT
    strip ``U+FEFF`` — it's zero-width non-breaking space, not
    whitespace by Python's classification).
@@ -17,9 +17,17 @@ Failure chain that motivated the widening:
    ASCII-encode when serializing the ``X-Api-Key`` header, raising.
 
 The fix is two-pronged: ``scripts/windows/install.ps1`` writes without
-a BOM, AND ``_read_token_file`` decodes as ``utf-8-sig`` so any
-upstream writer that re-introduces a BOM cannot reach the header
-encoder. These tests pin the reader half.
+a BOM, AND ``parse_env_file``/``_read_env_file_token`` decode as
+``utf-8-sig`` so any upstream writer that re-introduces a BOM cannot
+reach the header encoder. These tests pin the reader half.
+
+Issue #284 retired the standalone ``agent.token`` mirror file and its
+bare-value reader (``_read_token_file``); the live source is now
+``agent.env``, a ``KEY=VALUE`` file, read via ``_read_env_file_token``
+(a thin wrapper over ``parse_env_file`` scoped to
+``LLAUNCHER_AGENT_TOKEN``). These tests were updated in place to write
+``LLAUNCHER_AGENT_TOKEN=<value>`` lines rather than bare token files —
+the BOM-tolerance behavior under test is unchanged.
 """
 
 from __future__ import annotations
@@ -27,14 +35,14 @@ from __future__ import annotations
 
 def test_read_token_file_strips_utf8_bom(tmp_path):
     """A token file with a UTF-8 BOM yields the bare token (no ``\\ufeff``)."""
-    from llauncher.agent.auth import _read_token_file
+    from llauncher.agent.auth import _read_env_file_token
 
     token = "abc123-no-bom-here"
-    path = tmp_path / "agent.token"
+    path = tmp_path / "agent.env"
     # Bytes path so we have full control over the BOM placement.
-    path.write_bytes(b"\xef\xbb\xbf" + token.encode("ascii"))
+    path.write_bytes(b"\xef\xbb\xbf" + f"LLAUNCHER_AGENT_TOKEN={token}".encode("ascii"))
 
-    result = _read_token_file(path)
+    result = _read_env_file_token(path)
 
     assert result == token
     assert result is not None
@@ -43,38 +51,40 @@ def test_read_token_file_strips_utf8_bom(tmp_path):
 
 def test_read_token_file_strips_bom_and_trailing_newline(tmp_path):
     """The two stripping behaviors compose — BOM at head, ``\\n`` at tail."""
-    from llauncher.agent.auth import _read_token_file
+    from llauncher.agent.auth import _read_env_file_token
 
     token = "trailing-newline-token"
-    path = tmp_path / "agent.token"
-    path.write_bytes(b"\xef\xbb\xbf" + token.encode("ascii") + b"\n")
+    path = tmp_path / "agent.env"
+    path.write_bytes(
+        b"\xef\xbb\xbf" + f"LLAUNCHER_AGENT_TOKEN={token}".encode("ascii") + b"\n"
+    )
 
-    assert _read_token_file(path) == token
+    assert _read_env_file_token(path) == token
 
 
 def test_read_token_file_no_bom_still_works(tmp_path):
     """``utf-8-sig`` is a strict superset of ``utf-8`` for BOM-less input."""
-    from llauncher.agent.auth import _read_token_file
+    from llauncher.agent.auth import _read_env_file_token
 
     token = "plain-utf8-token"
-    path = tmp_path / "agent.token"
-    path.write_text(token, encoding="utf-8")  # no BOM
+    path = tmp_path / "agent.env"
+    path.write_text(f"LLAUNCHER_AGENT_TOKEN={token}", encoding="utf-8")  # no BOM
 
-    assert _read_token_file(path) == token
+    assert _read_env_file_token(path) == token
 
 
 def test_read_token_file_bom_only_returns_none(tmp_path):
-    """A file containing only a BOM is treated as empty — returns ``None``."""
-    from llauncher.agent.auth import _read_token_file
+    """A file containing only a BOM (no token line) is treated as empty."""
+    from llauncher.agent.auth import _read_env_file_token
 
-    path = tmp_path / "agent.token"
+    path = tmp_path / "agent.env"
     path.write_bytes(b"\xef\xbb\xbf")  # BOM, then nothing
 
-    assert _read_token_file(path) is None
+    assert _read_env_file_token(path) is None
 
 
 def test_read_token_file_missing_returns_none(tmp_path):
     """Pre-existing behavior: a missing file returns ``None`` (not raises)."""
-    from llauncher.agent.auth import _read_token_file
+    from llauncher.agent.auth import _read_env_file_token
 
-    assert _read_token_file(tmp_path / "does-not-exist") is None
+    assert _read_env_file_token(tmp_path / "does-not-exist") is None

--- a/tests/unit/test_agent_env_single_source.py
+++ b/tests/unit/test_agent_env_single_source.py
@@ -1,0 +1,235 @@
+"""Unit tests for issue #284 — single live source (``agent.env``).
+
+Covers the surface introduced/changed by #284:
+
+- ``parse_env_file``: the ``KEY=VALUE`` reader itself — blank lines,
+  comments, duplicate-key last-wins (matching systemd's
+  ``EnvironmentFile=`` semantics, issue #285), UTF-8 BOM tolerance, a
+  missing file, and an empty value.
+- ``resolve_agent_token`` precedence with the renamed ``env_path``
+  parameter: explicit env var still wins; ``agent.env`` is the fallback
+  source; auto-generate persists *into* ``agent.env`` (not a standalone
+  file).
+- **Regression, behavioral not grep**: nothing in the resolution path
+  reads a standalone ``agent.token`` file even when one is present and
+  populated — the retired mirror class must have zero read-side effect
+  on the resolved token.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llauncher.core.agent_token import (
+    _generate_and_persist_token,
+    _read_env_file_token,
+    parse_env_file,
+    resolve_agent_token,
+)
+
+
+# ─────────── parse_env_file: KEY=VALUE reader semantics ────────────────
+
+
+def test_parse_env_file_basic_key_value(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text("LLAUNCHER_AGENT_TOKEN=abc123\nLLAUNCHER_AGENT_PORT=8765\n")
+
+    result = parse_env_file(path)
+
+    assert result == {"LLAUNCHER_AGENT_TOKEN": "abc123", "LLAUNCHER_AGENT_PORT": "8765"}
+
+
+def test_parse_env_file_skips_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text("\n\nLLAUNCHER_AGENT_TOKEN=abc123\n\n\n")
+
+    assert parse_env_file(path) == {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+
+
+def test_parse_env_file_skips_comment_lines(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text(
+        "# this is a comment\n"
+        "LLAUNCHER_AGENT_TOKEN=abc123\n"
+        "  # indented comment, still skipped\n"
+    )
+
+    assert parse_env_file(path) == {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+
+
+def test_parse_env_file_duplicate_key_last_wins(tmp_path: Path) -> None:
+    """Matches systemd's EnvironmentFile= semantics exactly (issue #285)."""
+    path = tmp_path / "agent.env"
+    path.write_text(
+        "LLAUNCHER_AGENT_TOKEN=first-value\n"
+        "LLAUNCHER_AGENT_TOKEN=second-value\n"
+        "LLAUNCHER_AGENT_TOKEN=last-value\n"
+    )
+
+    assert parse_env_file(path)["LLAUNCHER_AGENT_TOKEN"] == "last-value"
+
+
+def test_parse_env_file_bom_stripped_from_first_key(tmp_path: Path) -> None:
+    """A leading UTF-8 BOM (PowerShell 5.1 ``-Encoding utf8``) must not
+    leak into the first key's name or value."""
+    path = tmp_path / "agent.env"
+    path.write_bytes(b"\xef\xbb\xbfLLAUNCHER_AGENT_TOKEN=abc123\n")
+
+    result = parse_env_file(path)
+
+    assert result == {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+    assert "LLAUNCHER_AGENT_TOKEN" in result  # not "﻿LLAUNCHER_AGENT_TOKEN"
+
+
+def test_parse_env_file_missing_file_returns_empty_dict(tmp_path: Path) -> None:
+    assert parse_env_file(tmp_path / "does-not-exist.env") == {}
+
+
+def test_parse_env_file_empty_value(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text("LLAUNCHER_AGENT_NODE_NAME=\nLLAUNCHER_AGENT_TOKEN=abc123\n")
+
+    result = parse_env_file(path)
+
+    assert result["LLAUNCHER_AGENT_NODE_NAME"] == ""
+    assert result["LLAUNCHER_AGENT_TOKEN"] == "abc123"
+
+
+def test_parse_env_file_line_without_equals_is_skipped(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text("not-a-valid-line\nLLAUNCHER_AGENT_TOKEN=abc123\n")
+
+    assert parse_env_file(path) == {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+
+
+def test_parse_env_file_line_with_empty_key_is_skipped(tmp_path: Path) -> None:
+    """A line like ``=value`` (no key before the ``=``) is malformed and
+    skipped rather than producing a bogus ``""`` dict key."""
+    path = tmp_path / "agent.env"
+    path.write_text("=orphan-value\nLLAUNCHER_AGENT_TOKEN=abc123\n")
+
+    result = parse_env_file(path)
+
+    assert result == {"LLAUNCHER_AGENT_TOKEN": "abc123"}
+    assert "" not in result
+
+
+def test_read_env_file_token_empty_value_counts_as_absent(tmp_path: Path) -> None:
+    path = tmp_path / "agent.env"
+    path.write_text("LLAUNCHER_AGENT_TOKEN=\n")
+
+    assert _read_env_file_token(path) is None
+
+
+# ─────────── resolve_agent_token: precedence with env_path ──────────────
+
+
+def test_resolve_agent_token_env_var_wins_over_env_file(tmp_path, monkeypatch):
+    """Explicit LLAUNCHER_AGENT_TOKEN always wins, even with a different
+    value present in agent.env."""
+    env_path = tmp_path / "agent.env"
+    env_path.write_text("LLAUNCHER_AGENT_TOKEN=from-file\n")
+    monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "from-explicit-env")
+
+    result = resolve_agent_token(env_path=env_path)
+
+    assert result == "from-explicit-env"
+
+
+def test_resolve_agent_token_falls_back_to_env_file(tmp_path, monkeypatch):
+    env_path = tmp_path / "agent.env"
+    env_path.write_text("LLAUNCHER_AGENT_TOKEN=from-file\n")
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+    result = resolve_agent_token(env_path=env_path)
+
+    assert result == "from-file"
+
+
+def test_resolve_agent_token_generates_into_env_file_when_absent(tmp_path, monkeypatch):
+    """allow_generate=True with no env/file token creates agent.env with
+    a LLAUNCHER_AGENT_TOKEN= line (not a standalone token file)."""
+    env_path = tmp_path / "agent.env"
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+    assert not env_path.exists()
+
+    result = resolve_agent_token(env_path=env_path, allow_generate=True)
+
+    assert result
+    assert env_path.exists()
+    assert env_path.read_text().strip() == f"LLAUNCHER_AGENT_TOKEN={result}"
+
+
+def test_resolve_agent_token_no_generate_returns_none(tmp_path, monkeypatch):
+    env_path = tmp_path / "agent.env"
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+    result = resolve_agent_token(env_path=env_path, allow_generate=False)
+
+    assert result is None
+    assert not env_path.exists(), "allow_generate=False must not create the file"
+
+
+# ─────────── Regression (behavioral): agent.token is never read ────────
+
+
+def test_standalone_agent_token_file_is_never_consulted(tmp_path, monkeypatch):
+    """A populated, sibling ``agent.token`` file must have ZERO effect on
+    resolution — proven behaviorally (the resolved value must differ from
+    the mirror's content), not merely by grepping the source for reads.
+
+    This is the direct regression guard for issue #284: the mirror class
+    used to be a second read path an installer had to keep in sync; the
+    runtime must now be blind to its existence entirely.
+    """
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    stale_mirror = state_dir / "agent.token"
+    stale_mirror.write_text("stale-mirror-value-must-not-be-read")
+
+    env_path = state_dir / "agent.env"
+    env_path.write_text("LLAUNCHER_AGENT_TOKEN=live-source-value\n")
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+
+    result = resolve_agent_token(env_path=env_path, allow_generate=False)
+
+    assert result == "live-source-value"
+    assert result != "stale-mirror-value-must-not-be-read"
+    # The mirror is untouched — resolution neither reads nor mutates it.
+    assert stale_mirror.read_text() == "stale-mirror-value-must-not-be-read"
+
+
+def test_generate_path_ignores_sibling_agent_token_file(tmp_path, monkeypatch):
+    """Even when agent.env is absent (triggering generate-and-persist), a
+    sibling agent.token with a real value must NOT be adopted — the
+    generator mints fresh and writes to agent.env, never falling back to
+    the retired mirror shape.
+    """
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    stale_mirror = state_dir / "agent.token"
+    stale_mirror.write_text("stale-mirror-value")
+
+    env_path = state_dir / "agent.env"
+    monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
+    assert not env_path.exists()
+
+    result = resolve_agent_token(env_path=env_path, allow_generate=True)
+
+    assert result != "stale-mirror-value"
+    assert env_path.exists()
+    assert env_path.read_text().strip() == f"LLAUNCHER_AGENT_TOKEN={result}"
+
+
+def test_generate_and_persist_token_never_touches_token_file_name(tmp_path):
+    """Direct unit check on the persistence primitive: given an agent.env
+    path, the function writes exactly that path — never a sibling named
+    agent.token."""
+    env_path = tmp_path / "agent.env"
+    sibling_token_path = tmp_path / "agent.token"
+
+    _generate_and_persist_token(env_path)
+
+    assert env_path.exists()
+    assert not sibling_token_path.exists()

--- a/tests/unit/test_agent_token_generate.py
+++ b/tests/unit/test_agent_token_generate.py
@@ -5,6 +5,12 @@ on filesystems where ``chmod`` is a no-op or fails (e.g. NTFS via WSL), the
 parent-dir 0700 and file 0600 hardening steps must degrade silently rather
 than abort token materialization. The file write itself is the load-bearing
 step and must still succeed.
+
+Issue #284 changed the persist target from a standalone ``agent.token``
+file (bare value) to a ``LLAUNCHER_AGENT_TOKEN=<value>`` line appended
+into (or seeding) ``agent.env`` — the single live source both the agent
+and the UI parse directly. These tests were updated in place; the
+chmod-degradation behavior under test is unchanged.
 """
 
 from __future__ import annotations
@@ -18,27 +24,89 @@ from llauncher.core.agent_token import _generate_and_persist_token
 def test_generate_token_survives_chmod_oserror(tmp_path: Path) -> None:
     """Both ``chmod`` calls raising ``OSError`` still yields a written token.
 
-    Patching ``Path.chmod`` to always raise exercises the parent-dir branch
-    (lines 110-114) on the first call and the file branch (lines 122-123) on
-    the second; the token is generated, persisted, and returned regardless.
+    Patching ``Path.chmod`` to always raise exercises the parent-dir and
+    file chmod fallbacks; the token is generated, persisted, and returned
+    regardless.
     """
-    target = tmp_path / "state" / "agent.token"
+    target = tmp_path / "state" / "agent.env"
 
     with patch.object(Path, "chmod", side_effect=OSError("chmod unsupported")):
         token = _generate_and_persist_token(target)
 
     assert token
     assert target.exists()
-    # File content is the token plus the trailing newline the writer appends.
-    assert target.read_text(encoding="utf-8").strip() == token
+    assert target.read_text(encoding="utf-8").strip() == f"LLAUNCHER_AGENT_TOKEN={token}"
 
 
 def test_generate_token_chmods_when_supported(tmp_path: Path) -> None:
     """Happy path: chmod succeeds, token persisted (no fallback taken)."""
-    target = tmp_path / "state" / "agent.token"
+    target = tmp_path / "state" / "agent.env"
 
     token = _generate_and_persist_token(target)
 
     assert token
     assert target.exists()
-    assert target.read_text(encoding="utf-8").strip() == token
+    assert target.read_text(encoding="utf-8").strip() == f"LLAUNCHER_AGENT_TOKEN={token}"
+
+
+def test_generate_token_appends_to_existing_env_file(tmp_path: Path) -> None:
+    """Existing ``agent.env`` content (other keys) survives the append.
+
+    The only way this function is reached is when ``agent.env`` exists but
+    has no usable ``LLAUNCHER_AGENT_TOKEN=`` line — the append must
+    preserve every prior line verbatim.
+    """
+    target = tmp_path / "agent.env"
+    target.write_text("LLAUNCHER_AGENT_HOST=0.0.0.0\nLLAUNCHER_AGENT_PORT=8765\n")
+
+    token = _generate_and_persist_token(target)
+
+    text = target.read_text(encoding="utf-8")
+    assert "LLAUNCHER_AGENT_HOST=0.0.0.0" in text
+    assert "LLAUNCHER_AGENT_PORT=8765" in text
+    assert f"LLAUNCHER_AGENT_TOKEN={token}" in text
+
+
+def test_generate_token_append_inserts_newline_when_missing(tmp_path: Path) -> None:
+    """A last existing line with no trailing newline must not fuse with
+    the appended key.
+
+    Without a separator guard, appending directly onto
+    ``...PORT=8765`` (no trailing ``\\n``) would produce
+    ``...PORT=8765LLAUNCHER_AGENT_TOKEN=<token>`` on one physical line —
+    unparseable by ``parse_env_file`` (the whole line has no valid
+    ``KEY=VALUE`` shape once a stray ``LLAUNCHER_AGENT_TOKEN=`` is fused
+    into the previous value). This pins the fix: a missing trailing
+    newline is detected and a separator is inserted before the append.
+    """
+    from llauncher.core.agent_token import parse_env_file
+
+    target = tmp_path / "agent.env"
+    target.write_text("LLAUNCHER_AGENT_PORT=8765")  # deliberately no \n
+
+    token = _generate_and_persist_token(target)
+
+    parsed = parse_env_file(target)
+    assert parsed["LLAUNCHER_AGENT_PORT"] == "8765"
+    assert parsed["LLAUNCHER_AGENT_TOKEN"] == token
+
+
+def test_generate_token_append_preserves_existing_file_permissions(tmp_path: Path) -> None:
+    """Appending to an existing agent.env must NOT tighten its mode.
+
+    systemd ``--system`` mode's agent.env is 0640/group-``inference`` so
+    the UI can read it via group membership; if this function ever
+    silently re-chmod'd an existing file to 0600 it would break that
+    cross-process read path the moment the agent auto-generates into an
+    env file that has other keys but no token line yet.
+    """
+    import stat as stat_mod
+
+    target = tmp_path / "agent.env"
+    target.write_text("LLAUNCHER_AGENT_HOST=0.0.0.0\n")
+    target.chmod(0o640)
+
+    _generate_and_persist_token(target)
+
+    mode = stat_mod.S_IMODE(target.stat().st_mode)
+    assert mode == 0o640, f"expected append to preserve 0640, got {oct(mode)}"

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -206,7 +206,7 @@ class TestRemoteDoesNotImportAgent:
         # exercising the resolver end-to-end with no filesystem writes.
         token = resolve_agent_token(
             env_value="",
-            token_path=__import__("pathlib").Path("/nonexistent/x.token"),
+            env_path=__import__("pathlib").Path("/nonexistent/agent.env"),
             allow_generate=False,
         )
         assert token is None

--- a/tests/unit/test_env_var_naming_regression.py
+++ b/tests/unit/test_env_var_naming_regression.py
@@ -73,7 +73,7 @@ def test_resolve_uses_new_env_var_name(monkeypatch, tmp_path):
     monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "correct-horse-battery-staple")
     monkeypatch.delenv("LAUNCHER_AGENT_TOKEN", raising=False)
 
-    result = resolve_agent_token(token_path=tmp_path / "agent.token")
+    result = resolve_agent_token(env_path=tmp_path / "agent.env")
 
     assert result == "correct-horse-battery-staple"
 
@@ -89,10 +89,10 @@ def test_resolve_ignores_old_env_var_name(monkeypatch, tmp_path):
 
     monkeypatch.setenv("LAUNCHER_AGENT_TOKEN", "stale-typo-value")
     monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
-    token_path = tmp_path / "agent.token"
-    assert not token_path.exists()
+    env_path_local = tmp_path / "agent.env"
+    assert not env_path_local.exists()
 
-    result = resolve_agent_token(token_path=token_path, allow_generate=False)
+    result = resolve_agent_token(env_path=env_path_local, allow_generate=False)
 
     assert result is None
 
@@ -104,7 +104,7 @@ def test_resolve_prefers_new_when_both_set(monkeypatch, tmp_path):
     monkeypatch.setenv("LAUNCHER_AGENT_TOKEN", "stale")
     monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "fresh")
 
-    result = resolve_agent_token(token_path=tmp_path / "agent.token")
+    result = resolve_agent_token(env_path=tmp_path / "agent.env")
 
     assert result == "fresh"
 
@@ -117,7 +117,7 @@ def test_resolve_stdin_trigger_uses_new_name(monkeypatch, tmp_path):
     monkeypatch.delenv("LAUNCHER_AGENT_TOKEN", raising=False)
     monkeypatch.setattr(auth_mod.sys, "stdin", io.StringIO("piped-token\n"))
 
-    result = auth_mod.resolve_agent_token(token_path=tmp_path / "agent.token")
+    result = auth_mod.resolve_agent_token(env_path=tmp_path / "agent.env")
 
     assert result == "piped-token"
 
@@ -134,10 +134,10 @@ def test_resolve_stdin_trigger_old_name_does_not_fire(monkeypatch, tmp_path):
 
     monkeypatch.setenv("LAUNCHER_AGENT_TOKEN", "-")
     monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
-    token_path = tmp_path / "agent.token"
-    assert not token_path.exists()
+    env_path_local = tmp_path / "agent.env"
+    assert not env_path_local.exists()
 
-    result = resolve_agent_token(token_path=token_path, allow_generate=False)
+    result = resolve_agent_token(env_path=env_path_local, allow_generate=False)
 
     assert result is None
 

--- a/tests/unit/test_nodes_tab.py
+++ b/tests/unit/test_nodes_tab.py
@@ -55,6 +55,6 @@ class TestAddNodeFormProvisioningCopy:
         assert len(api_key_calls) == 1
         help_text = api_key_calls[0].kwargs["help"]
         assert "llauncher-agent print-token" in help_text
-        assert "cat ~/.llauncher/agent.token" in help_text
-        assert "Get-Content $env:USERPROFILE\\.llauncher\\agent.token" in help_text
+        assert "~/.llauncher/agent.env" in help_text
+        assert "$env:USERPROFILE\\.llauncher\\agent.env" in help_text
         assert "ADR-003" in help_text

--- a/tests/unit/test_registry_extended.py
+++ b/tests/unit/test_registry_extended.py
@@ -443,11 +443,11 @@ class TestLocalNodeTokenResolution:
             }
         }))
         monkeypatch.setattr("llauncher.remote.registry.NODES_FILE", nodes_file)
-        # Token file the resolver will read.
-        token_path = tmp_path / "agent.token"
-        token_path.write_text("test-token-abc123")
+        # agent.env the resolver will parse.
+        env_path = tmp_path / "agent.env"
+        env_path.write_text("LLAUNCHER_AGENT_TOKEN=test-token-abc123\n")
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_env_path", lambda: env_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -467,10 +467,10 @@ class TestLocalNodeTokenResolution:
             }
         }))
         monkeypatch.setattr("llauncher.remote.registry.NODES_FILE", nodes_file)
-        # No token file, no env var → resolver returns None.
-        token_path = tmp_path / "nonexistent.token"
+        # No agent.env, no env var → resolver returns None.
+        env_path = tmp_path / "nonexistent.env"
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_env_path", lambda: env_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -499,10 +499,10 @@ class TestLocalNodeTokenResolution:
             },
         }))
         monkeypatch.setattr("llauncher.remote.registry.NODES_FILE", nodes_file)
-        token_path = tmp_path / "agent.token"
-        token_path.write_text("local-token-only")
+        env_path = tmp_path / "agent.env"
+        env_path.write_text("LLAUNCHER_AGENT_TOKEN=local-token-only\n")
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: token_path
+            "llauncher.core.agent_token.default_env_path", lambda: env_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
 
@@ -551,11 +551,11 @@ class TestRemoteNodeTokenPersistence:
         tokens_file = tmp_path / "node_tokens.json"
         monkeypatch.setattr(registry_mod, "NODES_FILE", nodes_file)
         monkeypatch.setattr(registry_mod, "NODE_TOKENS_FILE", tokens_file)
-        # Local-token resolver: no env, no on-disk agent.token in tmp.
+        # Local-token resolver: no env, no on-disk agent.env in tmp.
         # Prevents the resolver from picking up the real user's token.
-        agent_token_path = tmp_path / "agent.token-absent"
+        agent_env_path = tmp_path / "agent.env-absent"
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: agent_token_path
+            "llauncher.core.agent_token.default_env_path", lambda: agent_env_path
         )
         monkeypatch.delenv("LLAUNCHER_AGENT_TOKEN", raising=False)
         return nodes_file, tokens_file
@@ -625,15 +625,15 @@ class TestRemoteNodeTokenPersistence:
         assert "api_key" not in on_disk["remote-d"]
 
     def test_local_node_excluded_from_tokens_file(self, tmp_path, monkeypatch):
-        """The ``local`` entry's token belongs in ``agent.token``, NOT
+        """The ``local`` entry's token belongs in ``agent.env``, NOT
         the sidecar — duplicating it here would create drift.
         """
         nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
-        # Pre-seed an agent.token so _populate_local_token has a value.
-        agent_token = tmp_path / "agent.token"
-        agent_token.write_text("local-secret")
+        # Pre-seed an agent.env so _populate_local_token has a value.
+        agent_env = tmp_path / "agent.env"
+        agent_env.write_text("LLAUNCHER_AGENT_TOKEN=local-secret\n")
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: agent_token
+            "llauncher.core.agent_token.default_env_path", lambda: agent_env
         )
 
         reg = NodeRegistry()
@@ -669,7 +669,7 @@ class TestRemoteNodeTokenPersistence:
     def test_missing_tokens_file_leaves_api_keys_none(self, tmp_path, monkeypatch):
         """nodes.json says has_api_key=True but the sidecar is missing
         → load succeeds, that remote's api_key is None. No synthesis
-        from the local agent.token (credential-confusion guard).
+        from the local agent.env (credential-confusion guard).
         """
         nodes_file, tokens_file = self._patch_paths(monkeypatch, tmp_path)
         # nodes.json claims a token for remote-h.
@@ -679,11 +679,11 @@ class TestRemoteNodeTokenPersistence:
                 "port": 8765, "timeout": 5.0, "has_api_key": True,
             }
         }))
-        # And a local agent.token exists — but it must NOT bleed through.
-        agent_token = tmp_path / "agent.token"
-        agent_token.write_text("would-be-credential-confusion")
+        # And a local agent.env exists — but it must NOT bleed through.
+        agent_env = tmp_path / "agent.env"
+        agent_env.write_text("LLAUNCHER_AGENT_TOKEN=would-be-credential-confusion\n")
         monkeypatch.setattr(
-            "llauncher.core.agent_token.default_token_path", lambda: agent_token
+            "llauncher.core.agent_token.default_env_path", lambda: agent_env
         )
         assert not tokens_file.exists()
 

--- a/tests/unit/test_state_dir.py
+++ b/tests/unit/test_state_dir.py
@@ -1,7 +1,7 @@
 """Tests for the single LAUNCHER_STATE_DIR durable-state base (issue #196).
 
 The durable-state paths (config.json, nodes.json, node_tokens.json,
-agent.token, run/, audit.jsonl, logs/) all derive from one
+agent.env, run/, audit.jsonl, logs/) all derive from one
 env-configurable base, ``LAUNCHER_STATE_DIR``, defined in
 ``llauncher.core.settings``.
 
@@ -10,7 +10,7 @@ import time** (``settings.LAUNCHER_RUN_DIR``, ``config.CONFIG_DIR``,
 ``registry.NODES_FILE``, ...). They cannot be re-resolved by merely
 setting an env var after import, so these tests use
 ``importlib.reload`` under a patched environment to re-execute the
-module bodies. ``llauncher.agent.auth.default_token_path`` is the
+module bodies. ``llauncher.agent.auth.default_env_path`` is the
 exception — it resolves the base lazily at call time, so it picks up a
 ``monkeypatch.setattr`` on ``settings.LAUNCHER_STATE_DIR`` without a
 reload.
@@ -77,7 +77,7 @@ def test_defaults_under_home_llauncher_when_unset(monkeypatch, tmp_path):
     assert registry_mod.NODE_TOKENS_FILE == base / "node_tokens.json"
     # auth resolves lazily at call time
     monkeypatch.setattr(settings_mod, "LAUNCHER_STATE_DIR", base)
-    assert auth_mod.default_token_path() == base / "agent.token"
+    assert auth_mod.default_env_path() == base / "agent.env"
 
 
 # --- (b) LAUNCHER_STATE_DIR redirects every derived path ----------------
@@ -100,7 +100,7 @@ def test_state_dir_redirects_all_paths(monkeypatch, tmp_path):
     assert registry_mod.NODES_FILE == base / "nodes.json"
     assert registry_mod.NODE_TOKENS_FILE == base / "node_tokens.json"
     monkeypatch.setattr(settings_mod, "LAUNCHER_STATE_DIR", base)
-    assert auth_mod.default_token_path() == base / "agent.token"
+    assert auth_mod.default_env_path() == base / "agent.env"
 
 
 def test_state_dir_is_not_home_relative(monkeypatch, tmp_path):

--- a/tests/unit/test_windows_agent_env_example_docs.py
+++ b/tests/unit/test_windows_agent_env_example_docs.py
@@ -1,15 +1,17 @@
 """Regression guard for issue #123 — LLAMA_SERVER_PATH documented in the
 Windows agent env template.
 
-``scripts/windows/llauncher-agent.env.example`` is the source
-``install.ps1`` copies into ``%USERPROFILE%\\.llauncher\\agent.env`` and
-feeds to NSSM's ``AppEnvironmentExtra``. Before this fix, the template
-covered auth/network/identity vars but never mentioned
-``LLAMA_SERVER_PATH`` (or ``SCRIPTS_PATH``), so an operator installing
-the service under a non-default llama-server location — or under
-NSSM's default LocalSystem account, whose home does not resolve to the
-operator's own ``~/.local/bin`` — had no documented override channel in
-the file NSSM actually injects.
+``scripts/windows/agent.env.example`` (renamed from
+``llauncher-agent.env.example`` by issue #284 so the template name
+matches its live target) is the source ``install.ps1`` seeds, once, into
+``%USERPROFILE%\\.llauncher\\agent.env`` and feeds to NSSM's
+``AppEnvironmentExtra``. Before the #123 fix, the template covered
+auth/network/identity vars but never mentioned ``LLAMA_SERVER_PATH`` (or
+``SCRIPTS_PATH``), so an operator installing the service under a
+non-default llama-server location — or under NSSM's default LocalSystem
+account, whose home does not resolve to the operator's own
+``~/.local/bin`` — had no documented override channel in the file NSSM
+actually injects.
 
 This pins:
   1. Both vars are present as commented (opt-in) examples, matching the
@@ -40,8 +42,8 @@ def _repo_root() -> Path:
     raise RuntimeError(f"Could not locate repo root from {here}")
 
 
-WINDOWS_ENV_EXAMPLE = _repo_root() / "scripts" / "windows" / "llauncher-agent.env.example"
-SYSTEMD_ENV_EXAMPLE = _repo_root() / "scripts" / "systemd" / "llauncher-agent.env.example"
+WINDOWS_ENV_EXAMPLE = _repo_root() / "scripts" / "windows" / "agent.env.example"
+SYSTEMD_ENV_EXAMPLE = _repo_root() / "scripts" / "systemd" / "agent.env.example"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Root cause (#284, three counts from field evidence)

1. **The template name lied.** `llauncher-agent.env.example` → live file `agent.env`. Broke the `X.example → X` convention; couldn't grep your way to the target.
2. **`agent.env` was installer *input*, not live config.** `install.ps1` snapshotted it into NSSM `AppEnvironmentExtra` at install time. Edits between runs were inert, silently.
3. **The template was a first-run-only seed.** The installer read the example exactly once, only when `agent.env` was absent. Every subsequent edit to it was a silent no-op.

The one value shared across two processes (the token) was routed through the most fragile hop — the `agent.token` mirror — the same machine that produced #281's 403 class.

## Design as ratified (operator, 2026-07-11)

- **Single live source**: `core/agent_token.py::resolve_agent_token` precedence is now: explicit `LLAUNCHER_AGENT_TOKEN` env var → parse `LAUNCHER_STATE_DIR/agent.env` directly (new `parse_env_file`, systemd `EnvironmentFile=` semantics: blanks/comments skipped, **last-wins** on duplicate keys, `utf-8-sig` decoded) → (loopback + `allow_generate`) generate-and-persist **into** `agent.env` (append, not a standalone file).
- **`agent.token` mirror class retired entirely.** Runtime never reads it (verified behaviorally, not just by grep — see `tests/unit/test_agent_env_single_source.py::test_standalone_agent_token_file_is_never_consulted`). Both installers delete a stale `agent.token` on sight, announcing loudly ("retired by #284; live source is `<path>`"). If a stale mirror holds a live token and `agent.env` has none yet, the value is migrated in first — never silently discarded.
- **Template renamed** (`git mv`) on both platforms: `llauncher-agent.env.example` → `agent.env.example`, headers rewritten to state the seed-once role plainly. `install.ps1` / `install.sh` say so loudly when skipping the seed, naming the live path.
- **LocalSystem wrinkle handled**: `install.ps1` injects `LAUNCHER_STATE_DIR=<installing user's %USERPROFILE%\.llauncher>` into NSSM `AppEnvironmentExtra` so the service resolves the same `agent.env` as the operator's UI even under LocalSystem. The systemd side already had the symmetric fix in place (`llauncher-ui.service.user.in`'s fixed `LAUNCHER_STATE_DIR=/var/lib/llauncher`); only its stale comment (referencing the retired `default_token_path()`) needed updating.
- **Loud on ignored input** everywhere: template-skip, legacy-key migration, mirror migration/retirement, and the missing-token refusal all print/announce rather than silently proceeding.

## Code-review-driven fixes folded in (dispatched review, medium effort)

Two genuine bugs surfaced by review and fixed before opening this PR:

1. **Ordering bug in both installers** (confirmed): the "seed `agent.env` from the template with a fresh random token if missing" branch ran *before* the "migrate a stale `agent.token` mirror" check. If `agent.env` was absent (e.g. deleted without removing the mirror) but the mirror still held the operator's real, in-use token, the fresh-seed step would silently overwrite it with a new random token and the mirror would then be deleted — discarding the live credential the migration step's own comments claimed to protect. Fixed: both installers now check for a live mirror value *before* deciding how to seed, and seed from the mirror's value when one exists instead of generating fresh.
2. **Cross-parser last/first-wins divergence** (confirmed, ties to #285): `install.ps1`'s token-line lookups used `Select-Object -First 1` while bash's `tail -n1` and the new Python `parse_env_file` are last-wins by construction — a duplicate-key `agent.env` would let the Windows installer validate against a stale value while the agent/UI resolve a different one. Fixed to `-Last 1` on both call sites, with comments citing #285.

A third candidate (permission-tightening on the token-generate append path) was evaluated and **not** applied as originally drafted — an unconditional chmod-0600 on append would have broken systemd `--system` mode's intentional 0640/group-`inference` `agent.env`, which the UI's group-read access depends on. Kept the original preserve-existing-permissions behavior; only fixed the adjacent newline-concatenation bug (missing trailing newline could fuse the appended `LLAUNCHER_AGENT_TOKEN=` line onto the prior line, making the file unparseable).

A fourth candidate (reuse: hand-rolled `parse_env_file` vs. the already-a-dependency `python-dotenv`'s `dotenv_values()`) was evaluated and rejected with rationale recorded in the docstring: `dotenv_values()` prints stderr parser warnings and yields `None`-valued keys for malformed lines rather than silently skipping them, which doesn't match this function's specified "tolerant, silent skip" contract.

## Gates (real numbers, from the worktree venv)

```
1475 passed, 13 skipped, 1 failed (pre-existing, unrelated), 59 warnings
Required test coverage of 93% reached. Total coverage: 99.92%
```

The one failure, `tests/unit/test_log_rotation_extended.py::test_stat_oserror_returns_false`, reproduces identically on unmodified base `ef64b8d` when run in isolation (confirmed before touching any code) — a pre-existing test-order-dependent flake in an unrelated module (`core/log_rotation.py`), out of this contract's scope. `llauncher/core/agent_token.py` itself is at 100% coverage.

`bash -n` clean on both touched shell scripts (`scripts/systemd/install.sh`, `scripts/systemd/install-ui.sh`).

## Files changed

- `llauncher/core/agent_token.py` — the parser + resolution precedence + generate-into-`agent.env`.
- `llauncher/agent/auth.py`, `llauncher/agent/server.py`, `llauncher/remote/registry.py`, `llauncher/ui/tabs/nodes.py` — updated comments/help-text referencing the retired file/renamed symbols; no behavior change (they already called through `resolve_agent_token`).
- `scripts/windows/install.ps1`, `scripts/systemd/install.sh`, `scripts/systemd/install-ui.sh`, `scripts/systemd/llauncher-ui.service.user.in` — installer logic + comments.
- `scripts/{windows,systemd}/agent.env.example` (renamed from `llauncher-agent.env.example`) — seed-once headers.
- `docs/auth.md`, `docs/operations/run-as-a-service.md`, `README.md` — topology docs.
- `tests/unit/test_agent_env_single_source.py` (new) — parser semantics, resolution precedence, and the behavioral (not grep) regression guard that `agent.token` is never read.
- `tests/unit/test_agent_token_generate.py`, `tests/unit/test_agent_auth_token_file.py`, `tests/integration/test_agent_security_c1_c2.py`, and several other test files — updated in place for the renamed symbols/file shape.

## Residuals

- **PowerShell not runnable locally** — `install.ps1` was verified by static read-through, `bash -n`-equivalent manual trace of every branch, and a bash reproduction of the installer's env-file logic (seed-from-mirror ordering, migration, fail-loud) run against real files in a scratch dir. **Operator's post-merge verification step**: re-run `install.ps1` on the Windows box, confirm the loud seed-skip / migration / LocalSystem-injection messages appear as documented, then `curl`/browse `/node-info` and confirm 200 (not 403).
- `tests/unit/test_log_rotation_extended.py::test_stat_oserror_returns_false` — pre-existing, unrelated, order-dependent flake (see Gates above). Not fixed here; out of contract scope.

## #285 interaction

#285 (last-wins duplicate-key semantics unification across installers) is **substantially absorbed** by this PR: `parse_env_file` is last-wins by construction, bash already used `tail -n1`, and `install.ps1`'s two lookups were fixed from first- to last-match as part of this diff's review pass. What's **not** absorbed: #285 as filed may also cover other duplicate-prone reads (e.g. the legacy-key migration's `grep`/`sed` passes) that weren't in this contract's explicit scope — recommend a quick audit pass on #285 to confirm full closure, but the core semantic-agreement gap it named for the token line specifically is closed here.

Closes #284.