### PR TITLE
fix(ui): preserve same-model servers by port

### DIFF
--- a/llauncher/ui/tabs/model_card.py
+++ b/llauncher/ui/tabs/model_card.py
@@ -19,6 +19,7 @@ def render_model_card(
     node_name: str,
     model: dict,
     running_server: RemoteServerInfo | None = None,
+    widget_key_suffix: str = "",
 ) -> None:
     """Render a model card with inline toggle button and collapsed details.
 
@@ -48,7 +49,7 @@ def render_model_card(
         if is_running and running_server:
             if st.button(
                 status_icon,
-                key=f"toggle_stop_{node_name}_{model_name}",
+                key=f"toggle_stop_{node_name}_{model_name}{widget_key_suffix}",
                 help=f"Stop {model_name}",
                 width='stretch',
             ):
@@ -60,7 +61,15 @@ def render_model_card(
 
     # Collapsed expander for details (port, logs, edit button)
     with st.expander("📋 Details", expanded=False):
-        _render_model_details(state, aggregator, node_name, model_name, model, running_server)
+        _render_model_details(
+            state,
+            aggregator,
+            node_name,
+            model_name,
+            model,
+            running_server,
+            widget_key_suffix,
+        )
 
 
 def _render_start_button(
@@ -213,6 +222,7 @@ def _render_model_details(
     model_name: str,
     model: dict,
     running_server: RemoteServerInfo | None = None,
+    widget_key_suffix: str = "",
 ) -> None:
     """Render the model details in the expander.
 
@@ -262,7 +272,10 @@ def _render_model_details(
     if running_server:
         st.divider()
         with st.expander("📄 Logs (last 100 lines)", expanded=False):
-            if st.button("🔄 Refresh", key=f"refresh_logs_{node_name}_{model_name}"):
+            if st.button(
+                "🔄 Refresh",
+                key=f"refresh_logs_{node_name}_{model_name}{widget_key_suffix}",
+            ):
                 st.rerun()
 
             if node_name == "local":

--- a/llauncher/ui/tabs/models.py
+++ b/llauncher/ui/tabs/models.py
@@ -107,8 +107,23 @@ def render_models_tab(
 
     sorted_models = sorted(models_for_target, key=lambda m: m["name"].lower())
     for model in sorted_models:
-        running_server = running_map.get((target, model["name"]))
-        render_model_card(state, registry, aggregator, target, model, running_server)
+        running_servers = running_map.get((target, model["name"]), [])
+        if not running_servers:
+            render_model_card(state, registry, aggregator, target, model, None)
+            continue
+        for running_server in running_servers:
+            widget_key_suffix = (
+                f"_{running_server.port}" if len(running_servers) > 1 else ""
+            )
+            render_model_card(
+                state,
+                registry,
+                aggregator,
+                target,
+                model,
+                running_server,
+                widget_key_suffix=widget_key_suffix,
+            )
 
 
 def _get_editing_model(state: LauncherState) -> str | None:
@@ -128,9 +143,9 @@ def _build_running_map(
     state: LauncherState,
     aggregator: RemoteAggregator,
     target: str,
-) -> dict[tuple[str, str], RemoteServerInfo]:
-    """Index running servers by ``(node_name, config_name)`` for ``target``."""
-    running_map: dict[tuple[str, str], RemoteServerInfo] = {}
+) -> dict[tuple[str, str], list[RemoteServerInfo]]:
+    """Group running servers by ``(node_name, config_name)`` for ``target``."""
+    running_map: dict[tuple[str, str], list[RemoteServerInfo]] = {}
 
     if target == LOCAL_NODE:
         state.refresh()
@@ -144,10 +159,12 @@ def _build_running_map(
                 uptime_seconds=server.uptime_seconds(),
                 logs_path=server.logs_path,
             )
-            running_map[(LOCAL_NODE, server.config_name)] = info
+            running_map.setdefault((LOCAL_NODE, server.config_name), []).append(info)
     else:
         for server in aggregator.get_all_servers():
             if server.node_name == target:
-                running_map[(server.node_name, server.config_name)] = server
+                running_map.setdefault(
+                    (server.node_name, server.config_name), []
+                ).append(server)
 
     return running_map

--- a/tests/ui/test_models_tab.py
+++ b/tests/ui/test_models_tab.py
@@ -329,6 +329,26 @@ class TestModelCardLoop:
         # The lookup consumed a *fresh* process scan, not a stale snapshot.
         mock_state.refresh.assert_called_once_with()
 
+    def test_same_model_running_on_two_ports_gets_two_controllable_cards(
+        self, tab_harness, mock_state, mock_registry, mock_aggregator,
+        mock_sub_renders,
+    ):
+        mock_state.models["alpha"] = _model_config("alpha")
+        mock_state.running[PORT] = _local_server("alpha")
+        mock_state.running[PORT + 1] = _local_server(
+            "alpha", port=PORT + 1, pid=PID + 1
+        )
+
+        at = _tab(tab_harness, mock_state, mock_registry, mock_aggregator, "local")
+
+        assert not at.exception
+        calls = mock_sub_renders.render_model_card.call_args_list
+        assert [call.args[5].port for call in calls] == [PORT, PORT + 1]
+        assert [call.kwargs["widget_key_suffix"] for call in calls] == [
+            f"_{PORT}",
+            f"_{PORT + 1}",
+        ]
+
     def test_remote_target_cards_come_from_the_aggregator_not_local_state(
         self, tab_harness, mock_state, mock_registry, mock_aggregator,
         mock_sub_renders,


### PR DESCRIPTION
Closes #350

The Models tab now keeps every running instance for a model instead of overwriting earlier ports. When the same config is active on multiple ports, each instance gets its own card and port-qualified controls; single-instance widget keys remain unchanged

Regression coverage proves both same-config servers are rendered and independently keyed. All 60 focused Models-tab and model-card tests pass
