### PR TITLE
test(hygiene): declare integration_real/real_model_health in pytest.ini + adopt --strict-markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,9 @@ asyncio_mode = auto
 # harness; an aggregate floor would either be vacuous or block UI work.
 # Floor of 93% gives ~2pt headroom over the post-Phase D 95% baseline.
 # Re-baseline upward when #69 lands and ui/* joins the measurement.
-addopts = --cov=llauncher --cov-report=term --cov-fail-under=93
+addopts = --cov=llauncher --cov-report=term --cov-fail-under=93 --strict-markers
 markers =
     integration: Integration tests that may have external dependencies
     live: Live tests that interact with real llama-server processes
+    integration_real: integration tests that require a real llama-server binary + GGUF (opt-in via LLAUNCHER_INTEGRATION_REAL=1)
+    real_model_health: opt out of the autouse _patch_model_health mock and exercise the real llauncher.core.model_health.check_model_health

--- a/tests/architecture/test_pytest_ini_strict_markers.py
+++ b/tests/architecture/test_pytest_ini_strict_markers.py
@@ -1,0 +1,111 @@
+"""Static + behavioral guard: pytest.ini is the sole marker inventory (#318).
+
+Why this test exists
+---------------------
+``integration_real`` and ``real_model_health`` were previously registered
+only *dynamically*, via ``pytest_configure`` hooks in
+``tests/integration/conftest.py`` and ``tests/conftest.py`` — "so coverage
+runs do not error on unknown markers." That workaround meant ``pytest.ini``
+was not the authoritative marker inventory a reader assumes, and
+``--strict-markers`` was never set, so a typo'd or forgotten marker would
+only warn instead of failing collection.
+
+This test pins the fix: both custom markers are declared directly in
+``pytest.ini``'s ``markers=`` block, ``--strict-markers`` is in ``addopts``,
+and (behaviorally) an undeclared marker actually fails collection under the
+repo's own ``pytest.ini``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Repo root = two parents up from this file: tests/architecture/<file>.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTEST_INI = _REPO_ROOT / "pytest.ini"
+
+_REQUIRED_MARKERS = ("integration", "live", "integration_real", "real_model_health")
+
+
+def test_pytest_ini_has_strict_markers_addopt() -> None:
+    """``--strict-markers`` must be present in ``addopts``."""
+    text = _PYTEST_INI.read_text()
+    addopts_lines = [
+        line for line in text.splitlines() if line.strip().startswith("addopts")
+    ]
+    assert addopts_lines, "pytest.ini has no addopts line"
+    assert "--strict-markers" in addopts_lines[0], (
+        "pytest.ini addopts is missing --strict-markers: "
+        f"{addopts_lines[0]!r}"
+    )
+
+
+def test_pytest_ini_declares_every_marker_used_by_the_suite() -> None:
+    """Every marker referenced anywhere in ``tests/`` must be declared here.
+
+    Guards against the exact gap #318 closed: ``integration_real`` and
+    ``real_model_health`` were used by the suite but only ever registered
+    dynamically, never in ``pytest.ini`` itself.
+    """
+    text = _PYTEST_INI.read_text()
+    for marker in _REQUIRED_MARKERS:
+        assert f"{marker}:" in text, (
+            f"pytest.ini markers= block is missing a declaration for "
+            f"{marker!r}"
+        )
+
+
+def test_conftests_no_longer_dynamically_register_markers() -> None:
+    """The dynamic ``pytest_configure`` marker-registration workaround is gone.
+
+    ``pytest.ini`` is now the single source of truth (per the issue); a
+    ``pytest_configure`` hook re-appearing in either conftest would silently
+    reintroduce a second inventory that ``--strict-markers`` can't audit by
+    reading ``pytest.ini`` alone.
+    """
+    for rel in ("tests/conftest.py", "tests/integration/conftest.py"):
+        text = (_REPO_ROOT / rel).read_text()
+        assert "def pytest_configure(" not in text, (
+            f"{rel} re-registers markers dynamically; pytest.ini should be "
+            "the sole marker inventory (#318)"
+        )
+
+
+def test_undeclared_marker_fails_collection_under_strict_markers() -> None:
+    """Behavioral proof: an unregistered marker errors out, not just warns.
+
+    Runs a throwaway test file, using the *real* ``pytest.ini``, that applies
+    a marker never declared anywhere. Under ``--strict-markers`` collection
+    must fail; without it, this would merely emit a warning and pass.
+    """
+    scratch = _REPO_ROOT / "tests" / "architecture" / "_strict_markers_probe.py"
+    scratch.write_text(
+        textwrap.dedent(
+            """\
+            import pytest
+
+            @pytest.mark.definitely_not_a_registered_marker
+            def test_probe():
+                assert True
+            """
+        )
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--no-cov", str(scratch)],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, (
+            "an undeclared marker did not fail collection under "
+            f"--strict-markers: stdout={result.stdout!r}"
+        )
+        assert "not found in `markers` configuration option" in result.stdout, (
+            f"unexpected failure mode: stdout={result.stdout!r}"
+        )
+    finally:
+        scratch.unlink()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,8 @@ from llauncher.state import LauncherState
 from llauncher.models.config import ModelConfig
 
 
-def pytest_configure(config):
-    """Register custom markers used by the suite."""
-    config.addinivalue_line(
-        "markers",
-        "real_model_health: opt out of the autouse "
-        "``_patch_model_health`` mock and exercise the real "
-        "``llauncher.core.model_health.check_model_health``.",
-    )
+# ``real_model_health`` is declared in pytest.ini's markers= block (single
+# source of truth per #318); no dynamic pytest_configure registration needed.
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,14 +37,8 @@ HERE = Path(__file__).parent
 STUB_PATH = HERE / "_stubs" / "llama-server-stub"
 
 
-# Mark registrations live here in addition to pytest.ini so coverage runs
-# do not error on unknown markers. (Phase C adds ``integration_real``.)
-def pytest_configure(config):  # noqa: D401
-    config.addinivalue_line(
-        "markers",
-        "integration_real: integration tests that require a real llama-server "
-        "binary + GGUF (opt-in via LLAUNCHER_INTEGRATION_REAL=1)",
-    )
+# ``integration_real`` is declared in pytest.ini's markers= block (single
+# source of truth per #318); no dynamic pytest_configure registration needed.
 
 
 # ─────────────────────────── Stub / env fixtures ────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #318

- `pytest.ini`'s `markers=` block previously listed only `integration` and `live`; `integration_real` and `real_model_health` were registered **dynamically** via `pytest_configure` hooks in `tests/integration/conftest.py` and `tests/conftest.py` — a workaround "so coverage runs do not error on unknown markers" — which left `pytest.ini` as an incomplete marker inventory.
- Declared both markers directly in `pytest.ini`, removed the now-redundant dynamic registrations from both conftest files, and added `--strict-markers` to `addopts` so an unregistered/typo'd marker fails collection instead of only warning.
- Swept the full suite (`grep -rhoE '@pytest\.mark\.[a-zA-Z_]+' tests/`) for every marker actually in use: `asyncio`, `parametrize`, `skip`, `skipif` are pytest/pytest-asyncio built-ins needing no declaration; `integration`, `live`, `integration_real`, `real_model_health` are the full custom set, all now declared in `pytest.ini`.
- Added `tests/architecture/test_pytest_ini_strict_markers.py`: static guards that `--strict-markers` is set and both custom markers are declared, that the dynamic `pytest_configure` registrations don't reappear, plus a behavioral guard (subprocess) proving an undeclared marker actually fails collection under the repo's real `pytest.ini`.

## Why

Low-severity landmine per the issue: strict mode was off so unknown markers only warned, but anyone turning strict on later (or ADR-018 coverage governance) would hit `pytest.ini` silently missing two markers already relied upon by the suite.

## Test plan

- [x] Full suite: `.venv/bin/python -m pytest` from repo root — 1504 passed, 19 skipped (opt-in real/live tests), 0 failed.
- [x] Coverage: 99.89% (floor 93%).
- [x] Manual proof: an ad-hoc test file with an undeclared marker fails collection with `'... not found in \`markers\` configuration option'` under this `pytest.ini` — pinned as `test_undeclared_marker_fails_collection_under_strict_markers`.