### PR TITLE
test(log-rotation): path-scope stat-OSError patch to fix #287 order flake

### DIFF
--- a/tests/unit/test_log_rotation_extended.py
+++ b/tests/unit/test_log_rotation_extended.py
@@ -24,11 +24,30 @@ def _big_file(p: Path, size: int = 100) -> None:
 def test_stat_oserror_returns_false(tmp_path: Path) -> None:
     """If ``path.stat()`` (for size check) raises, rotation aborts and returns False.
 
-    ``Path.exists()`` itself calls ``stat`` internally, so the patch must
-    let the existence check succeed and only fail on the explicit
-    ``path.stat()`` size lookup. We do that by side-effecting only when
-    ``follow_symlinks`` is unset (the rotation code calls ``path.stat()``
-    with no kwargs; ``Path.exists`` passes ``follow_symlinks``).
+    Isolation contract (issue #287). ``Path.stat`` is patched at the *class*
+    level (the only interception point ``pathlib`` exposes), so the side effect
+    must be scoped to *this* test's target path — otherwise it silently governs
+    every ``Path`` operation that happens to run inside the patch window,
+    including pytest-internal ones on unrelated paths. Two guards enforce that
+    scoping and make the pass order-independent:
+
+    1.  **Path-scoped.** The ``OSError`` fires only when ``self`` *is* the target
+        ``p``. Any other path (a temp dir, a fixture path, an ``importlib``
+        probe from a neighbouring test) falls straight through to the real
+        ``stat``. This is what removes the global blast radius that made the
+        old arg-shape-only heuristic order-dependent.
+    2.  **Probe-preserving.** Even for ``p`` we must let the existence check
+        succeed and fail *only* on the explicit size lookup. ``Path.exists``
+        calls ``self.stat(follow_symlinks=...)`` (kwargged), whereas the
+        rotation code and ``Path.is_file`` both call a bare ``self.stat()``.
+        The rotation flow on ``p`` is ``exists()`` then a bare ``stat()`` and
+        never ``is_file()``, so gating the raise on "bare call, no kwargs"
+        targets exactly the size lookup while the existence probe passes.
+
+    The bare ``OSError`` deliberately carries no ``errno``: ``pathlib``'s
+    ``_ignore_error`` would swallow ``ENOENT``/``EBADF`` inside ``exists`` and
+    hide the failure, so an errno-less error is what actually propagates to the
+    rotation code's ``except OSError`` guard.
     """
     p = tmp_path / "foo.log"
     _big_file(p, 100)
@@ -36,7 +55,7 @@ def test_stat_oserror_returns_false(tmp_path: Path) -> None:
     real_stat = Path.stat
 
     def selective_stat(self, *args, **kwargs):
-        if not args and not kwargs:
+        if self == p and not args and not kwargs:
             raise OSError("boom")
         return real_stat(self, *args, **kwargs)
 
@@ -44,6 +63,44 @@ def test_stat_oserror_returns_false(tmp_path: Path) -> None:
         assert lr.rotate_if_needed(p, max_bytes=10, keep=3) is False
     # The live file must still exist (rotation was aborted).
     assert p.exists()
+
+
+def test_stat_oserror_patch_is_path_scoped(tmp_path: Path) -> None:
+    """Regression guard for issue #287: the size-check ``stat`` failure is
+    scoped to the target path and never leaks to unrelated ``Path`` operations.
+
+    The previous ``selective_stat`` discriminated purely by call shape
+    (``not args and not kwargs``), so its ``OSError`` fired for *any* path a
+    bare ``stat()`` was called on inside the patch window — including the
+    identically-shaped call that ``Path.is_file()`` makes. That global blast
+    radius is exactly what turned the test order-dependent: whether an unrelated
+    path was stat'd during the window decided the outcome. This asserts the two
+    behaviours that must hold simultaneously for the isolation to be real:
+
+    * a *bare* ``stat()`` on the target path raises (the branch under test), and
+    * the same bare-``stat`` shape on a *different* path (here via
+      ``is_file()``) is untouched and returns normally.
+    """
+    target = tmp_path / "foo.log"
+    _big_file(target, 100)
+    sibling = tmp_path / "bar.log"
+    _big_file(sibling, 100)
+
+    real_stat = Path.stat
+
+    def selective_stat(self, *args, **kwargs):
+        if self == target and not args and not kwargs:
+            raise OSError("boom")
+        return real_stat(self, *args, **kwargs)
+
+    with patch.object(Path, "stat", selective_stat):
+        # The target's bare size-check stat raises (rotation aborts).
+        with pytest.raises(OSError):
+            target.stat()
+        # A sibling path — bare-stat via is_file() — is unaffected. If the
+        # patch were arg-shape-only (the #287 bug) this would raise too.
+        assert sibling.is_file() is True
+        assert sibling.stat().st_size == 100
 
 
 def test_oldest_slot_unlink_failure_aborts(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #287.

## Leak source

`test_stat_oserror_returns_false` patches `Path.stat` at the **class level** (the
only interception point `pathlib` exposes) and raised a bare `OSError("boom")`
whenever the call had no args and no kwargs:

```python
def selective_stat(self, *args, **kwargs):
    if not args and not kwargs:      # arg-shape ONLY
        raise OSError("boom")
    return real_stat(self, *args, **kwargs)
```

That discriminator is global: the identical bare-`stat()` call shape is also what
`Path.is_file()` makes (verified: `is_file()` → `self.stat()` → `()`, `{}`). So for
the duration of the `with patch.object(Path, "stat", ...)` window, **any** `Path`
operation on **any** path that bottomed out in a bare `stat()` — an unrelated
`is_file()`/`stat()` from a neighbouring test's fixture or `importlib` probe running
in the same window under a given collection order — tripped the `OSError`. Whether
such a call landed inside the window depended on test order, which is exactly the
observed pass-in-isolation / fail-in-full-suite flake.

Demonstration (old heuristic vs. new), same patch window:

```
OLD: LEAK -> unrelated sibling.is_file() raised boom
NEW: sibling.is_file() -> True (no leak);  rotate result = False
```

## Fix (at the source of the leak)

Scope the side effect to the **target path instance**, so the patch can never
govern an unrelated `Path`:

```python
def selective_stat(self, *args, **kwargs):
    if self == p and not args and not kwargs:   # path-scoped
        raise OSError("boom")
    return real_stat(self, *args, **kwargs)
```

The arg-shape guard is retained only to let the *same-path* `exists()` probe (which
calls `stat(follow_symlinks=...)`, kwargged) succeed while the bare size-check
`stat()` fails — the rotation flow on `p` is `exists()` then a bare `stat()` and
never `is_file()`, so this targets exactly the branch under test. This is the same
precise-target discipline the sibling tests already use (`test_live_rename_failure`
scopes on `os.replace` by src/dst; `test_oldest_slot_unlink_failure` scopes on
`unlink` by `self.name`).

## Isolation is now asserted

Added `test_stat_oserror_patch_is_path_scoped`: inside the patch window, a bare
`stat()` on the target raises **and** a sibling path's `is_file()`/`stat()` returns
normally. Under the old arg-shape-only heuristic this new test fails; it is the
enforcement surface for the isolation.

No production-code state was involved — `llauncher/core/log_rotation.py` has no
module-level cache or global; the leak was entirely in the test's patch scope, so
nothing needed to be filed separately (per the issue's acceptance note).

## Gates

- Full suite: **1477 passed, 13 skipped** (was 1476; +1 for the new regression test).
- Coverage: **99.89%** (floor `--cov-fail-under=93`).
- Order-independence: full suite run under 6 random seeds (1, 42, 100, 777, 2024,
  31337) — **0 target failures** in every ordering; plus deterministic
  `-p no:randomly` order green.
