### PR TITLE
fix(installer): dedupe same-pass legacy-key collisions + guard message accuracy (#298)

### DIFF
--- a/llauncher/agent/server.py
+++ b/llauncher/agent/server.py
@@ -388,6 +388,15 @@ def run_agent(config: AgentConfig) -> None:
     # hand-edit that reorders them makes server and client resolve different
     # values. Refuse to run with the latent hazard rather than paper over
     # it; the remediation is to leave exactly one canonical line.
+    #
+    # count_env_file_token_lines only counts CANONICAL (double-L)
+    # LLAUNCHER_AGENT_TOKEN= lines, so this guard only ever fires on two
+    # canonical lines — never on a legacy/canonical pair (that case is
+    # handled, and remediated by re-running the installer, above and by
+    # #285's installer-side dedupe). Re-running the installer cannot fix
+    # two canonical lines: the installer's migration only touches legacy
+    # `LAUNCHER_AGENT_*` lines and leaves canonical ones untouched (#298).
+    # The only remediation here is a hand-edit.
     env_path = default_env_path()
     token_line_count = count_env_file_token_lines(env_path)
     if token_line_count > 1:
@@ -398,9 +407,11 @@ def run_agent(config: AgentConfig) -> None:
             "footgun behind the recurring UI-403s (#293): a later edit that "
             "reorders them makes the agent and the UI resolve different "
             "tokens.\n"
-            "[llauncher-agent] Remediation: edit the file to leave exactly "
-            "one LLAUNCHER_AGENT_TOKEN= line, or re-run the installer "
-            "(install.ps1 / install.sh) to migrate it.\n"
+            "[llauncher-agent] Remediation: these are canonical "
+            "LLAUNCHER_AGENT_TOKEN= lines, so re-running the installer will "
+            "not fix this (it only migrates legacy LAUNCHER_AGENT_* lines) "
+            f"— hand-edit {env_path} to leave exactly one "
+            "LLAUNCHER_AGENT_TOKEN= line.\n"
         )
         raise SystemExit(2)
 

--- a/scripts/systemd/migrate_env_keys.sh
+++ b/scripts/systemd/migrate_env_keys.sh
@@ -15,6 +15,16 @@
 # operator can trip by hand-editing). PARSE-AT-THE-DOOR: migrate in place
 # once, and a legacy line colliding with an existing canonical key is
 # DROPPED (never rewritten into a second line), loudly.
+#
+# Issue #298 (follow-up from #296 review): the collision set above must
+# also catch a collision produced WITHIN the same migration pass — two
+# legacy same-key lines (e.g. two ``LAUNCHER_AGENT_TOKEN=`` lines) with NO
+# pre-existing canonical line. The original snapshot-once ``canonical_keys``
+# only knew about canonical lines already in the file, so both legacy lines
+# migrated and the pass itself produced two canonical lines. The fix walks
+# legacy lines in file order and grows the canonical set as each one
+# migrates, so the second occurrence of a same-pass collision is caught and
+# dropped just like a pre-existing one.
 
 # migrate_and_dedupe_env_keys <env_file>
 #
@@ -36,13 +46,6 @@
 migrate_and_dedupe_env_keys() {
     local env_file="$1"
 
-    # Canonical keys already present (post-rename form) — these win any
-    # collision with a migrated legacy line.
-    local canonical_keys
-    canonical_keys="$(grep -E '^[[:space:]]*LLAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=' "$env_file" 2>/dev/null \
-        | sed -E 's/^[[:space:]]*(LLAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
-        | sort -u || true)"
-
     local legacy_keys
     legacy_keys="$(grep -E '^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=' "$env_file" 2>/dev/null \
         | sed -E 's/^[[:space:]]*(LAUNCHER_AGENT_[A-Za-z0-9_]*).*/\1/' \
@@ -50,56 +53,64 @@ migrate_and_dedupe_env_keys() {
 
     [ -z "$legacy_keys" ] && return 0
 
-    local migrated=() dropped=() legacy_key migrated_key
-    while IFS= read -r legacy_key; do
-        [ -z "$legacy_key" ] && continue
-        migrated_key="L$legacy_key"  # LAUNCHER_ -> LLAUNCHER_
-        if printf '%s\n' "$canonical_keys" | grep -qxF "$migrated_key"; then
-            dropped+=("$legacy_key -> $migrated_key")
-        else
-            migrated+=("$legacy_key -> $migrated_key")
-        fi
-    done <<EOF
-$legacy_keys
-EOF
-
-    # Rewrite the file in a single awk pass so the read and the write never
-    # race and the temp swap is atomic. For each legacy line: drop if its
-    # migrated key is in the collision set, else migrate the prefix.
-    local tmp drop_keys=""
-    if [ "${#dropped[@]}" -gt 0 ]; then
-        drop_keys="$(printf '%s\n' "${dropped[@]}" | sed -E 's/ -> .*//')"
-    fi
+    # Single awk pass does BOTH the collision decision and the rewrite, so
+    # the "canonical key" set grows as lines are seen in file order (#298):
+    # it seeds from pre-existing canonical lines, then adds each migrated
+    # key the instant its first legacy occurrence is migrated. A second
+    # same-key legacy line — whether it collides with a pre-existing
+    # canonical line or with the FIRST line of a same-pass legacy pair — is
+    # dropped identically. Emits two summary lines on fd 3/4 (migrated/
+    # dropped, "OLD -> NEW" pairs) for the caller to report.
+    local tmp
     tmp="$(mktemp "${env_file}.migrate.XXXXXX")"
-    DROP_KEYS="$drop_keys" \
-        awk '
-        BEGIN {
-            n = split(ENVIRON["DROP_KEYS"], arr, "\n")
-            for (i = 1; i <= n; i++) if (arr[i] != "") drop[arr[i]] = 1
+    local migrated_summary dropped_summary
+    exec 3>"${tmp}.migrated" 4>"${tmp}.dropped"
+    awk '
+        /^[[:space:]]*LLAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/ {
+            k = $0
+            sub(/^[[:space:]]*/, "", k)
+            sub(/[[:space:]]*=.*/, "", k)
+            seen[k] = 1
+            print
+            next
         }
-        {
-            line = $0
-            if (line ~ /^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/) {
-                k = line
-                sub(/^[[:space:]]*/, "", k)
-                sub(/[[:space:]]*=.*/, "", k)
-                if (k in drop) next        # collides with canonical -> drop
-                lead = line; sub(/[^[:space:]].*/, "", lead)
-                rest = line; sub(/^[[:space:]]*LAUNCHER_AGENT_/, "", rest)
-                print lead "LLAUNCHER_AGENT_" rest
+        /^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/ {
+            k = $0
+            sub(/^[[:space:]]*/, "", k)
+            sub(/[[:space:]]*=.*/, "", k)
+            newk = "L" k
+            if (newk in seen) {
+                print k " -> " newk > "/dev/fd/4"
                 next
             }
-            print line
+            seen[newk] = 1
+            print k " -> " newk > "/dev/fd/3"
+            lead = $0; sub(/[^[:space:]].*/, "", lead)
+            rest = $0; sub(/^[[:space:]]*LAUNCHER_AGENT_/, "", rest)
+            print lead "LLAUNCHER_AGENT_" rest
+            next
         }
+        { print }
         ' "$env_file" > "$tmp"
+    exec 3>&- 4>&-
     cat "$tmp" > "$env_file"  # preserve inode/perms of $env_file
-    rm -f "$tmp"
+
+    local migrated=() dropped=() line
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        migrated+=("$line")
+    done < "${tmp}.migrated"
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        dropped+=("$line")
+    done < "${tmp}.dropped"
+    rm -f "$tmp" "${tmp}.migrated" "${tmp}.dropped"
 
     if [ "${#migrated[@]}" -gt 0 ]; then
         _env_migrate_say "Migrated pre-#139 legacy keys in $env_file: $(_join_comma "${migrated[@]}")"
     fi
     if [ "${#dropped[@]}" -gt 0 ]; then
-        _env_migrate_say "Dropped ${#dropped[@]} pre-#139 legacy line(s) in $env_file whose migrated key already existed (canonical line wins; issue #285): $(_join_comma "${dropped[@]}")"
+        _env_migrate_say "Dropped ${#dropped[@]} pre-#139 legacy line(s) in $env_file whose migrated key already existed (canonical line wins, including a same-pass collision; issue #285/#298): $(_join_comma "${dropped[@]}")"
     fi
 }
 

--- a/scripts/systemd/migrate_env_keys.sh
+++ b/scripts/systemd/migrate_env_keys.sh
@@ -53,25 +53,27 @@ migrate_and_dedupe_env_keys() {
 
     [ -z "$legacy_keys" ] && return 0
 
-    # Single awk pass does BOTH the collision decision and the rewrite, so
-    # the "canonical key" set grows as lines are seen in file order (#298):
-    # it seeds from pre-existing canonical lines, then adds each migrated
-    # key the instant its first legacy occurrence is migrated. A second
-    # same-key legacy line — whether it collides with a pre-existing
-    # canonical line or with the FIRST line of a same-pass legacy pair — is
-    # dropped identically. Emits two summary lines on fd 3/4 (migrated/
-    # dropped, "OLD -> NEW" pairs) for the caller to report.
+    # Two-phase seed-then-grow, mirroring MigrateEnvKeys.ps1 exactly: the
+    # file is read TWICE by one awk program. Pass 1 (NR == FNR) only seeds
+    # `seen` with every pre-existing canonical key in the WHOLE file — so a
+    # canonical line wins the collision regardless of whether it appears
+    # before or after its legacy twin in file order (#285). Pass 2 rewrites:
+    # each migrated legacy key is added to `seen` the instant it migrates,
+    # so a LATER same-key legacy line — a same-pass collision, no
+    # pre-existing canonical line required — is dropped identically (#298).
+    # Emits two summary lines on fd 3/4 (migrated/dropped, "OLD -> NEW"
+    # pairs) for the caller to report.
     local tmp
     tmp="$(mktemp "${env_file}.migrate.XXXXXX")"
-    local migrated_summary dropped_summary
     exec 3>"${tmp}.migrated" 4>"${tmp}.dropped"
     awk '
-        /^[[:space:]]*LLAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/ {
-            k = $0
-            sub(/^[[:space:]]*/, "", k)
-            sub(/[[:space:]]*=.*/, "", k)
-            seen[k] = 1
-            print
+        NR == FNR {
+            if ($0 ~ /^[[:space:]]*LLAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/) {
+                k = $0
+                sub(/^[[:space:]]*/, "", k)
+                sub(/[[:space:]]*=.*/, "", k)
+                seen[k] = 1
+            }
             next
         }
         /^[[:space:]]*LAUNCHER_AGENT_[A-Za-z0-9_]*[[:space:]]*=/ {
@@ -91,7 +93,7 @@ migrate_and_dedupe_env_keys() {
             next
         }
         { print }
-        ' "$env_file" > "$tmp"
+        ' "$env_file" "$env_file" > "$tmp"
     exec 3>&- 4>&-
     cat "$tmp" > "$env_file"  # preserve inode/perms of $env_file
 

--- a/scripts/windows/MigrateEnvKeys.ps1
+++ b/scripts/windows/MigrateEnvKeys.ps1
@@ -12,6 +12,16 @@
 # colliding with an existing canonical key is DROPPED (never rewritten into
 # a second line), loudly. This mirrors migrate_env_keys.sh exactly so both
 # installers resolve duplicates identically (issue #285).
+#
+# Issue #298 (follow-up from #296 review): the collision set must also
+# catch a collision produced WITHIN the same migration pass — two legacy
+# same-key lines (e.g. two ``LAUNCHER_AGENT_TOKEN=`` lines) with NO
+# pre-existing canonical line. The original snapshot-once $canonicalKeys
+# only knew about canonical lines already present, so both legacy lines
+# migrated and the pass itself produced two canonical lines. The fix grows
+# $canonicalKeys as each legacy line migrates (in file order), so a second
+# same-key legacy line — whether colliding with a pre-existing canonical
+# line or with the first line of a same-pass pair — is dropped identically.
 
 function Invoke-EnvKeyMigration {
     <#
@@ -64,6 +74,10 @@ function Invoke-EnvKeyMigration {
             $newLine = $line -replace '^(\s*)LAUNCHER_AGENT_', '${1}LLAUNCHER_AGENT_'
             $out.Add($newLine)
             $migrated += "$oldKey -> $newKey"
+            # Grow the canonical set immediately (#298) so a LATER legacy
+            # line with this same key — a same-pass collision, no
+            # pre-existing canonical line required — is dropped too.
+            [void]$canonicalKeys.Add($newKey)
         }
         else {
             $out.Add($line)

--- a/scripts/windows/MigrateEnvKeys.ps1
+++ b/scripts/windows/MigrateEnvKeys.ps1
@@ -14,14 +14,14 @@
 # installers resolve duplicates identically (issue #285).
 #
 # Issue #298 (follow-up from #296 review): the collision set must also
-# catch a collision produced WITHIN the same migration pass — two legacy
+# catch a collision produced WITHIN the same migration pass -- two legacy
 # same-key lines (e.g. two ``LAUNCHER_AGENT_TOKEN=`` lines) with NO
 # pre-existing canonical line. The original snapshot-once $canonicalKeys
 # only knew about canonical lines already present, so both legacy lines
 # migrated and the pass itself produced two canonical lines. The fix grows
 # $canonicalKeys as each legacy line migrates (in file order), so a second
-# same-key legacy line — whether colliding with a pre-existing canonical
-# line or with the first line of a same-pass pair — is dropped identically.
+# same-key legacy line -- whether colliding with a pre-existing canonical
+# line or with the first line of a same-pass pair -- is dropped identically.
 
 function Invoke-EnvKeyMigration {
     <#
@@ -75,8 +75,8 @@ function Invoke-EnvKeyMigration {
             $out.Add($newLine)
             $migrated += "$oldKey -> $newKey"
             # Grow the canonical set immediately (#298) so a LATER legacy
-            # line with this same key — a same-pass collision, no
-            # pre-existing canonical line required — is dropped too.
+            # line with this same key -- a same-pass collision, no
+            # pre-existing canonical line required -- is dropped too.
             [void]$canonicalKeys.Add($newKey)
         }
         else {

--- a/tests/unit/test_agent_duplicate_token_guard.py
+++ b/tests/unit/test_agent_duplicate_token_guard.py
@@ -76,6 +76,13 @@ def test_run_agent_fails_loud_on_duplicate_token_lines(
     err = capsys.readouterr().err
     assert "2 LLAUNCHER_AGENT_TOKEN=" in err
     assert str(env) in err
+    # #298: the guard only ever fires on two CANONICAL lines (the counter
+    # only counts double-L lines), so "re-run the installer" is never a
+    # correct remediation here — the message must say so and point at a
+    # hand-edit instead.
+    assert "will not fix this" in err
+    assert "hand-edit" in err
+    assert "re-run the installer" not in err
 
 
 def test_run_agent_allows_single_token_line(

--- a/tests/unit/test_install_ps1_dedupe.py
+++ b/tests/unit/test_install_ps1_dedupe.py
@@ -89,6 +89,25 @@ def test_legacy_token_colliding_with_canonical_is_dropped() -> None:
     assert any("LLAUNCHER_AGENT_TOKEN" in d for d in dropped)
 
 
+def test_samepass_legacy_collision_with_no_canonical_line_is_deduped() -> None:
+    """Issue #298: two legacy same-key lines with NO pre-existing canonical
+    line must still dedupe down to exactly one canonical line."""
+    result = _invoke(
+        [
+            "LAUNCHER_AGENT_TOKEN=first",
+            "LAUNCHER_AGENT_TOKEN=second",
+            "LAUNCHER_AGENT_HOST=1.2.3.4",
+        ]
+    )
+    lines = _as_list(result["Lines"])
+    token_lines = [ln for ln in lines if ln.startswith("LLAUNCHER_AGENT_TOKEN=")]
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=first"]
+    assert not any("second" in ln for ln in lines)
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in lines
+    dropped = _as_list(result["Dropped"])
+    assert any("LLAUNCHER_AGENT_TOKEN" in d for d in dropped)
+
+
 def test_legacy_only_migrates_without_dropping() -> None:
     result = _invoke(
         ["LAUNCHER_AGENT_TOKEN=only-legacy", "LAUNCHER_AGENT_HOST=1.2.3.4"]

--- a/tests/unit/test_install_ps1_dedupe.py
+++ b/tests/unit/test_install_ps1_dedupe.py
@@ -89,6 +89,25 @@ def test_legacy_token_colliding_with_canonical_is_dropped() -> None:
     assert any("LLAUNCHER_AGENT_TOKEN" in d for d in dropped)
 
 
+def test_legacy_line_preceding_canonical_is_dropped() -> None:
+    """PR #325 review (regression pinned): the canonical line wins even when
+    a legacy line appears BEFORE it in line order — the pre-scan seeds the
+    canonical-key set from ALL lines before any drop/migrate decision."""
+    result = _invoke(
+        [
+            "LAUNCHER_AGENT_TOKEN=legacy1",
+            "LLAUNCHER_AGENT_TOKEN=canon",
+            "LAUNCHER_AGENT_TOKEN=legacy2",
+        ]
+    )
+    lines = _as_list(result["Lines"])
+    token_lines = [ln for ln in lines if ln.startswith("LLAUNCHER_AGENT_TOKEN=")]
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=canon"]
+    assert not any("legacy1" in ln or "legacy2" in ln for ln in lines)
+    dropped = _as_list(result["Dropped"])
+    assert len(dropped) == 2
+
+
 def test_samepass_legacy_collision_with_no_canonical_line_is_deduped() -> None:
     """Issue #298: two legacy same-key lines with NO pre-existing canonical
     line must still dedupe down to exactly one canonical line."""

--- a/tests/unit/test_install_sh_dedupe.py
+++ b/tests/unit/test_install_sh_dedupe.py
@@ -78,6 +78,32 @@ def test_legacy_token_colliding_with_canonical_is_dropped(tmp_path: Path) -> Non
     assert "#285" in (result.stdout + result.stderr)
 
 
+def test_samepass_legacy_collision_with_no_canonical_line_is_deduped(
+    tmp_path: Path,
+) -> None:
+    """Issue #298: two legacy same-key lines with NO pre-existing canonical
+    line must still dedupe down to exactly one canonical line — the
+    collision produced WITHIN this migration pass, not just against a
+    pre-existing canonical line."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LAUNCHER_AGENT_TOKEN=first\n"
+        "LAUNCHER_AGENT_TOKEN=second\n"
+        "LAUNCHER_AGENT_HOST=1.2.3.4\n"
+    )
+
+    result = _run_migration(env)
+
+    lines = env.read_text().splitlines()
+    token_lines = [ln for ln in lines if ln.strip().startswith("LLAUNCHER_AGENT_TOKEN=")]
+    # Exactly one canonical line results; the first occurrence wins.
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=first"], token_lines
+    assert "second" not in env.read_text()
+    assert "LLAUNCHER_AGENT_HOST=1.2.3.4" in lines
+    # The drop is reported loudly, same as the pre-existing-canonical case.
+    assert "Dropped" in result.stdout or "Dropped" in result.stderr
+
+
 def test_legacy_only_migrates_without_dropping(tmp_path: Path) -> None:
     """No canonical collision: legacy keys migrate in place, none dropped,
     exactly one canonical token line results."""

--- a/tests/unit/test_install_sh_dedupe.py
+++ b/tests/unit/test_install_sh_dedupe.py
@@ -78,6 +78,31 @@ def test_legacy_token_colliding_with_canonical_is_dropped(tmp_path: Path) -> Non
     assert "#285" in (result.stdout + result.stderr)
 
 
+def test_legacy_line_preceding_canonical_is_dropped(tmp_path: Path) -> None:
+    """PR #325 review (regression pinned): the canonical line wins the
+    collision even when a legacy line appears BEFORE it in file order. The
+    canonical-key set must be seeded from the WHOLE file before any
+    drop/migrate decision — a single top-to-bottom pass that grows the set
+    as it reads would migrate the leading legacy line and leave two
+    canonical lines."""
+    env = tmp_path / "agent.env"
+    env.write_text(
+        "LAUNCHER_AGENT_TOKEN=legacy1\n"
+        "LLAUNCHER_AGENT_TOKEN=canon\n"
+        "LAUNCHER_AGENT_TOKEN=legacy2\n"
+    )
+
+    result = _run_migration(env)
+
+    lines = env.read_text().splitlines()
+    token_lines = [ln for ln in lines if ln.strip().startswith("LLAUNCHER_AGENT_TOKEN=")]
+    # Exactly one canonical line survives — the pre-existing canonical value.
+    assert token_lines == ["LLAUNCHER_AGENT_TOKEN=canon"], token_lines
+    assert "legacy1" not in env.read_text()
+    assert "legacy2" not in env.read_text()
+    assert "Dropped" in (result.stdout + result.stderr)
+
+
 def test_samepass_legacy_collision_with_no_canonical_line_is_deduped(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Fixes #298

## What changed

Two non-blocking follow-ups from the #296 review, both confirmed **contained** by the #293 runtime fail-loud guard (no token-loss risk — envelope/UX defects only):

1. **Same-pass migrated-key dedupe** (`migrate_env_keys.sh` / `MigrateEnvKeys.ps1`): both scripts snapshotted the canonical-key set once *before* migrating. Two legacy same-key lines with **no** pre-existing canonical line (e.g. two `LAUNCHER_AGENT_TOKEN=` lines) both migrated to `LLAUNCHER_AGENT_TOKEN=`, producing two canonical lines and reporting "Migrated" instead of catching the collision. Both scripts now grow the canonical-key set as each legacy line migrates, in file order, so a same-pass collision is dropped identically to a pre-existing one (first occurrence wins, loudly reported as "Dropped").
2. **Guard message accuracy** (`llauncher/agent/server.py`, `run_agent`'s duplicate-token startup guard): the message said "re-run the installer to migrate it" as an alternative remediation. Since `count_env_file_token_lines` only counts *canonical* (double-L) lines, this guard only ever fires on two canonical lines — which the installer's migration cannot fix (it only touches legacy `LAUNCHER_AGENT_*` lines). The message now says so explicitly and points at a hand-edit as the only remediation.

## Why

`PARSE-AT-THE-DOOR`: a migration pass should never leave two shapes (here, two canonical lines) of the same persisted key behind, regardless of whether the collision source is pre-existing or produced within the pass itself. And a fail-loud guard's remediation text needs to name a path that actually works, not one that silently does nothing for this case.

## Tests

- `tests/unit/test_install_sh_dedupe.py::test_samepass_legacy_collision_with_no_canonical_line_is_deduped` — two legacy `LAUNCHER_AGENT_TOKEN=` lines, no canonical line, dedupe to one (first wins), drop reported.
- `tests/unit/test_install_ps1_dedupe.py::test_samepass_legacy_collision_with_no_canonical_line_is_deduped` — same scenario via `pwsh` (skips here, no `pwsh` on this box, consistent with the file's existing skip convention).
- `tests/unit/test_agent_duplicate_token_guard.py::test_run_agent_fails_loud_on_duplicate_token_lines` — extended to assert the message says "will not fix this" / "hand-edit" and no longer says "re-run the installer".

Manually verified both the pre-existing-canonical-collision and 3-way same-pass-collision cases, plus file-permission (0640) preservation, against the shell script directly.

## Gates

- Full pytest: **1501 passed, 20 skipped, 0 failed** (matches the clean-main baseline of zero pre-existing failures; the 20 skips are pre-existing skip conditions, e.g. `pwsh`-gated tests on this box).
- Coverage: **99.89%** (floor 93%), changed paths (`llauncher/agent/server.py`) at 100%.