### PR TITLE
fix(agent): timestamp uvicorn access/error log lines

### DIFF
--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -50,6 +50,52 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# uvicorn's own default log config (uvicorn.config.LOGGING_CONFIG) formats
+# both the "default" (error/lifecycle) and "access" loggers WITHOUT a
+# timestamp — e.g. ``INFO:     127.0.0.1:64557 - "POST /start/8081..."``.
+# That makes it impossible to correlate request timing against the agent's
+# own (timestamped) log lines when diagnosing hangs/slow requests (#307).
+#
+# This is uvicorn's stock dict config with ``%(asctime)s`` prepended to both
+# formatters' ``fmt`` strings — everything else (handlers, stream targets,
+# logger levels/propagation) is left exactly as uvicorn ships it, so we pick
+# up upstream defaults/behavior otherwise unchanged.
+UVICORN_LOG_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": "%(asctime)s - %(levelprefix)s %(message)s",
+            "use_colors": None,
+        },
+        "access": {
+            "()": "uvicorn.logging.AccessFormatter",
+            "fmt": (
+                "%(asctime)s - %(levelprefix)s %(client_addr)s - "
+                '"%(request_line)s" %(status_code)s'
+            ),
+        },
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+    },
+}
+
 
 def find_process_on_port(port: int) -> int | None:
     """Find the PID of the process listening on the given port.
@@ -448,13 +494,15 @@ def run_agent(config: AgentConfig) -> None:
 
     # Run the server. ``lifespan="on"`` ensures the FastAPI lifespan handler
     # (which reaps llama-server children on shutdown per #65) actually fires
-    # regardless of uvicorn's auto-detection heuristics.
+    # regardless of uvicorn's auto-detection heuristics. ``log_config``
+    # carries our timestamped access/error formatters (#307).
     uvicorn.run(
         app,
         host=config.host,
         port=config.port,
         log_level="info",
         lifespan="on",
+        log_config=UVICORN_LOG_CONFIG,
     )
 
 

--- a/tests/integration/test_agent_security_c1_c2.py
+++ b/tests/integration/test_agent_security_c1_c2.py
@@ -179,7 +179,7 @@ def test_loopback_first_run_generates_token_file(monkeypatch, tmp_path):
     # Capture the token-handed-to-create_app by intercepting uvicorn.run
     # AND by re-running create_app with the same env state.
     captured: dict = {}
-    def fake_uvicorn_run(app, host=None, port=None, log_level="info", lifespan="auto"):
+    def fake_uvicorn_run(app, host=None, port=None, log_level="info", lifespan="auto", log_config=None):
         captured["app"] = app
         captured["host"] = host
     monkeypatch.setattr("uvicorn.run", fake_uvicorn_run)

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -944,12 +944,24 @@ class TestUtilityFunctions:
 
     def test_run_agent(self, monkeypatch):
         """Test run_agent calls uvicorn.run with correct parameters."""
-        from llauncher.agent.server import run_agent
+        from llauncher.agent.server import run_agent, UVICORN_LOG_CONFIG
         from llauncher.agent.config import AgentConfig
         import llauncher.agent.server
 
         # Mock uvicorn.run to capture the arguments
-        mock_run = lambda app, host=None, port=None, log_level="info", lifespan="auto": None
+        captured_kwargs = {}
+
+        def mock_run(app, host=None, port=None, log_level="info", lifespan="auto", log_config=None):
+            captured_kwargs.update(
+                {
+                    "host": host,
+                    "port": port,
+                    "log_level": log_level,
+                    "lifespan": lifespan,
+                    "log_config": log_config,
+                }
+            )
+
         monkeypatch.setattr("uvicorn.run", mock_run)
 
         # Mock logging.info to avoid output
@@ -968,8 +980,70 @@ class TestUtilityFunctions:
         # Call the function
         run_agent(config)
 
-        # If we get here without exception, the test passes
-        # For simplicity, we just ensure no exception.
+        # run_agent must hand uvicorn our timestamped log config (#307) so
+        # access AND error lines both carry asctime, rather than falling
+        # back to uvicorn's un-timestamped stock formatters.
+        assert captured_kwargs["log_config"] is UVICORN_LOG_CONFIG
+
+    def test_uvicorn_log_config_access_formatter_has_timestamp(self):
+        """Access-log lines must carry an asctime timestamp (#307).
+
+        Regression guard for the original bug: uvicorn's stock ``access``
+        formatter renders lines like
+        ``INFO:     127.0.0.1:64557 - "POST /start/8081 HTTP/1.1" 500``
+        with no timestamp, making request timing impossible to correlate.
+        """
+        from llauncher.agent.server import UVICORN_LOG_CONFIG
+
+        access_fmt = UVICORN_LOG_CONFIG["formatters"]["access"]["fmt"]
+        assert "%(asctime)s" in access_fmt
+
+    def test_uvicorn_log_config_default_formatter_has_timestamp(self):
+        """Error/lifecycle-log lines must also carry an asctime timestamp (#307)."""
+        from llauncher.agent.server import UVICORN_LOG_CONFIG
+
+        default_fmt = UVICORN_LOG_CONFIG["formatters"]["default"]["fmt"]
+        assert "%(asctime)s" in default_fmt
+
+    def test_uvicorn_log_config_renders_timestamped_access_line(self):
+        """End-to-end: dictConfig-ing UVICORN_LOG_CONFIG and logging through
+        ``uvicorn.access`` actually emits a line with a real timestamp,
+        not just a format string that mentions asctime.
+        """
+        import io
+        import logging
+        import logging.config
+        import re
+
+        from llauncher.agent.server import UVICORN_LOG_CONFIG
+
+        logging.config.dictConfig(UVICORN_LOG_CONFIG)
+        access_logger = logging.getLogger("uvicorn.access")
+
+        buf = io.StringIO()
+        # Swap in a stream handler pointed at our buffer, keeping the
+        # configured (timestamped) formatter, so we can inspect output
+        # without depending on stdout capture.
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(access_logger.handlers[0].formatter)
+        access_logger.handlers = [handler]
+
+        # Matches uvicorn's own call convention (h11_impl.py /
+        # httptools_impl.py): a 5-arg tuple that AccessFormatter.formatMessage
+        # unpacks as (client_addr, method, full_path, http_version, status_code).
+        access_logger.info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:64557",
+            "POST",
+            "/start/8081",
+            "1.1",
+            500,
+        )
+
+        output = buf.getvalue()
+        # e.g. "2026-07-16 11:46:42,789 - INFO:     127.0.0.1:64557 - ..."
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}", output)
+        assert "127.0.0.1:64557" in output
 
     def test_run_agent_refuses_non_loopback_without_token(self, monkeypatch):
         """Security §3 C1: refuse to start on non-loopback without token.
@@ -1699,8 +1773,8 @@ class TestAgentServerFunctions:
 
         # Mock uvicorn.run to capture arguments
         captured_args = {}
-        def mock_run(app, host=None, port=None, log_level="info", lifespan="auto"):
-            captured_args.update({"app": app, "host": host, "port": port, "log_level": log_level, "lifespan": lifespan})
+        def mock_run(app, host=None, port=None, log_level="info", lifespan="auto", log_config=None):
+            captured_args.update({"app": app, "host": host, "port": port, "log_level": log_level, "lifespan": lifespan, "log_config": log_config})
 
         monkeypatch.setattr("uvicorn.run", mock_run)
 
@@ -1735,7 +1809,7 @@ class TestAgentServerFunctions:
 
         # Mock uvicorn.run
         captured: dict = {}
-        def mock_run(app, host=None, port=None, log_level="info", lifespan="auto"):
+        def mock_run(app, host=None, port=None, log_level="info", lifespan="auto", log_config=None):
             captured["host"] = host
             captured["port"] = port
         monkeypatch.setattr("uvicorn.run", mock_run)


### PR DESCRIPTION
Fixes #307

## What changed
- `llauncher/agent/server.py`: added `UVICORN_LOG_CONFIG`, a dict-based logging config derived from uvicorn's own stock `LOGGING_CONFIG`, with `%(asctime)s` prepended to both the `default` (error/lifecycle) and `access` formatters' `fmt` strings. Passed it to `uvicorn.run(..., log_config=UVICORN_LOG_CONFIG)` in `run_agent`.
- Everything else (handlers, stream targets, logger levels/propagation) is left exactly as uvicorn ships it — this is additive, not a rewrite of uvicorn's logging behavior.

## Why
`agent.out.log` (uvicorn's access log) had no timestamps — e.g. `INFO:     127.0.0.1:64557 - "POST /start/8081 HTTP/1.1" 500 Internal Server Error` — while the agent's own logger already timestamps every line. This made it impossible to correlate request timing (e.g. the observed 45s UI hang) against the request stream.

Verified live (in-process `uvicorn.Server` + `httpx` client hitting `/health` and a 404 path): both access lines and default/lifecycle lines now render with a leading `YYYY-MM-DD HH:MM:SS,fff` timestamp, e.g.:
```
2026-07-16 11:50:52,463 - INFO:     127.0.0.1:60052 - "GET /health HTTP/1.1" 200 OK
2026-07-16 11:50:52,464 - INFO:     127.0.0.1:60052 - "GET /nonexistent-path-triggers-404 HTTP/1.1" 404 Not Found
```

## Gates
- Full pytest (worktree-scoped, confirmed `llauncher.__file__` resolves under the worktree): **1503 passed, 19 skipped**, 0 new failures vs. clean-main baseline (empty baseline).
- Coverage: **99.92%** total (floor 93%); `llauncher/agent/server.py` itself at **100%** coverage.
- Existing `uvicorn.run` mocks across `tests/unit/test_agent.py` and `tests/integration/test_agent_security_c1_c2.py` updated to accept the new `log_config` kwarg (previously fixed positional/kwarg signatures didn't anticipate a new param).
- New tests: `test_run_agent` now asserts `log_config is UVICORN_LOG_CONFIG` is passed through; `test_uvicorn_log_config_access_formatter_has_timestamp`, `test_uvicorn_log_config_default_formatter_has_timestamp`, and an end-to-end `test_uvicorn_log_config_renders_timestamped_access_line` (dictConfig + real logger call, regex-matches a rendered timestamp) guard the regression directly.

## Test plan
- [x] `pytest` full suite green, no new failures
- [x] Coverage floor (93%) met — 99.92% actual
- [x] Manual live verification: both access and error/lifecycle lines carry `asctime`