### PR TITLE
fix(windows): de-Unicode install.ps1 to pure ASCII + Linux ASCII guard (#300)

### DIFF
--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -13,13 +13,13 @@
 # (values preserved; issue #281).
 #
 # Single live source (issue #284): %USERPROFILE%\.llauncher\agent.env is
-# read DIRECTLY by both the agent service and the UI at startup — there is
+# read DIRECTLY by both the agent service and the UI at startup -- there is
 # no installer-time snapshot and no agent.token mirror file any more. This
 # script's job on every run is: seed agent.env ONCE if absent, migrate a
 # stale agent.token into it if found, inject LAUNCHER_STATE_DIR into the
 # NSSM service env (see the LocalSystem note below), and pass through
 # interpreter-level vars via NSSM AppEnvironmentExtra. Editing
-# agent.env.example after first install does nothing — it is a
+# agent.env.example after first install does nothing -- it is a
 # seed-once template, not live config.
 #
 # LocalSystem wrinkle: NSSM defaults new services to the LocalSystem
@@ -105,7 +105,7 @@ if (-not (Test-Path $LogDir))  { New-Item -ItemType Directory -Path $LogDir  | O
 # still holds the operator's real, already-in-use token (e.g. agent.env
 # was deleted/never synced while the mirror survived), the seed-from-
 # template step below must NOT overwrite it with a newly generated
-# random token — that would silently orphan the live credential the
+# random token -- that would silently orphan the live credential the
 # mirror was carrying. So: if the mirror exists and carries a value,
 # seed agent.env from THAT value instead of generating a fresh one, and
 # skip the generate-new-token seed entirely.
@@ -135,23 +135,23 @@ if (-not (Test-Path $EnvFile)) {
     Info "Edit it to set LLAUNCHER_AGENT_NODE_NAME / HOST / PORT as needed."
 } else {
     # Loud on skip (issue #284): edits to the template are never read again
-    # after this first-install seed — agent.env is the only file either
+    # after this first-install seed -- agent.env is the only file either
     # process consults from here on.
-    Info "agent.env already exists at $EnvFile — skipping template seed."
+    Info "agent.env already exists at $EnvFile -- skipping template seed."
     Info "  Edits to ${EnvExample} are never read after first install;"
     Info "  edit $EnvFile directly (the live source) and re-run this script."
 
     # --- Migrate pre-#139 legacy keys (issue #281), deduped (issue #285)
     # Commit 9f098d9 (#138/#139) renamed LAUNCHER_AGENT_* to
     # LLAUNCHER_AGENT_*, but env files written from the pre-rename
-    # template still carry the single-L keys — which nothing reads any
+    # template still carry the single-L keys -- which nothing reads any
     # more, so the agent silently auto-generates its own token under the
     # SERVICE account's profile and the UI 403s on every authed endpoint.
     # PARSE-AT-THE-DOOR: rewrite the key prefix in place, once,
     # deterministically, preserving each value byte-for-byte.
     #
     # Issue #285: a blanket prefix rewrite created a DUPLICATE when a legacy
-    # line's migrated key already existed as a canonical line — the
+    # line's migrated key already existed as a canonical line -- the
     # installer half of the "403s keep coming back" recurrence (paired with
     # #293's runtime half). The migration now DROPS a legacy line whose
     # migrated key already exists (the canonical line wins), loudly. Logic
@@ -161,7 +161,7 @@ if (-not (Test-Path $EnvFile)) {
     . (Join-Path $ScriptDir 'MigrateEnvKeys.ps1')
     $migration = Invoke-EnvKeyMigration -Lines @(Get-Content $EnvFile)
     if ($migration.Migrated.Count -gt 0 -or $migration.Dropped.Count -gt 0) {
-        # IMPORTANT: write WITHOUT a UTF-8 BOM — Windows PowerShell 5.1's
+        # IMPORTANT: write WITHOUT a UTF-8 BOM -- Windows PowerShell 5.1's
         # `Set-Content -Encoding utf8` prepends EF BB BF, which would
         # corrupt the first key name.
         [System.IO.File]::WriteAllLines(
@@ -192,7 +192,7 @@ Say "Locked ACL on $EnvFile (current user only)."
 
 # --- Retire the agent.token mirror (issue #284) ------------------------
 # agent.env is now the single live source, parsed directly by both the
-# service and the UI (llauncher.core.agent_token.resolve_agent_token) — no
+# service and the UI (llauncher.core.agent_token.resolve_agent_token) -- no
 # installer-maintained mirror file. A stale agent.token from a pre-#284
 # install is migrated in place, once, at the door (PARSE-AT-THE-DOOR):
 # if agent.env has NO usable token line, the mirror's value is moved into
@@ -202,7 +202,7 @@ Say "Locked ACL on $EnvFile (current user only)."
 if (Test-Path $TokenFile) {
     # -Last 1 (not -First 1): matches systemd's EnvironmentFile= parser
     # semantics ("last wins") and llauncher.core.agent_token.parse_env_file
-    # — a duplicate-key agent.env must resolve identically across the
+    # -- a duplicate-key agent.env must resolve identically across the
     # installer's own check and the runtime the installer is validating
     # against (issue #285).
     $tokenLineExisting = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -Last 1
@@ -219,7 +219,7 @@ if (Test-Path $TokenFile) {
 }
 
 # --- Fail loud if agent.env still has no usable token (issue #281/#284) -
-# -Last 1: same last-wins rationale as above (issue #285) — this check
+# -Last 1: same last-wins rationale as above (issue #285) -- this check
 # must agree with what the agent process will actually resolve.
 $tokenLine = (Get-Content $EnvFile) | Where-Object { $_ -match '^LLAUNCHER_AGENT_TOKEN=' } | Select-Object -Last 1
 $tokenValue = if ($tokenLine) { ($tokenLine -replace '^LLAUNCHER_AGENT_TOKEN=', '').Trim() } else { '' }
@@ -253,7 +253,7 @@ foreach ($line in Get-Content $EnvFile) {
 # agent.env than $EnvFile above, silently diverging from what the
 # operator's UI reads. Inject the resolved state dir explicitly so both
 # processes converge on the same live file. This does NOT re-introduce a
-# token mirror — it is a pointer to the single live source, not a copy of
+# token mirror -- it is a pointer to the single live source, not a copy of
 # its contents.
 $envPairs += "LAUNCHER_STATE_DIR=$EnvDir"
 Say "Injecting LAUNCHER_STATE_DIR=$EnvDir into the service environment (LocalSystem wrinkle, #284)."

--- a/tests/architecture/test_ps1_ascii.py
+++ b/tests/architecture/test_ps1_ascii.py
@@ -1,0 +1,75 @@
+"""Static guard: every repo ``.ps1`` must be pure ASCII.
+
+Why this test exists
+--------------------
+``scripts/windows/install.ps1`` shipped as BOM-less UTF-8 containing
+em-dashes (``U+2014``, bytes ``E2 80 94``). Windows PowerShell 5.1 reads a
+BOM-less script as the system ANSI codepage (CP1252), not UTF-8, so each
+em-dash mis-decodes into three characters and the tokenizer trips -- the
+installer fails to parse at all (#300).
+
+The pwsh-gated CI check runs only where a real ``pwsh`` is present; on the
+Linux runner it skips, which is exactly why #296's PS1 changes shipped
+unverified. This guard closes that gap: it runs on any Linux runner with
+no ``pwsh`` and fails the class -- non-ASCII in a ``.ps1`` -- before it can
+reach a PS 5.1 field parse. ASCII sidesteps the codepage question entirely;
+an ASCII-only script needs no BOM and cannot be mis-decoded.
+
+Prose ("no Unicode in .ps1") erodes; this test does not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Repo root = two parents up from this file: tests/architecture/<file>.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PS1_FILES = sorted(
+    p for p in _REPO_ROOT.rglob("*.ps1") if ".git" not in p.parts
+)
+
+
+def _first_non_ascii(text: str) -> tuple[int, int, str] | None:
+    """Return (1-based line, 1-based column, char) of the first non-ASCII
+    character in ``text``, or ``None`` if the text is pure ASCII.
+    """
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for col_no, ch in enumerate(line, start=1):
+            if ord(ch) > 0x7F:
+                return line_no, col_no, ch
+    return None
+
+
+def test_ps1_files_discovered() -> None:
+    """Guard the guard: if no ``.ps1`` is ever found, the parametrized
+    check below silently passes and protects nothing. This repo ships
+    Windows installer scripts, so the glob must be non-empty.
+    """
+    assert _PS1_FILES, (
+        "No .ps1 files found under the repo root; the ASCII guard would "
+        "vacuously pass. Check the glob in tests/architecture/test_ps1_ascii.py."
+    )
+
+
+@pytest.mark.parametrize("ps1_path", _PS1_FILES, ids=lambda p: p.name)
+def test_ps1_is_pure_ascii(ps1_path: Path) -> None:
+    """Every ``.ps1`` must decode as pure ASCII.
+
+    A byte outside ``0x00..0x7F`` is a defect: under Windows PowerShell
+    5.1 a BOM-less non-ASCII script is decoded as CP1252 and mis-parses
+    (#300). Read as latin-1 so no byte is lost or replaced -- every byte
+    maps 1:1 to a codepoint, making ``ord(ch) > 0x7F`` an exact test for
+    a non-ASCII byte and letting the message report the true offset.
+    """
+    text = ps1_path.read_text(encoding="latin-1")
+    hit = _first_non_ascii(text)
+    rel = ps1_path.relative_to(_REPO_ROOT)
+    assert hit is None, (
+        f"{rel}:{hit[0]}:{hit[1]} contains non-ASCII character "
+        f"{hit[2]!r} (U+{ord(hit[2]):04X}). Windows PowerShell 5.1 reads a "
+        f"BOM-less script as CP1252 and mis-decodes it (#300). Replace it "
+        f"with an ASCII equivalent (e.g. em-dash -> '--')."
+    )


### PR DESCRIPTION
## Summary

Fixes #300. `scripts/windows/install.ps1` failed to parse under Windows PowerShell 5.1: the file was BOM-less UTF-8 containing 12 em-dashes (`—`, U+2014, bytes `E2 80 94`). PS 5.1 reads a BOM-less script as the system ANSI codepage (CP1252), so each em-dash mis-decoded into three characters and the tokenizer tripped, cascading to an "Unexpected token" at line 142 — the installer could not run at all.

Root cause was verified in the issue (operator-reproduced on Windows); this PR implements the mechanical fix and adds the enforcement surface.

## Changes

1. **De-Unicode `install.ps1` to pure ASCII** — all 12 em-dashes replaced with ASCII `--` (comments and strings). No logic change; pure character-encoding cleanup. No BOM added (ASCII sidesteps the codepage question entirely). `grep -nP '[^\x00-\x7F]' scripts/windows/install.ps1` now returns nothing; file still starts `23 20 49` (`# I`, no BOM). The repo's other `.ps1` (`MigrateEnvKeys.ps1`) was already clean — verified.

2. **Enforcement surface — `tests/architecture/test_ps1_ascii.py`** — a Linux-runnable pytest that globs every `**/*.ps1` and asserts each is pure ASCII, failing with `file:line:col` + the offending codepoint. Reads as latin-1 so every byte maps 1:1 and the reported offset is exact. Includes a "guard the guard" test so an empty glob can't vacuously pass. Modeled on the existing `tests/architecture/` style.

   This **closes the pwsh-gated CI gap that let #296's PS1 changes ship unverified**: the guard catches the mis-decode class on any Linux runner with no `pwsh`, before a script can reach a PS 5.1 field parse. Prose ("no Unicode in .ps1") erodes; the test does not.

## Verification (Linux — this is the gate for this fix)

- `grep -nP '[^\x00-\x7F]' scripts/windows/install.ps1` → nothing.
- Guard **proven to fail** on a deliberately-Unicode'd `.ps1` (reported `:1:9 ... 'â' (U+00E2)`) and **pass** on the cleaned tree.
- Full pytest: **1493 passed, 16 skipped**; coverage **99.89%** (floor `--cov-fail-under=93`).

## Scope note (not claimed here)

The PS 5.1 field-parse confirmation (`.\install.ps1` parses and runs on Windows) is `user:gate` and folds into **#299** — deliberately NOT claimed in this PR. This fix's acceptance is Linux-verifiable (grep clean + guard passes), and that is what the gates above establish.
