### PR TITLE
docs(readme): present both UI run postures per ADR-022 (#355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,22 @@ run.bat agent-bg     :: Start agent detached (logs to agent.log)
 run.bat discover     :: List discovered launch scripts
 ```
 
-### Running the agent as a service
+### Running as a service
 
 For a persistent install that survives reboots and restarts on crash,
 the agent ships with installers for systemd (Linux, user-mode) and NSSM
 (Windows). See [`docs/operations/run-as-a-service.md`](docs/operations/run-as-a-service.md).
-The UI is not service-managed by design — it's interactive and you
-launch it on demand.
+
+The UI supports two postures — pick whichever fits how you work:
+
+- **On demand:** `llauncher-ui` (or `./run.sh ui`) starts the dashboard in
+  the foreground for the session; close the terminal and it's gone.
+- **Per-operator `systemd --user` service** ([ADR-022](docs/adrs/accepted/022-llauncher-ui-user-service.md)):
+  install with [`scripts/systemd/install-ui.sh`](scripts/systemd/install-ui.sh)
+  for a unit that restarts on crash (`Restart=on-failure`) and logs to
+  journald (`journalctl --user -u llauncher-ui -f`). See
+  [`docs/operations/run-as-a-service.md`](docs/operations/run-as-a-service.md)
+  for the full install steps.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

README.md's "Running the agent as a service" section claimed the UI "is not service-managed by design — it's interactive and you launch it on demand." That predates [ADR-022](docs/adrs/accepted/022-llauncher-ui-user-service.md) (accepted 2026-06-28), which ships a per-operator `systemd --user` unit (`Restart=on-failure`, journald logging) installed via `scripts/systemd/install-ui.sh`.

This PR rewrites the section to present **both** supported UI run postures rather than stating on-demand launch as "the design":

- **On demand:** `llauncher-ui` / `./run.sh ui`.
- **Per-operator `systemd --user` service** (ADR-022): `scripts/systemd/install-ui.sh`, with pointers to `docs/operations/run-as-a-service.md` and the ADR itself.

The "not service-managed by design" phrasing is removed; on-demand is now framed as one option among two, matching the ADR-022 decision record.

## Why

README predates ADR-022 and directly contradicts the accepted decision record — the UI is no longer "not service-managed by design," it has a supported service posture. `docs/operations/run-as-a-service.md` was already updated for ADR-022; only README lagged.

No code changes — doc-only.

Closes #355

## Test plan

- [x] `git fetch origin` confirmed base at `b9879de` (matches issue's stated main)
- [x] `.venv/bin/pytest -q` run in full: 1664 passed, 26 skipped, 0 failed (env-local skip count differs from the issue's stated 1666/27 baseline only via environment-dependent opt-in markers — e.g. `pwsh` not installed in this sandbox — unrelated to this change)
- [x] Diff is README.md only, confirmed via `git diff`