### PR TITLE
fix(deploy): dedupe LLAUNCHER_AGENT_TOKEN in place — 403-recurrence, two-file fix (#293, #285)

### DIFF
--- a/llauncher/agent/auth.py
+++ b/llauncher/agent/auth.py
@@ -27,6 +27,7 @@ import sys  # noqa: F401  (re-exported for legacy ``auth_mod.sys`` patch sites)
 from llauncher.core.agent_token import (  # noqa: F401
     LEGACY_ENV_VAR,
     _read_env_file_token,  # imported directly by tests/unit/test_agent_auth_token_file.py
+    count_env_file_token_lines,
     default_env_path,
     legacy_token_env_misconfigured,
     parse_env_file,

--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -26,6 +26,8 @@ from fastapi import FastAPI
 from llauncher import __version__
 from llauncher import operations as ops
 from llauncher.agent.auth import (
+    count_env_file_token_lines,
+    default_env_path,
     is_loopback,
     legacy_token_env_misconfigured,
     resolve_agent_token,
@@ -357,8 +359,10 @@ def run_agent(config: AgentConfig) -> None:
 
     Raises:
         SystemExit: With code 2 when binding non-loopback without an
-            available authentication token, or when a pre-#139 legacy
-            env var is the only token source present. The error message
+            available authentication token, when a pre-#139 legacy
+            env var is the only token source present, or when the live
+            env file carries more than one LLAUNCHER_AGENT_TOKEN= line
+            (the #293 duplicate-token split-brain). The error message
             names the remediation paths.
     """
     if legacy_token_env_misconfigured():
@@ -374,6 +378,29 @@ def run_agent(config: AgentConfig) -> None:
             "to LLAUNCHER_AGENT_* in your env file, or re-run the "
             "installer (install.ps1 / install.sh) to migrate them "
             "automatically.\n"
+        )
+        raise SystemExit(2)
+
+    # Fail loud on a duplicate token line in the live env file (#293). All
+    # resolvers are last-wins (#284/d5f83b9) so a duplicate does not change
+    # which value wins *now*, but two token lines in one file is the
+    # split-brain footgun that reopened the UI-403 recurrence — a later
+    # hand-edit that reorders them makes server and client resolve different
+    # values. Refuse to run with the latent hazard rather than paper over
+    # it; the remediation is to leave exactly one canonical line.
+    env_path = default_env_path()
+    token_line_count = count_env_file_token_lines(env_path)
+    if token_line_count > 1:
+        sys.stderr.write(
+            "[llauncher-agent] ERROR: found "
+            f"{token_line_count} LLAUNCHER_AGENT_TOKEN= lines in {env_path}.\n"
+            "[llauncher-agent] Duplicate token lines are the split-brain "
+            "footgun behind the recurring UI-403s (#293): a later edit that "
+            "reorders them makes the agent and the UI resolve different "
+            "tokens.\n"
+            "[llauncher-agent] Remediation: edit the file to leave exactly "
+            "one LLAUNCHER_AGENT_TOKEN= line, or re-run the installer "
+            "(install.ps1 / install.sh) to migrate it.\n"
         )
         raise SystemExit(2)
 

--- a/llauncher/core/agent_token.py
+++ b/llauncher/core/agent_token.py
@@ -39,10 +39,13 @@ The policy in precedence order:
    both installers agree with the runtime on which line wins; see
    issue #285).
 4. Otherwise, generate a fresh ``secrets.token_urlsafe(32)`` token and
-   persist it *into* ``agent.env`` (appending a
-   ``LLAUNCHER_AGENT_TOKEN=`` line — creating the file with mode 0600,
-   parent dir 0700, if it does not yet exist), print it to stderr
-   *once*, and return it.
+   persist it *into* ``agent.env`` — rewriting in place so the file is
+   left with exactly one ``LLAUNCHER_AGENT_TOKEN=`` line (any prior
+   token line, e.g. an empty template placeholder, is stripped first;
+   issue #293), creating the file with mode 0600, parent dir 0700 if it
+   does not yet exist — print it to stderr *once*, and return it. Never
+   appends a second token line: two token lines in one file is the
+   split-brain footgun that reopened the UI-403 recurrence.
 
 The auto-generation path is only safe to silently take when the
 agent is bound to a loopback interface. The refuse-to-start guard
@@ -203,25 +206,83 @@ def _read_env_file_token(path: Path) -> str | None:
     return parse_env_file(path).get(_TOKEN_KEY) or None
 
 
+def count_env_file_token_lines(path: Path) -> int:
+    """Return how many ``LLAUNCHER_AGENT_TOKEN=`` lines ``path`` contains.
+
+    Counts physical lines whose key (after optional leading whitespace,
+    up to the first ``=``) is exactly ``LLAUNCHER_AGENT_TOKEN`` — the same
+    key-extraction :func:`parse_env_file` uses, so a commented
+    ``# LLAUNCHER_AGENT_TOKEN=`` line or a same-substring inside another
+    value never counts. Returns ``0`` for a missing file.
+
+    Two or more is the duplicate-token split-brain (#293): the resolvers
+    are all last-wins (#284/d5f83b9), so a duplicate does not by itself
+    change which value wins, but it is the footgun a later hand-edit trips
+    into a server/client mismatch — the agent's startup guard fails loud on
+    it rather than running with a latent split.
+    """
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except FileNotFoundError:
+        return 0
+    count = 0
+    for raw_line in text.splitlines():
+        stripped = raw_line.lstrip()
+        key = stripped.partition("=")[0].rstrip()
+        if key == _TOKEN_KEY:
+            count += 1
+    return count
+
+
+def _strip_token_lines(text: str) -> str:
+    """Return ``text`` with every ``LLAUNCHER_AGENT_TOKEN=`` line removed.
+
+    Anchors on the canonical token key at line start (after optional
+    leading whitespace), matching :func:`parse_env_file`'s key extraction,
+    so a commented line (``# LLAUNCHER_AGENT_TOKEN=...``) or a same-value
+    substring inside another key's value is never mistaken for a token
+    line. Preserves every other line verbatim, including blank and comment
+    lines, and preserves whether the input ended with a newline.
+    """
+    kept: list[str] = []
+    for raw_line in text.splitlines(keepends=True):
+        stripped = raw_line.lstrip()
+        key = stripped.partition("=")[0].rstrip()
+        if key == _TOKEN_KEY:
+            continue
+        kept.append(raw_line)
+    return "".join(kept)
+
+
 def _generate_and_persist_token(path: Path) -> str:
-    """Generate a fresh token and append it to the ``agent.env`` at ``path``.
+    """Generate a fresh token and rewrite it into ``agent.env`` at ``path``.
 
-    If ``path`` does not exist yet, it is created (mode 0600, parent
-    dir 0700) containing just the token line. If it already exists (but
-    has no usable ``LLAUNCHER_AGENT_TOKEN=`` line — the only way this
-    function is reached), the token line is appended, preserving every
-    existing line verbatim; the file's mode is left as-is in that case
-    since it presumably already carries whatever permissions the
-    installer or a previous run set — e.g. systemd ``--system`` mode's
-    0640/group-``inference`` ``agent.env``, which the UI's group-read
-    access depends on. Tightening it to 0600 here would silently break
-    that cross-process read path; the new-file case has no such prior
-    permission to preserve, so it gets the same 0600/0700 hardening as
-    before.
+    **Rewrite in place, never append (issue #293).** If ``path`` does not
+    exist yet, it is created (mode 0600, parent dir 0700) containing just
+    the token line. If it already exists (reached only when it has no
+    *usable* ``LLAUNCHER_AGENT_TOKEN=`` line — an empty or absent value),
+    every existing ``LLAUNCHER_AGENT_TOKEN=`` line is stripped first and
+    exactly one canonical line is written, so the file always ends with a
+    single token line. The earlier append-only behavior could leave a
+    second ``LLAUNCHER_AGENT_TOKEN=`` line behind (e.g. an empty
+    ``LLAUNCHER_AGENT_TOKEN=`` template line the operator never filled),
+    and although every resolver is last-wins as of #284/d5f83b9, two token
+    lines is the split-brain footgun that reopened the UI-403 recurrence
+    (server and client resolving different values the moment a later edit
+    reorders them). PARSE-AT-THE-DOOR: migrate to a single canonical line,
+    once — never leave two shapes of the token in one file.
 
-    The append guards against a missing trailing newline on the last
-    existing line, which would otherwise fuse onto the appended key and
-    make the file unparseable by :func:`parse_env_file`.
+    The file's mode is left as-is when it already exists, since it
+    presumably already carries whatever permissions the installer or a
+    previous run set — e.g. systemd ``--system`` mode's 0640/group-
+    ``inference`` ``agent.env``, which the UI's group-read access depends
+    on. Tightening it to 0600 here would silently break that cross-process
+    read path; the new-file case has no such prior permission to preserve,
+    so it gets the same 0600/0700 hardening as before.
+
+    A missing trailing newline on the last preserved line is repaired so
+    the appended token key lands on its own physical line and stays
+    parseable by :func:`parse_env_file`.
 
     The token is printed to stderr once so the operator can copy it
     into their client config; we deliberately avoid the regular logger
@@ -250,12 +311,14 @@ def _generate_and_persist_token(path: Path) -> str:
         except OSError:
             pass
     else:
-        existing = path.read_text(encoding="utf-8-sig")
-        needs_separator = existing and not existing.endswith("\n")
-        with path.open("a", encoding="utf-8") as fh:
-            if needs_separator:
-                fh.write("\n")
-            fh.write(line)
+        # Rewrite in place: drop any existing token line(s) so the file is
+        # left with exactly one canonical token line, then re-write the
+        # whole file (preserving its inode's permissions, since we open the
+        # existing path for write rather than replacing it).
+        preserved = _strip_token_lines(path.read_text(encoding="utf-8-sig"))
+        if preserved and not preserved.endswith("\n"):
+            preserved += "\n"
+        path.write_text(preserved + line, encoding="utf-8")
 
     print(
         f"[llauncher-agent] Generated new auth token and wrote it to {path} "

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -218,24 +218,27 @@ else
     info "  Edits to $ENV_EXAMPLE are never read after first install;"
     info "  edit $ENV_FILE directly (the live source) and re-run this installer."
 
-    # --- Migrate pre-#139 legacy keys (issue #281) ----------------------
+    # --- Migrate pre-#139 legacy keys (issue #281), deduped (issue #285) --
     # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* → LLAUNCHER_AGENT_*,
     # but env files written from the pre-rename template still carry the
     # single-L keys — which nothing reads any more, so the agent silently
     # auto-generates its own token and the UI 403s on every authed endpoint.
     # PARSE-AT-THE-DOOR: rewrite the key prefix in place, once,
-    # deterministically, preserving each value byte-for-byte. Comment lines
-    # start with '#' and never match the key-anchored pattern. Line order is
-    # preserved, so systemd's last-wins EnvironmentFile semantics (and the
-    # `tail -n1` mirror below) are unaffected.
-    legacy_keys="$(grep -E '^[[:space:]]*LAUNCHER_AGENT_' "$ENV_FILE" \
-        | sed -E 's/^[[:space:]]*(LAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
-        | sort -u || true)"
-    if [ -n "$legacy_keys" ]; then
-        sed -i -E 's/^([[:space:]]*)LAUNCHER_AGENT_/\1LLAUNCHER_AGENT_/' "$ENV_FILE"
-        renames="$(echo "$legacy_keys" | sed 's/^\(.*\)$/\1 -> L\1/' | paste -sd ', ' -)"
-        say "Migrated pre-#139 legacy keys in $ENV_FILE: $renames"
-    fi
+    # deterministically, preserving each value byte-for-byte.
+    #
+    # Issue #285: a blanket prefix rewrite created a DUPLICATE when a legacy
+    # line's migrated key already existed as a canonical line — the
+    # installer half of the "403s keep coming back" recurrence (paired with
+    # #293's runtime half). The migration now DROPS a legacy line whose
+    # migrated key already exists (the canonical line wins), loudly. Comment
+    # lines start with '#' and never match the key-anchored pattern; line
+    # order of surviving lines is preserved, so systemd's last-wins
+    # EnvironmentFile semantics (and the `tail -n1` reads below) are
+    # unaffected. Logic is extracted to migrate_env_keys.sh so it is
+    # unit-testable without the venv/systemctl preflight above.
+    # shellcheck source=scripts/systemd/migrate_env_keys.sh
+    . "$SCRIPT_DIR/migrate_env_keys.sh"
+    migrate_and_dedupe_env_keys "$ENV_FILE"
 fi
 
 # --- Retire the agent.token mirror (issue #284) -------------------------

--- a/scripts/systemd/migrate_env_keys.sh
+++ b/scripts/systemd/migrate_env_keys.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=bash
+# Pre-#139 legacy-key migration + dedupe, extracted so it is unit-testable
+# in isolation (tests/unit/test_install_sh_dedupe.py) without driving the
+# full systemd installer's venv/systemctl preflight. Sourced by
+# scripts/systemd/install.sh; defines one function and runs nothing at
+# source time.
+#
+# Issue #285 (installer half of the "403s keep coming back" recurrence,
+# paired with #293's runtime half): the pre-#139 rename migrates
+# LAUNCHER_AGENT_* → LLAUNCHER_AGENT_* IN PLACE, but with no dedupe a
+# legacy line whose migrated key already exists as a canonical line becomes
+# a DUPLICATE. For LLAUNCHER_AGENT_TOKEN that duplicate is a split-brain
+# waiting to happen (the runtime, install.ps1, and install.sh all resolve
+# last-wins as of d5f83b9, but two token lines is still a footgun the
+# operator can trip by hand-editing). PARSE-AT-THE-DOOR: migrate in place
+# once, and a legacy line colliding with an existing canonical key is
+# DROPPED (never rewritten into a second line), loudly.
+
+# migrate_and_dedupe_env_keys <env_file>
+#
+# Rewrites <env_file> in place:
+#   - Each legacy `LAUNCHER_AGENT_<K>=...` line whose migrated key
+#     `LLAUNCHER_AGENT_<K>` does NOT already appear (as a canonical line)
+#     in the file is migrated in place, value preserved byte-for-byte.
+#   - A legacy line whose migrated key ALREADY appears canonically is
+#     DROPPED (the existing canonical line wins), with a loud message on
+#     stderr naming the dropped line.
+#
+# Emits a `say`/`info`-style summary via the caller's `say` function when
+# it exists (install.sh defines it); falls back to stderr otherwise so the
+# function is usable standalone in tests.
+#
+# Comment lines (`#…`) never match the key-anchored pattern and pass
+# through untouched. Line order is preserved for surviving lines, so the
+# runtime's last-wins EnvironmentFile semantics are unaffected.
+migrate_and_dedupe_env_keys() {
+    local env_file="$1"
+
+    # Canonical keys already present (post-rename form) — these win any
+    # collision with a migrated legacy line.
+    local canonical_keys
+    canonical_keys="$(grep -E '^[[:space:]]*LLAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=' "$env_file" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*(LLAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
+        | sort -u || true)"
+
+    local legacy_keys
+    legacy_keys="$(grep -E '^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=' "$env_file" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*(LAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
+        | sort -u || true)"
+
+    [ -z "$legacy_keys" ] && return 0
+
+    local migrated=() dropped=() legacy_key migrated_key
+    while IFS= read -r legacy_key; do
+        [ -z "$legacy_key" ] && continue
+        migrated_key="L$legacy_key"  # LAUNCHER_ -> LLAUNCHER_
+        if printf '%s\n' "$canonical_keys" | grep -qxF "$migrated_key"; then
+            dropped+=("$legacy_key -> $migrated_key")
+        else
+            migrated+=("$legacy_key -> $migrated_key")
+        fi
+    done <<EOF
+$legacy_keys
+EOF
+
+    # Rewrite the file in a single awk pass so the read and the write never
+    # race and the temp swap is atomic. For each legacy line: drop if its
+    # migrated key is in the collision set, else migrate the prefix.
+    local tmp drop_keys=""
+    if [ "${#dropped[@]}" -gt 0 ]; then
+        drop_keys="$(printf '%s\n' "${dropped[@]}" | sed -E 's/ -> .*//')"
+    fi
+    tmp="$(mktemp "${env_file}.migrate.XXXXXX")"
+    DROP_KEYS="$drop_keys" \
+        awk '
+        BEGIN {
+            n = split(ENVIRON["DROP_KEYS"], arr, "\n")
+            for (i = 1; i <= n; i++) if (arr[i] != "") drop[arr[i]] = 1
+        }
+        {
+            line = $0
+            if (line ~ /^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/) {
+                k = line
+                sub(/^[[:space:]]*/, "", k)
+                sub(/[[:space:]]*=.*/, "", k)
+                if (k in drop) next        # collides with canonical -> drop
+                lead = line; sub(/[^[:space:]].*/, "", lead)
+                rest = line; sub(/^[[:space:]]*LAUNCHER_AGENT_/, "", rest)
+                print lead "LLAUNCHER_AGENT_" rest
+                next
+            }
+            print line
+        }
+        ' "$env_file" > "$tmp"
+    cat "$tmp" > "$env_file"  # preserve inode/perms of $env_file
+    rm -f "$tmp"
+
+    if [ "${#migrated[@]}" -gt 0 ]; then
+        _env_migrate_say "Migrated pre-#139 legacy keys in $env_file: $(_join_comma "${migrated[@]}")"
+    fi
+    if [ "${#dropped[@]}" -gt 0 ]; then
+        _env_migrate_say "Dropped ${#dropped[@]} pre-#139 legacy line(s) in $env_file whose migrated key already existed (canonical line wins; issue #285): $(_join_comma "${dropped[@]}")"
+    fi
+}
+
+# Join array elements with ", ".
+_join_comma() {
+    local out="" x
+    for x in "$@"; do
+        if [ -z "$out" ]; then out="$x"; else out="$out, $x"; fi
+    done
+    printf '%s' "$out"
+}
+
+# Use install.sh's `say` when sourced by it; otherwise stderr (standalone/test).
+_env_migrate_say() {
+    if command -v say >/dev/null 2>&1; then
+        say "$1"
+    else
+        printf '%s\n' "$1" >&2
+    fi
+}

--- a/scripts/windows/MigrateEnvKeys.ps1
+++ b/scripts/windows/MigrateEnvKeys.ps1
@@ -1,0 +1,77 @@
+# Pre-#139 legacy-key migration + dedupe for the Windows installer,
+# extracted so it is unit-testable in isolation (Pester / a pwsh harness)
+# without driving install.ps1's ACL/venv steps. Dot-sourced by
+# scripts/windows/install.ps1; defines one function and runs nothing at
+# dot-source time.
+#
+# Issue #285 (installer half of the "403s keep coming back" recurrence,
+# paired with #293's runtime half): the pre-#139 rename migrates
+# LAUNCHER_AGENT_* -> LLAUNCHER_AGENT_* IN PLACE, but with no dedupe a
+# legacy line whose migrated key already exists as a canonical line becomes
+# a DUPLICATE. PARSE-AT-THE-DOOR: migrate in place once, and a legacy line
+# colliding with an existing canonical key is DROPPED (never rewritten into
+# a second line), loudly. This mirrors migrate_env_keys.sh exactly so both
+# installers resolve duplicates identically (issue #285).
+
+function Invoke-EnvKeyMigration {
+    <#
+    .SYNOPSIS
+        Migrate + dedupe pre-#139 legacy LAUNCHER_AGENT_* keys in a set of
+        env-file lines.
+    .DESCRIPTION
+        Pure over its input: takes the file's lines, returns an ordered
+        hashtable-like PSCustomObject with:
+          - Lines    : the rewritten line array (write these back)
+          - Migrated : "OLD -> NEW" strings for legacy lines migrated
+          - Dropped  : "OLD -> NEW" strings for legacy lines dropped because
+                       their migrated key already existed canonically
+        A legacy line whose migrated key already appears as a canonical
+        (LLAUNCHER_AGENT_) line is DROPPED; the canonical line wins. Comment
+        lines and non-matching lines pass through untouched, order preserved.
+    .PARAMETER Lines
+        The env file's lines (e.g. @(Get-Content $EnvFile)).
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$Lines
+    )
+
+    # Canonical keys already present (post-rename form) win any collision.
+    $canonicalKeys = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*(LLAUNCHER_AGENT_[A-Za-z0-9_]*)\s*=') {
+            [void]$canonicalKeys.Add($Matches[1])
+        }
+    }
+
+    $out = New-Object System.Collections.Generic.List[string]
+    $migrated = @()
+    $dropped = @()
+    foreach ($line in $Lines) {
+        # Single-L legacy line? (LLAUNCHER already matched the canonical set;
+        # the negative lookahead keeps a canonical LLAUNCHER_ line from
+        # matching this legacy branch.)
+        if ($line -match '^(\s*)LAUNCHER_AGENT_([A-Za-z0-9_]*)\s*=') {
+            $oldKey = ($line -split '=', 2)[0].Trim()
+            $newKey = 'L' + $oldKey  # LAUNCHER_ -> LLAUNCHER_
+            if ($canonicalKeys.Contains($newKey)) {
+                # Migrated key already exists canonically -> DROP this line.
+                $dropped += "$oldKey -> $newKey"
+                continue
+            }
+            $newLine = $line -replace '^(\s*)LAUNCHER_AGENT_', '${1}LLAUNCHER_AGENT_'
+            $out.Add($newLine)
+            $migrated += "$oldKey -> $newKey"
+        }
+        else {
+            $out.Add($line)
+        }
+    }
+
+    return [PSCustomObject]@{
+        Lines    = $out.ToArray()
+        Migrated = $migrated
+        Dropped  = $dropped
+    }
+}

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -141,32 +141,37 @@ if (-not (Test-Path $EnvFile)) {
     Info "  Edits to ${EnvExample} are never read after first install;"
     Info "  edit $EnvFile directly (the live source) and re-run this script."
 
-    # --- Migrate pre-#139 legacy keys (issue #281) --------------------
+    # --- Migrate pre-#139 legacy keys (issue #281), deduped (issue #285)
     # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* to
     # LLAUNCHER_AGENT_*, but env files written from the pre-rename
     # template still carry the single-L keys — which nothing reads any
     # more, so the agent silently auto-generates its own token under the
     # SERVICE account's profile and the UI 403s on every authed endpoint.
     # PARSE-AT-THE-DOOR: rewrite the key prefix in place, once,
-    # deterministically, preserving each value byte-for-byte. Comment
-    # lines start with '#' and never match the key-anchored pattern.
-    $lines = @(Get-Content $EnvFile)
-    $migratedKeys = @()
-    for ($i = 0; $i -lt $lines.Count; $i++) {
-        if ($lines[$i] -match '^\s*LAUNCHER_AGENT_') {
-            $oldKey = ($lines[$i] -split '=', 2)[0].Trim()
-            $lines[$i] = $lines[$i] -replace '^(\s*)LAUNCHER_AGENT_', '${1}LLAUNCHER_AGENT_'
-            $newKey = ($lines[$i] -split '=', 2)[0].Trim()
-            $migratedKeys += "$oldKey -> $newKey"
-        }
-    }
-    if ($migratedKeys.Count -gt 0) {
+    # deterministically, preserving each value byte-for-byte.
+    #
+    # Issue #285: a blanket prefix rewrite created a DUPLICATE when a legacy
+    # line's migrated key already existed as a canonical line — the
+    # installer half of the "403s keep coming back" recurrence (paired with
+    # #293's runtime half). The migration now DROPS a legacy line whose
+    # migrated key already exists (the canonical line wins), loudly. Logic
+    # is extracted to MigrateEnvKeys.ps1 (mirrors migrate_env_keys.sh) so
+    # both installers resolve duplicates identically and the logic is
+    # unit-testable without install.ps1's ACL/NSSM steps.
+    . (Join-Path $ScriptDir 'MigrateEnvKeys.ps1')
+    $migration = Invoke-EnvKeyMigration -Lines @(Get-Content $EnvFile)
+    if ($migration.Migrated.Count -gt 0 -or $migration.Dropped.Count -gt 0) {
         # IMPORTANT: write WITHOUT a UTF-8 BOM — Windows PowerShell 5.1's
         # `Set-Content -Encoding utf8` prepends EF BB BF, which would
         # corrupt the first key name.
         [System.IO.File]::WriteAllLines(
-            $EnvFile, $lines, (New-Object System.Text.UTF8Encoding($false)))
-        Say ("Migrated pre-#139 legacy keys in ${EnvFile}: " + ($migratedKeys -join ', '))
+            $EnvFile, $migration.Lines, (New-Object System.Text.UTF8Encoding($false)))
+    }
+    if ($migration.Migrated.Count -gt 0) {
+        Say ("Migrated pre-#139 legacy keys in ${EnvFile}: " + ($migration.Migrated -join ', '))
+    }
+    if ($migration.Dropped.Count -gt 0) {
+        Say ("Dropped $($migration.Dropped.Count) pre-#139 legacy line(s) in ${EnvFile} whose migrated key already existed (canonical line wins; issue #285): " + ($migration.Dropped -join ', '))
     }
 }
 

--- a/tests/unit/test_agent_duplicate_token_guard.py
+++ b/tests/unit/test_agent_duplicate_token_guard.py
@@ -1,0 +1,102 @@
+"""Startup guard: refuse to run with a duplicate token line (issue #293).
+
+The recurring UI-403 ("403s keep coming back") traced to two
+``LLAUNCHER_AGENT_TOKEN=`` lines in one ``agent.env``. Every resolver is
+last-wins (#284/d5f83b9), so a duplicate does not by itself change which
+value wins — but it is the split-brain footgun a later hand-edit reordering
+the lines trips into a server/client mismatch. ``run_agent`` fails loud
+(``SystemExit(2)``) on more than one token line rather than run with the
+latent hazard. This is the enforcement surface for "one canonical token
+line" at the runtime door, paired with the installer-side dedupe (#285) and
+the rewrite-in-place persist (#293).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import llauncher.agent.server as agent_server
+from llauncher.agent.config import AgentConfig
+from llauncher.core.agent_token import count_env_file_token_lines
+
+
+def _silence_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_server.logger, "info", lambda *a, **k: None)
+    monkeypatch.setattr(agent_server.logger, "warning", lambda *a, **k: None)
+
+
+def test_count_token_lines_missing_file_is_zero(tmp_path: Path) -> None:
+    assert count_env_file_token_lines(tmp_path / "nope.env") == 0
+
+
+def test_count_token_lines_counts_only_real_key_lines(tmp_path: Path) -> None:
+    """Comments and same-substring values do not count; leading ws does."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "# LLAUNCHER_AGENT_TOKEN=commented\n"
+        "  LLAUNCHER_AGENT_TOKEN=leading-ws-still-counts\n"
+        "LLAUNCHER_AGENT_HOST=x LLAUNCHER_AGENT_TOKEN=not-a-key\n"
+        "LLAUNCHER_AGENT_TOKEN=real\n"
+    )
+    assert count_env_file_token_lines(env) == 2
+
+
+def test_run_agent_fails_loud_on_duplicate_token_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two token lines in the live env file → SystemExit(2), loud message,
+    uvicorn never started."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LLAUNCHER_AGENT_TOKEN=first\nLLAUNCHER_AGENT_TOKEN=second\n"
+    )
+    monkeypatch.setattr(agent_server, "default_env_path", lambda: env)
+
+    started = {"uvicorn": False}
+
+    def _fake_uvicorn_run(app: Any, **kwargs: Any) -> None:
+        started["uvicorn"] = True
+
+    monkeypatch.setattr(agent_server.uvicorn, "run", _fake_uvicorn_run)
+    _silence_logs(monkeypatch)
+    # Ensure the legacy-env guard above it does not pre-empt this one.
+    monkeypatch.delenv("LAUNCHER_AGENT_TOKEN", raising=False)
+    monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "envwins")
+
+    with pytest.raises(SystemExit) as exc:
+        agent_server.run_agent(AgentConfig(host="127.0.0.1", port=8000))
+
+    assert exc.value.code == 2
+    assert started["uvicorn"] is False
+    err = capsys.readouterr().err
+    assert "2 LLAUNCHER_AGENT_TOKEN=" in err
+    assert str(env) in err
+
+
+def test_run_agent_allows_single_token_line(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exactly one token line does not trip the guard; uvicorn starts."""
+    env = tmp_path / "agent.env"
+    env.write_text("LLAUNCHER_AGENT_TOKEN=only-one\n")
+    monkeypatch.setattr(agent_server, "default_env_path", lambda: env)
+
+    started = {"uvicorn": False}
+
+    def _fake_uvicorn_run(app: Any, **kwargs: Any) -> None:
+        started["uvicorn"] = True
+
+    monkeypatch.setattr(agent_server.uvicorn, "run", _fake_uvicorn_run)
+    _silence_logs(monkeypatch)
+    monkeypatch.delenv("LAUNCHER_AGENT_TOKEN", raising=False)
+    monkeypatch.setenv("LLAUNCHER_AGENT_TOKEN", "envwins")
+
+    agent_server.run_agent(AgentConfig(host="127.0.0.1", port=8000))
+
+    assert started["uvicorn"] is True

--- a/tests/unit/test_agent_token_generate.py
+++ b/tests/unit/test_agent_token_generate.py
@@ -110,3 +110,120 @@ def test_generate_token_append_preserves_existing_file_permissions(tmp_path: Pat
 
     mode = stat_mod.S_IMODE(target.stat().st_mode)
     assert mode == 0o640, f"expected append to preserve 0640, got {oct(mode)}"
+
+
+# --- Rewrite-in-place / no-split-brain (issue #293) --------------------
+#
+# The generate/persist path is reached only when the file has no *usable*
+# token line (empty or absent value; an empty ``LLAUNCHER_AGENT_TOKEN=``
+# counts as absent). Before #293 it *appended* a token line unconditionally,
+# so an existing empty/placeholder token line was left behind alongside the
+# new one — two ``LLAUNCHER_AGENT_TOKEN=`` lines in one file. Every resolver
+# is last-wins, but two token lines is the split-brain footgun that reopened
+# the recurring UI-403: a later hand-edit reordering them makes the agent and
+# the UI resolve different values. These pin the rewrite-in-place fix: exactly
+# one canonical token line remains, and the value the *file* resolves to (what
+# a client reading agent.env would get) equals the returned token (what the
+# agent runs with) — no split.
+
+
+def _resolved_file_token(path: Path) -> str | None:
+    """The token a client would resolve by parsing agent.env (last-wins)."""
+    from llauncher.core.agent_token import _read_env_file_token
+
+    return _read_env_file_token(path)
+
+
+def test_generate_token_strips_existing_empty_token_line_no_duplicate(
+    tmp_path: Path,
+) -> None:
+    """An empty placeholder ``LLAUNCHER_AGENT_TOKEN=`` line is rewritten, not
+    duplicated.
+
+    This is the exact pre-#293 recurrence shape: a template seeded the file
+    with an empty token line, the operator never filled it, so the agent
+    reaches the generate path — and must leave the file with EXACTLY ONE
+    token line (the fresh one), never append a second.
+    """
+    from llauncher.core.agent_token import count_env_file_token_lines
+
+    target = tmp_path / "agent.env"
+    target.write_text(
+        "LLAUNCHER_AGENT_HOST=0.0.0.0\nLLAUNCHER_AGENT_TOKEN=\n"
+    )
+
+    token = _generate_and_persist_token(target)
+
+    assert count_env_file_token_lines(target) == 1
+    # Non-token lines preserved.
+    assert "LLAUNCHER_AGENT_HOST=0.0.0.0" in target.read_text(encoding="utf-8")
+    # Server-resolved (returned) == client-resolved (file parse): no split.
+    assert _resolved_file_token(target) == token
+
+
+def test_generate_token_no_split_between_server_and_client(tmp_path: Path) -> None:
+    """The returned token equals the file-resolved token — the split-brain
+    invariant.
+
+    Pre-seed a file with an empty legacy-migrated token placeholder plus
+    other keys; after generate, the value the agent runs with (return value)
+    and the value a client resolves from agent.env must be identical.
+    """
+    target = tmp_path / "agent.env"
+    target.write_text(
+        "LLAUNCHER_AGENT_HOST=127.0.0.1\n"
+        "LLAUNCHER_AGENT_TOKEN=\n"
+        "LLAUNCHER_AGENT_PORT=8765\n"
+    )
+
+    token = _generate_and_persist_token(target)
+
+    assert _resolved_file_token(target) == token
+    assert token  # non-empty
+
+
+def test_generate_token_ignores_commented_token_line(tmp_path: Path) -> None:
+    """A commented ``# LLAUNCHER_AGENT_TOKEN=`` line is not treated as a token
+    line and survives the rewrite verbatim.
+
+    Guards the key-anchored strip: only a real ``KEY=`` line (optional
+    leading whitespace) is a token line; a comment must not be stripped and
+    must not count toward the duplicate guard.
+    """
+    from llauncher.core.agent_token import count_env_file_token_lines
+
+    target = tmp_path / "agent.env"
+    target.write_text(
+        "# LLAUNCHER_AGENT_TOKEN=example-do-not-use\n"
+        "LLAUNCHER_AGENT_HOST=0.0.0.0\n"
+    )
+
+    token = _generate_and_persist_token(target)
+
+    text = target.read_text(encoding="utf-8")
+    assert "# LLAUNCHER_AGENT_TOKEN=example-do-not-use" in text
+    assert count_env_file_token_lines(target) == 1
+    assert _resolved_file_token(target) == token
+
+
+def test_generate_token_with_legacy_only_line_yields_single_canonical(
+    tmp_path: Path,
+) -> None:
+    """A legacy-only ``LAUNCHER_AGENT_TOKEN`` line (single-L) is not read by
+    the runtime, so generate is reached and writes ONE canonical line.
+
+    The runtime never reads the legacy single-L key (#138/#139), so a file
+    carrying only it has no usable canonical token — the agent generates
+    one. The legacy line is left in place (the installer migrates it; the
+    runtime is inert to it), but there must be exactly one *canonical*
+    ``LLAUNCHER_AGENT_TOKEN=`` line afterward and no server/client split.
+    """
+    from llauncher.core.agent_token import count_env_file_token_lines
+
+    target = tmp_path / "agent.env"
+    target.write_text("LAUNCHER_AGENT_TOKEN=legacy-inert-value\n")
+
+    token = _generate_and_persist_token(target)
+
+    assert count_env_file_token_lines(target) == 1  # canonical only
+    assert _resolved_file_token(target) == token

--- a/tests/unit/test_env_var_naming_regression.py
+++ b/tests/unit/test_env_var_naming_regression.py
@@ -52,6 +52,13 @@ The allowlist is the set of paths where matches are *expected*:
       read path*; #281's references are inert string literals used only
       to detect and migrate away from that old shape at the door
       (PARSE-AT-THE-DOOR), never a fallback read.
+    - ``scripts/systemd/migrate_env_keys.sh``,
+      ``scripts/windows/MigrateEnvKeys.ps1``,
+      ``tests/unit/test_install_sh_dedupe.py``, and
+      ``tests/unit/test_install_ps1_dedupe.py`` are allowlisted for issue
+      #285: the migration+dedupe logic extracted from the two installers
+      (and its tests) — same inert-migration-literal rationale as the
+      installers above.
 """
 
 from __future__ import annotations
@@ -252,6 +259,17 @@ ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     "tests/integration/test_agent_security_c1_c2.py",
     "tests/unit/test_agent_token_legacy_env.py",
     "docs/operations/run-as-a-service.md",
+    # #285: the migration+dedupe logic extracted from the two installers so
+    # it is unit-testable in isolation — same legitimate migration-code home
+    # for the legacy prefix as the installers above.
+    "scripts/systemd/migrate_env_keys.sh",
+    "scripts/windows/MigrateEnvKeys.ps1",
+    "tests/unit/test_install_sh_dedupe.py",
+    "tests/unit/test_install_ps1_dedupe.py",
+    # #293: rewrite-in-place persist and the duplicate-token startup guard —
+    # their tests pre-seed legacy/collision shapes to pin the fix.
+    "tests/unit/test_agent_token_generate.py",
+    "tests/unit/test_agent_duplicate_token_guard.py",
 )
 
 

--- a/tests/unit/test_install_ps1_dedupe.py
+++ b/tests/unit/test_install_ps1_dedupe.py
@@ -1,0 +1,108 @@
+"""Unit tests for the Windows installer's legacy-key migration + dedupe.
+
+Issue #285 (installer half of the "403s keep coming back" recurrence): the
+PowerShell installer's pre-#139 migration must DROP a legacy line whose
+migrated key already exists as a canonical line, mirroring the shell
+installer exactly so both resolve duplicates identically. The logic is
+extracted to ``scripts/windows/MigrateEnvKeys.ps1`` (function
+``Invoke-EnvKeyMigration``) so it is testable without install.ps1's
+ACL/NSSM steps.
+
+Gated on ``pwsh`` (PowerShell Core) being on PATH. On a host without it —
+including this CI/dev box — the test SKIPS rather than fakes a pass; the
+field confirmation of the PowerShell path is a Windows-box user:gate
+follow-up. When pwsh IS present (Windows CI, the operator's box) these run
+and pin parity with the shell installer's behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("pwsh") is None,
+    reason="pwsh (PowerShell Core) not available; PowerShell dedupe is a "
+    "Windows-box user:gate follow-up",
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+def _invoke(lines: list[str]) -> dict:
+    """Dot-source the module, run Invoke-EnvKeyMigration, return its result
+    as a dict (Lines/Migrated/Dropped) via JSON round-trip."""
+    module = _repo_root() / "scripts" / "windows" / "MigrateEnvKeys.ps1"
+    ps_lines = "@(" + ",".join(f"'{ln}'" for ln in lines) + ")"
+    script = (
+        f". '{module}';\n"
+        f"$r = Invoke-EnvKeyMigration -Lines {ps_lines};\n"
+        # Force arrays so single-element results still serialize as arrays.
+        "$out = [PSCustomObject]@{"
+        "  Lines = @($r.Lines);"
+        "  Migrated = @($r.Migrated);"
+        "  Dropped = @($r.Dropped);"
+        "};\n"
+        "$out | ConvertTo-Json -Compress -Depth 4\n"
+    )
+    proc = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def _as_list(v) -> list:
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def test_legacy_token_colliding_with_canonical_is_dropped() -> None:
+    result = _invoke(
+        [
+            "LLAUNCHER_AGENT_TOKEN=good",
+            "# comment",
+            "LAUNCHER_AGENT_TOKEN=legacy-bad",
+            "LAUNCHER_AGENT_HOST=1.2.3.4",
+            "LLAUNCHER_AGENT_PORT=8765",
+        ]
+    )
+    lines = _as_list(result["Lines"])
+    token_lines = [ln for ln in lines if ln.startswith("LLAUNCHER_AGENT_TOKEN=")]
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=good"]
+    assert "LAUNCHER_AGENT_TOKEN=legacy-bad" not in lines
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in lines
+    dropped = _as_list(result["Dropped"])
+    assert any("LLAUNCHER_AGENT_TOKEN" in d for d in dropped)
+
+
+def test_legacy_only_migrates_without_dropping() -> None:
+    result = _invoke(
+        ["LAUNCHER_AGENT_TOKEN=only-legacy", "LAUNCHER_AGENT_HOST=1.2.3.4"]
+    )
+    lines = _as_list(result["Lines"])
+    assert lines.count("LLAUNCHER_AGENT_TOKEN=only-legacy") == 1
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in lines
+    assert _as_list(result["Dropped"]) == []
+    assert len(_as_list(result["Migrated"])) == 2
+
+
+def test_no_legacy_keys_is_noop() -> None:
+    original = ["LLAUNCHER_AGENT_TOKEN=good", "LLAUNCHER_AGENT_HOST=9.9.9.9"]
+    result = _invoke(original)
+    assert _as_list(result["Lines"]) == original
+    assert _as_list(result["Migrated"]) == []
+    assert _as_list(result["Dropped"]) == []

--- a/tests/unit/test_install_sh_dedupe.py
+++ b/tests/unit/test_install_sh_dedupe.py
@@ -1,0 +1,146 @@
+"""Unit tests for the systemd installer's legacy-key migration + dedupe.
+
+Issue #285 (installer half of the "403s keep coming back" recurrence,
+paired with #293's runtime half): the pre-#139 migration
+(``LAUNCHER_AGENT_*`` → ``LLAUNCHER_AGENT_*``) rewrote every legacy line's
+prefix with no dedupe, so a legacy line whose migrated key already existed
+as a canonical line became a DUPLICATE. For ``LLAUNCHER_AGENT_TOKEN`` that
+duplicate is a split-brain footgun. The fix DROPS a legacy line whose
+migrated key already exists (canonical line wins), loudly.
+
+The dedupe logic is extracted to ``scripts/systemd/migrate_env_keys.sh`` so
+it is testable in isolation — these tests source that file and call
+``migrate_and_dedupe_env_keys`` directly, without driving the full
+installer's venv/systemctl preflight. Skipped if ``bash`` is unavailable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+def _run_migration(env_file: Path) -> subprocess.CompletedProcess[str]:
+    """Source the helper and run the migration over ``env_file``."""
+    helper = _repo_root() / "scripts" / "systemd" / "migrate_env_keys.sh"
+    script = (
+        f'set -euo pipefail\n'
+        f'source "{helper}"\n'
+        f'migrate_and_dedupe_env_keys "{env_file}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_legacy_token_colliding_with_canonical_is_dropped(tmp_path: Path) -> None:
+    """A legacy token line whose migrated key already exists is dropped,
+    leaving exactly one canonical token line (the pre-existing value)."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LLAUNCHER_AGENT_TOKEN=good\n"
+        "# comment line\n"
+        "LAUNCHER_AGENT_TOKEN=legacy-bad\n"
+        "LAUNCHER_AGENT_HOST=1.2.3.4\n"
+        "LLAUNCHER_AGENT_PORT=8765\n"
+    )
+
+    result = _run_migration(env)
+
+    lines = env.read_text().splitlines()
+    token_lines = [ln for ln in lines if ln.strip().startswith("LLAUNCHER_AGENT_TOKEN=")]
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=good"], token_lines
+    # The colliding legacy line was DROPPED, not rewritten into a second line.
+    assert "legacy-bad" not in env.read_text()
+    # A non-colliding legacy key (HOST) is still migrated in place.
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in lines
+    assert "LAUNCHER_AGENT_HOST=1.2.3.4" not in lines
+    # Loud message names the drop and cites the issue.
+    assert "Dropped" in result.stdout or "Dropped" in result.stderr
+    assert "#285" in (result.stdout + result.stderr)
+
+
+def test_legacy_only_migrates_without_dropping(tmp_path: Path) -> None:
+    """No canonical collision: legacy keys migrate in place, none dropped,
+    exactly one canonical token line results."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LAUNCHER_AGENT_TOKEN=only-legacy\n"
+        "LAUNCHER_AGENT_HOST=1.2.3.4\n"
+    )
+
+    result = _run_migration(env)
+
+    text = env.read_text()
+    assert text.count("LLAUNCHER_AGENT_TOKEN=") == 1
+    assert "LLAUNCHER_AGENT_TOKEN=only-legacy" in text
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in text
+    assert "Migrated" in (result.stdout + result.stderr)
+    assert "Dropped" not in (result.stdout + result.stderr)
+
+
+def test_no_legacy_keys_is_noop(tmp_path: Path) -> None:
+    """A file with only canonical keys is left byte-for-byte unchanged."""
+    env = tmp_path / "agent.env"
+    original = "LLAUNCHER_AGENT_TOKEN=good\nLLAUNCHER_AGENT_HOST=9.9.9.9\n"
+    env.write_text(original)
+
+    _run_migration(env)
+
+    assert env.read_text() == original
+
+
+def test_comment_lines_are_never_migrated(tmp_path: Path) -> None:
+    """A commented legacy line is not a key line and passes through."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "# LAUNCHER_AGENT_TOKEN=example\n"
+        "LLAUNCHER_AGENT_TOKEN=real\n"
+    )
+
+    _run_migration(env)
+
+    text = env.read_text()
+    # The commented single-L legacy line is untouched (not migrated to LLAUNCHER).
+    assert "# LAUNCHER_AGENT_TOKEN=example" in text
+    # Exactly one canonical token line, and it is the pre-existing real one.
+    real_lines = [
+        ln for ln in text.splitlines()
+        if ln.startswith("LLAUNCHER_AGENT_TOKEN=")
+    ]
+    assert real_lines == ["LLAUNCHER_AGENT_TOKEN=real"]
+
+
+def test_file_permissions_preserved(tmp_path: Path) -> None:
+    """The in-place rewrite preserves the env file's mode (0640 group-read
+    matters for the systemd --system UI read path)."""
+    import stat as stat_mod
+
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LLAUNCHER_AGENT_TOKEN=good\nLAUNCHER_AGENT_TOKEN=legacy-bad\n"
+    )
+    env.chmod(0o640)
+
+    _run_migration(env)
+
+    mode = stat_mod.S_IMODE(env.stat().st_mode)
+    assert mode == 0o640, f"expected 0640 preserved, got {oct(mode)}"


### PR DESCRIPTION
## The 403-recurrence: one bug, two files

Closes #293 (code half) and #285 (installer half). The recurring "403s keep
coming back" (/node-info + /start 403 while /health 200) is a **duplicate
`LLAUNCHER_AGENT_TOKEN=` line** in `agent.env` — server and client resolve
different values the moment a later edit reorders them. Two code paths can
create that duplicate; this PR closes both, restoring `PARSE-AT-THE-DOOR`
(migrate in place, once; never leave two shapes of the token in one file).

The last-wins **wins-rule is untouched** — it is already correct and
consistent across all four resolvers (Python runtime, `install.ps1`
`Select-Object -Last 1`, `install.sh` `tail -n1`) as of d5f83b9. This PR only
stops the *duplicate* from being written in the first place, and fails loud if
one is already present.

### Code half (#293) — `llauncher/core/agent_token.py`
`_generate_and_persist_token` **appended** a fresh token line unconditionally,
so an existing empty/placeholder `LLAUNCHER_AGENT_TOKEN=` line was left behind
alongside the new one → two token lines. Now it **rewrites in place**: strips
any existing token line(s) (new helper `_strip_token_lines`, key-anchored so a
`# LLAUNCHER_AGENT_TOKEN=` comment is never touched) and writes exactly one
canonical line, preserving every other line and the file's mode (0640
group-read for the systemd `--system` UI path).

### Installer half (#285) — `install.sh` + `install.ps1`
The pre-#139 `LAUNCHER_AGENT_*` → `LLAUNCHER_AGENT_*` migration rewrote every
legacy prefix with **no dedupe**, so a legacy line whose migrated key already
existed became a duplicate. Both installers now **drop** a legacy line whose
migrated key already exists (the canonical line wins), with a loud message
naming the drop. The dedupe logic is extracted so both installers resolve
duplicates identically:
- `scripts/systemd/migrate_env_keys.sh` — `migrate_and_dedupe_env_keys`
- `scripts/windows/MigrateEnvKeys.ps1` — `Invoke-EnvKeyMigration`

### Hardening — duplicate-token startup guard (#293)
`run_agent` now fails loud (`SystemExit(2)`) when the live `agent.env` carries
more than one `LLAUNCHER_AGENT_TOKEN=` line (new `count_env_file_token_lines`),
refusing to run with the latent split-brain rather than paper over it. This is
the enforcement surface for "one canonical token line" at the runtime door.

## Tests
- `test_agent_token_generate.py` — rewrite-in-place: empty-placeholder line is
  not duplicated; legacy-only line yields a single canonical line; commented
  token line survives; **server-resolved == client-resolved** (no split).
- `test_agent_duplicate_token_guard.py` — `count_env_file_token_lines`
  (comments/substrings don't count, leading ws does); two token lines →
  `SystemExit(2)` + loud message + uvicorn never started; one line runs fine.
- `test_install_sh_dedupe.py` — drives the extracted shell helper: collision
  dropped (not rewritten), non-colliding key still migrated, legacy-only
  migrates, no-legacy no-op, comment never migrated, 0640 preserved.
- `test_install_ps1_dedupe.py` — drives `Invoke-EnvKeyMigration` via `pwsh`;
  **skips** where pwsh is absent (this CI/dev box) rather than fake-green.
- `test_env_var_naming_regression.py` — allowlist extended for the new
  migration-code homes (inert legacy-name literals, same rationale as the
  existing installers).

## Gates
- Full pytest: **1489 passed, 16 skipped** (16 incl. the 3 pwsh installer
  tests, honestly skipped here).
- Coverage: **99.89%** (floor 93%); changed-path coverage maximized
  (agent_token / server new lines exercised).

## Field confirmation — user:gate follow-up
The 403s are **not** claimed confirmed-fixed here: the Windows PowerShell
installer path and the live UI-403 reproduction need the operator's Windows
box. That end-to-end confirmation (and running the pwsh-gated tests) is a
`user:gate` follow-up.
