### PR TITLE
test(coverage): drop the llauncher/ui/* omit and re-baseline the floor to 99 (#329)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,24 +40,24 @@ build-backend = "hatchling.build"
 # Coverage configuration
 # ---------------------------------------------------------------------------
 #
-# The aggregate line-coverage number is misleading for this project: the
-# Streamlit UI tabs (``llauncher/ui/*``) sit at 5–8% pending the AppTest
-# harness in #69, while the non-UI code base sits above 90%. A single
-# ``--cov-fail-under`` floor against the full source mixes those two
-# populations and either becomes vacuous (low) or blocks legitimate UI
-# work (high).
-#
-# Resolution: scope coverage measurement to non-UI sources via ``omit``
-# below, then enforce a meaningful floor in ``pytest.ini`` ``addopts``.
-# When #69 lands the UI harness, drop the ``llauncher/ui/*`` omit and
-# re-baseline the floor against the combined measurement.
+# The Streamlit UI is measured alongside everything else: the AppTest
+# harness landed via #328 (all 7 tabs driven behaviorally, per-module
+# 96–100%), so the old UI/non-UI split — and its ``llauncher/ui/*``
+# omit — is gone (#329). The ``--cov-fail-under`` floor in ``pytest.ini``
+# ``addopts`` is the *measured combined* number rounded down, not a
+# per-population compromise. Only genuine entry-point shims remain
+# omitted below, each with its rationale inline.
 
 [tool.coverage.run]
 source = ["llauncher"]
 branch = false
 omit = [
-    # UI tabs — deferred to #69 (Streamlit AppTest harness).
-    "llauncher/ui/*",
+    # Console-script entry shim for ``llauncher-ui`` that subprocess-execs
+    # ``python -m streamlit run`` (no cross-layer import, by design). Same
+    # entry-shim category as ``agent/__main__.py`` / ``mcp_server/__main__.py``
+    # below: its pure helpers are separable, but the module as a whole is not
+    # unit-import-testable. The rest of ``llauncher/ui/`` is measured (#329).
+    "llauncher/ui/launch.py",
     # CLI entry-point shim for ``python -m llauncher.agent``; covered
     # indirectly through integration runs of the agent, not unit tests.
     "llauncher/agent/__main__.py",

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,12 +5,11 @@ python_classes = Test*
 python_functions = test_*
 asyncio_mode = auto
 # Coverage configuration lives in pyproject.toml [tool.coverage.*].
-# The floor is set against the *non-UI* scope (ui/tabs is omitted there)
-# because the UI sub-tree is at 5–8% pending #69's Streamlit AppTest
-# harness; an aggregate floor would either be vacuous or block UI work.
-# Floor of 93% gives ~2pt headroom over the post-Phase D 95% baseline.
-# Re-baseline upward when #69 lands and ui/* joins the measurement.
-addopts = --cov=llauncher --cov-report=term --cov-fail-under=93 --strict-markers
+# The floor is the *measured combined* number (UI included since the
+# AppTest harness landed via #328) rounded down to an integer: 99.56%
+# measured at re-baseline (#329), floor 99. Only entry-point shims are
+# omitted; see the rationale inline in pyproject's [tool.coverage.run].
+addopts = --cov=llauncher --cov-report=term --cov-fail-under=99 --strict-markers
 markers =
     integration: Integration tests that may have external dependencies
     live: Live tests that interact with real llama-server processes


### PR DESCRIPTION
Fixes #329

**Measured combined coverage: 99.56%** (4545 stmts, 20 missed) — new floor `--cov-fail-under=99` (measured value rounded down). Suite: 1663 passed, 0 failed, 27 skipped, matching the pre-change baseline; the confirmation re-run passes against the new floor.

What changed:

- `pyproject.toml` `[tool.coverage.run]`: removed the `llauncher/ui/*` omit — the UI joins the combined measurement now that the AppTest harness covers all 7 tabs (#328, per-module 96–100%). Added a narrow omit for `llauncher/ui/launch.py` with the same entry-shim rationale as `agent/__main__.py` / `mcp_server/__main__.py` (console-script shim that subprocess-execs streamlit; pure helpers separable but the module isn't unit-import-testable as a whole). Rewrote the stale "when #69 lands" comment block to describe the combined posture (#328/#329).
- `pytest.ini`: `--cov-fail-under` 93 → 99; comment block updated to state the floor is the measured combined number, not the old non-UI split.

Run context: SP-7 of the #328 wave; parent run-ledger #331. Precondition verified before the change: main tip `b9879de` contained all six UI test-suite squashes, no unmerged wave PRs.