### PR TITLE
docs(handoff): 2026-07-13 branch-reap closeout + PR re-triage steer

### DIFF
--- a/docs/handoffs/2026-07-13-branch-reap-closeout-and-pr-retriage.md
+++ b/docs/handoffs/2026-07-13-branch-reap-closeout-and-pr-retriage.md
@@ -1,0 +1,71 @@
+# Handoff — 2026-07-13 — branch-reap closeout; next session: re-triage the 8 open PRs
+
+## Next session's target (start here)
+
+**Re-triage the 8 open PRs.** The stale-branch pile is fully reaped (#275 CLOSED); the
+only off-`main` branches left are these 8, each the head of an open PR. Several are flagged
+below as *likely superseded by already-merged work* — the re-triage is to confirm each PR
+is still live-and-wanted, close the superseded ones, and rebase the stale-but-wanted ones.
+Start from the flags; they are leads, not verdicts — confirm each with `git cherry main <headRef>`
+(the correct patch-id test for this squash-merge repo — see "gate of record" below).
+
+| PR | headRef | what it is | triage lead |
+|---|---|---|---|
+| #164 | fix/88-skip-path-validation | make `_skip_path_validation` context-local | **likely close** — mergeable CONFLICTING; issue #88 already resolved via merged #210 (different mechanism). Confirm, then close-as-superseded or reconcile. |
+| #166 | fix/151-llauncher-env-rename | rename remaining `LAUNCHER_*` → `LLAUNCHER_*` (38 files) | **wanted but stale** — needs rebase; adjacent env churn landed since (#282 env-topology, `LAUNCHER_STATE_DIR` derivation). Rebase before it can merge. |
+| #168 | docs/adr-018-coverage-governance | draft ADR: coverage governance | `auto:draft` — awaiting operator ratification. Not a triage-close; a ratify-or-hold. |
+| #183 | repro/issue-181-eject-divergence | GPU-free repro suite for open bug #181 | **keep** — now the SOLE carrier of the #181 repro (its duplicate `salvage/181` was reaped this session). Do not close while #181 is open. |
+| #212 | docs/multiuser-migration-consolidation | consolidate multiuser/systemd migration runbook | docs; confirm still current vs merged migration work, then merge or refresh. |
+| #217 | fix/150-vram-preflight-unknown | fail-loud on unknown VRAM in preflight | **likely close** — issue #150 already landed via merged #240 (`d8f06ba …(#150)(#240)`). Confirm this PR isn't additive, then close-as-superseded. |
+| #218 | fix/126-adr003-exempt-paths-drift | narrow ADR-003 auth-exempt paths to match middleware | **verify overlap** — `main` has a separate `8e537ad` ADR-003 alignment commit; check this PR isn't already redundant with it before merging or closing. |
+| #222 | fix/124-test-summary-drift-gate | gate TEST_SUITE_SUMMARY against drift | tooling gate; appears live/distinct. Review-and-merge candidate. |
+
+Recommended re-triage motion: run the `triage-issues` skill's disposition pass over these 8
+(it handles PRs too), or a direct per-PR `git cherry main <headRef>` + `gh pr view` sweep.
+Two are near-certain closes (#164, #217), two need a decision (#166 rebase, #168 ratify),
+one is a hard keep (#183), three are review-and-merge (#212, #218, #222).
+
+## What closed this session (context, not action)
+
+- **#275 CLOSED.** ~79 stale off-`main` branches → 8 (all open-PR heads, which self-reap on
+  merge/close). **22 local branches deleted + 7 remotes reaped** in this agent's campaign
+  (on top of the 49 DELETE-LANDED reaped earlier the same session after the `-D` ban lift).
+  Every deleted branch's reflog recovery SHA is banked in the #275 comment thread (~90d).
+- **3 tracking issues minted** from genuinely-unmerged content, then their branches reaped:
+  - **#288** — stop-path hardening (in-flight-registry reap + reaper coalescing) from
+    `fixup-140`; core stop fix landed via #161 but this hardening did not. Recovery `3c4627f`.
+  - **#289** — Add-Node provisioning UI smoke test from `salvage/134`. Feature confirmed
+    LIVE on `main` (`render_add_node_form`/`add_node`), so the test is adoptable now.
+    Recovery `95f94c2`.
+  - **#290** — progress-snapshot ADR draft from `docs/adr-019`; feature shipped via #264
+    without its ADR; draft NUMBER-COLLIDES with shipped ADR-019 (server-metrics-surface) —
+    formalize-and-renumber or discard. Recovery `186f459`.
+
+## Open thread the operator did NOT resolve (parked, no action forced)
+
+- **Labels on #288/#289/#290.** All three landed `auto:draft` by dispatch reflex. The
+  operator questioned whether that's right: #290 is genuinely draft-shaped (a real
+  formalize-or-discard call), but **#288/#289 are "adopt existing salvaged work," closer to
+  `auto:fix`** (an agent could branch → adopt + profile tests → gate → PR → merge with no
+  ratification). If the operator wants those two auto-cleared, relabel `auto:draft` →
+  `auto:fix`. Left as-is pending their word. Reminder for next session: `auto:draft`
+  ratification gates the *implementation step*, not operator attention — a parked
+  `auto:draft` issue asks nothing until someone decides to build it.
+
+## Gate of record (reuse this, don't re-derive it)
+
+This repo merges via `gh pr merge --squash --delete-branch`, so **no branch is ever an
+ancestor of `main`**. Consequences that cost a wasted pass this session:
+- `git diff main...<branch>` (three-dot) is ancestry-oriented and **structurally useless
+  here** — never empty, even for fully-landed content.
+- `git branch -d` (safe delete) refuses every squash-merged branch.
+- **Correct content-equivalence test: `git cherry main <branch>`** (patch-id) — a `-`
+  prefix means the commit's patch is already on `main` (possibly under a renamed branch);
+  all-`-` = safe to reap; any `+` = carries unique content. This is the gate that did the
+  real sorting. Use it for the PR re-triage too.
+
+## Ground state at handoff
+
+- `git status -sb`: clean on `main`, in sync with origin. Never switched off `main` all session.
+- Local branches: 9 (`main` + the 8 open-PR heads). `--no-merged main`: 16 (8 local + 8 origin mirrors).
+- #275 closed; #288/#289/#290 open (`auto:draft`). No worktrees, no stashes.


### PR DESCRIPTION
Closes out #275's branch-reap (22+49 branches reaped); mints follow-up issues #288/#289/#290; steers next session to re-triage the 8 open PRs. See the doc's lead table for details.