### PR TITLE
fix(test): unblock live e2e — resolve mcp_env/real_binary_env mkdir collision (#316)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -208,11 +208,19 @@ def _real_mode_available() -> tuple[bool, str]:
 
 
 @pytest.fixture
-def real_binary_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def real_binary_env(mcp_env: dict, monkeypatch: pytest.MonkeyPatch):
     """Real ``llama-server`` + GGUF fixture.
 
     Tests using this fixture must be marked ``@pytest.mark.integration_real``
     and will skip unless opted in via env. Do NOT download anything.
+
+    Depends on ``mcp_env`` rather than re-deriving its own run/log/config
+    dirs from ``tmp_path``: a test that requests both fixtures (directly, or
+    transitively via ``mcp_dispatch``/``agent_client``) shares ONE run
+    context, so the dirs must be created exactly once. ``mcp_env`` already
+    isolates every disk-bound seam onto ``tmp_path``; this fixture layers on
+    top of it and swaps only what differs for real-binary mode — the server
+    binary itself (the stub path back to the real ``llama-server``).
     """
     ok, reason = _real_mode_available()
     if not ok:
@@ -221,24 +229,8 @@ def real_binary_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     real_bin = Path(os.environ["LLAMA_SERVER_PATH"]).resolve()
     gguf = Path(os.environ["LLAMA_SMALL_GGUF"]).resolve()
 
-    run_dir = tmp_path / "run"
-    log_dir = tmp_path / "logs"
-    audit_path = tmp_path / "audit.jsonl"
-    config_dir = tmp_path / "cfg"
-    run_dir.mkdir()
-    log_dir.mkdir()
-    config_dir.mkdir()
-
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.lockfile.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.marker.LAUNCHER_RUN_DIR", run_dir)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_LOG_DIR", log_dir)
-    monkeypatch.setattr("llauncher.core.process.LOG_DIR", log_dir)
-    monkeypatch.setattr("llauncher.core.settings.LAUNCHER_AUDIT_PATH", audit_path)
-    monkeypatch.setattr("llauncher.core.audit_log.LAUNCHER_AUDIT_PATH", audit_path)
-    monkeypatch.setattr("llauncher.core.config.CONFIG_DIR", config_dir)
-    monkeypatch.setattr("llauncher.core.config.CONFIG_PATH", config_dir / "config.json")
     monkeypatch.setattr("llauncher.core.settings.LLAMA_SERVER_PATH", real_bin)
     monkeypatch.setattr("llauncher.core.process.DEFAULT_SERVER_BINARY", real_bin)
+    monkeypatch.setattr("llauncher.core.process.LLAMA_SERVER_PATH", real_bin)
 
-    return {"binary": real_bin, "gguf": gguf, "run_dir": run_dir}
+    return {"binary": real_bin, "gguf": gguf, "run_dir": mcp_env["run_dir"]}

--- a/tests/integration/test_conftest_fixtures.py
+++ b/tests/integration/test_conftest_fixtures.py
@@ -1,0 +1,83 @@
+"""Regression coverage for the integration-test harness itself.
+
+``mcp_env`` and ``real_binary_env`` both isolate the same disk-bound seams
+(run/log/config dirs) onto the same function-scoped ``tmp_path``. A test
+that requests both — directly, or transitively via ``mcp_dispatch`` /
+``agent_client``, which depend on ``mcp_env`` — used to hit two independent
+``mkdir(exist_ok=False)`` calls on the identical path, raising
+``FileExistsError`` at fixture setup before the test body ever ran. That bug
+blocked every ``integration_real`` live test (``test_self_swap.py::
+test_self_swap_live_completion_against_new_model``,
+``test_server_metrics_live.py::test_server_metrics_live_reports_phase_and_rate``).
+
+This module exercises the same fixture composition WITHOUT a real binary or
+GPU, so the regression is caught by the fast non-live suite rather than only
+by the opt-in live run. It works by satisfying ``_real_mode_available()``
+with a fake-but-existing binary/gguf pair, which is enough to drive
+``real_binary_env`` past its skip and into the dir-setup path under test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def fake_real_mode(tmp_path, stub_binary, monkeypatch):
+    """Satisfy ``_real_mode_available()`` without a real llama-server/GGUF.
+
+    Points ``LLAMA_SERVER_PATH`` / ``LLAMA_SMALL_GGUF`` at files that merely
+    need to *exist* — the stub binary and a throwaway placeholder file — so
+    ``real_binary_env`` proceeds past its skip guard into the dir-setup and
+    monkeypatch logic this test is actually probing.
+    """
+    fake_gguf = tmp_path / "fake.gguf"
+    fake_gguf.write_bytes(b"\x00")
+    monkeypatch.setenv("LLAUNCHER_INTEGRATION_REAL", "1")
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(stub_binary))
+    monkeypatch.setenv("LLAMA_SMALL_GGUF", str(fake_gguf))
+    return fake_gguf
+
+
+def test_real_binary_env_composes_with_mcp_env_without_collision(
+    fake_real_mode, mcp_env, real_binary_env
+):
+    """Requesting both fixtures on one ``tmp_path`` must not raise.
+
+    This is the direct regression test for the double-``mkdir(exist_ok=False)``
+    collision: before the fix, resolving both fixtures for one test raised
+    ``FileExistsError`` at setup. Here both are requested explicitly (rather
+    than transitively through ``mcp_dispatch``) so the failure — if
+    reintroduced — surfaces at fixture setup, before any assertion runs.
+    """
+    assert mcp_env["run_dir"].is_dir()
+    assert mcp_env["log_dir"].is_dir()
+    assert mcp_env["config_dir"].is_dir()
+
+    # real_binary_env must resolve to the SAME run context mcp_env created —
+    # not a second, independently-created directory tree.
+    assert real_binary_env["run_dir"] == mcp_env["run_dir"]
+    assert real_binary_env["run_dir"].is_dir()
+
+
+async def test_real_binary_env_composes_with_mcp_dispatch_without_collision(
+    fake_real_mode, real_binary_env, mcp_dispatch
+):
+    """The exact composition the live tests use: ``real_binary_env`` +
+    ``mcp_dispatch`` (which transitively depends on ``mcp_env``).
+
+    ``test_self_swap.py::test_self_swap_live_completion_against_new_model``
+    and ``test_server_metrics_live.py::test_server_metrics_live_reports_phase_and_rate``
+    both request this exact pair. Reaching this point without a
+    ``FileExistsError`` is the regression guard; the ``server_status`` call
+    is a cheap liveness check that the harness is actually usable afterward.
+    ``server_status`` does a live OS process scan (``LauncherState.refresh``),
+    so it may report servers already running on the host outside this test's
+    isolated dirs — we only assert the call succeeds and is well-shaped.
+    """
+    status = await mcp_dispatch("server_status", {})
+    assert set(status) == {"running_servers", "count"}
+    assert status["count"] == len(status["running_servers"])


### PR DESCRIPTION
Fixes #316.

## Problem

`mcp_env` and `real_binary_env` (`tests/integration/conftest.py`) each `mkdir(exist_ok=False)` the same `tmp_path/run` (+log/config). The two live e2e tests compose them (transitive `mcp_env` via `mcp_dispatch`/`agent_client`) → `FileExistsError` at setup under `LLAUNCHER_INTEGRATION_REAL=1`, blocking **all** live GPU coverage. Empirically confirmed: both `integration_real` tests errored at setup before any model loaded.

## Fix

`real_binary_env` now **depends on `mcp_env` and reuses its one run-context** (dirs created once) instead of re-`mkdir`-ing them. It layers on only what real-mode differs by: re-pointing `settings.LLAMA_SERVER_PATH`, `process.DEFAULT_SERVER_BINARY`, **and `process.LLAMA_SERVER_PATH`** at the real binary — the last of which the pre-fix code was *missing*, so real-mode override coverage is now strictly better.

## Enforcement surface

New `tests/integration/test_conftest_fixtures.py` (2 non-live tests) composes both fixtures and asserts no collision. **Verified fail-on-revert** (reconstructing pre-fix conftest → both error with the exact `FileExistsError`).

## Live proof

```
test_self_swap_live_completion_against_new_model PASSED
test_server_metrics_live_reports_phase_and_rate PASSED
2 passed in 18.55s
```
Real gemma-4-E2B + Qwen3.5-4B GGUFs loaded via real `llama-server`, real completion + real metrics asserted.

## Review / gates

- Opus delegate-up review: **SHIP**, no blocker; verified stub→real override completeness and fail-on-revert independently.
- Non-live suite green; coverage 99.92%. Test-only diff (two files under `tests/integration/`), no production code.

## Follow-up (banked, non-blocking)

Review nit: the composition test could also assert the real-binary override took effect (`process.DEFAULT_SERVER_BINARY == real_binary_env["binary"]`), turning it into a guard for the stub-vs-real override too. Cheap; deferred.
