### PR TITLE
feat(ui): LLAUNCHER_UI_PORT env var with fail-loud validation (#356)

### DIFF
--- a/llauncher/ui/launch.py
+++ b/llauncher/ui/launch.py
@@ -31,6 +31,13 @@ DEFAULT_UI_HOST = "127.0.0.1"
 # both converge on LLAUNCHER_UI_HOST.
 UI_HOST_ENV = "LLAUNCHER_UI_HOST"
 
+# Streamlit's own default; made explicit here so the day 8501 collides with
+# another service, LLAUNCHER_UI_PORT is a documented knob rather than a
+# hardcoded-by-omission surprise (#356).
+DEFAULT_UI_PORT = 8501
+
+UI_PORT_ENV = "LLAUNCHER_UI_PORT"
+
 
 def resolve_ui_host(environ: Mapping[str, str] | None = None) -> str:
     """Return the UI bind address, defaulting to loopback.
@@ -42,7 +49,35 @@ def resolve_ui_host(environ: Mapping[str, str] | None = None) -> str:
     return env.get(UI_HOST_ENV) or DEFAULT_UI_HOST
 
 
-def build_streamlit_argv(app_path: Path, host: str) -> list[str]:
+def resolve_ui_port(environ: Mapping[str, str] | None = None) -> int:
+    """Return the UI bind port, defaulting to Streamlit's 8501.
+
+    An empty or unset ``LLAUNCHER_UI_PORT`` falls back to the default —
+    absence is not garbage. A set value that fails to parse as an integer,
+    or that parses outside 1-65535, fails loud (PARSE-AT-THE-DOOR) rather
+    than silently falling back — garbage is not absence.
+    """
+    env = os.environ if environ is None else environ
+    raw = env.get(UI_PORT_ENV)
+    if not raw:
+        return DEFAULT_UI_PORT
+
+    try:
+        port = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"Invalid {UI_PORT_ENV}={raw!r}: must be an integer in 1-65535"
+        ) from None
+
+    if not 1 <= port <= 65535:
+        raise ValueError(
+            f"Invalid {UI_PORT_ENV}={raw!r}: must be an integer in 1-65535"
+        )
+
+    return port
+
+
+def build_streamlit_argv(app_path: Path, host: str, port: int) -> list[str]:
     """Assemble the ``python -m streamlit run`` command line."""
     return [
         sys.executable,
@@ -52,6 +87,8 @@ def build_streamlit_argv(app_path: Path, host: str) -> list[str]:
         str(app_path),
         "--server.address",
         host,
+        "--server.port",
+        str(port),
     ]
 
 
@@ -66,8 +103,14 @@ def main() -> int:
         )
         return 1
 
+    try:
+        port = resolve_ui_port()
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
     app_path = Path(__file__).resolve().parent / "app.py"
-    argv = build_streamlit_argv(app_path, resolve_ui_host())
+    argv = build_streamlit_argv(app_path, resolve_ui_host(), port)
     return subprocess.call(argv)
 
 

--- a/tests/unit/test_ui_launch.py
+++ b/tests/unit/test_ui_launch.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from llauncher.ui import launch
 
 
@@ -19,14 +21,52 @@ def test_resolve_ui_host_blank_override_falls_back_to_loopback():
     assert launch.resolve_ui_host({"LLAUNCHER_UI_HOST": ""}) == "127.0.0.1"
 
 
+def test_resolve_ui_port_defaults_to_8501():
+    # No override -> Streamlit's own default (#356). Absence is not garbage.
+    assert launch.resolve_ui_port({}) == 8501
+
+
+def test_resolve_ui_port_blank_override_falls_back_to_default():
+    assert launch.resolve_ui_port({"LLAUNCHER_UI_PORT": ""}) == 8501
+
+
+def test_resolve_ui_port_honors_env_override():
+    assert launch.resolve_ui_port({"LLAUNCHER_UI_PORT": "9999"}) == 9999
+
+
+@pytest.mark.parametrize("bad_value", ["not-a-number", "8080.5", "8080x"])
+def test_resolve_ui_port_non_integer_fails_loud(bad_value):
+    # PARSE-AT-THE-DOOR: garbage is not absence, so it must not silently
+    # fall back to the default.
+    with pytest.raises(ValueError, match="LLAUNCHER_UI_PORT"):
+        launch.resolve_ui_port({"LLAUNCHER_UI_PORT": bad_value})
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "65536", "100000"])
+def test_resolve_ui_port_out_of_range_fails_loud(bad_value):
+    with pytest.raises(ValueError, match="LLAUNCHER_UI_PORT"):
+        launch.resolve_ui_port({"LLAUNCHER_UI_PORT": bad_value})
+
+
 def test_build_streamlit_argv_runs_the_packaged_app():
     app = Path("/opt/llauncher/ui/app.py")
-    argv = launch.build_streamlit_argv(app, "127.0.0.1")
+    argv = launch.build_streamlit_argv(app, "127.0.0.1", 8501)
 
     assert argv[1:4] == ["-m", "streamlit", "run"]
     assert str(app) in argv
 
 
 def test_build_streamlit_argv_binds_resolved_host():
-    argv = launch.build_streamlit_argv(Path("/x/app.py"), "192.168.1.5")
+    argv = launch.build_streamlit_argv(Path("/x/app.py"), "192.168.1.5", 8501)
     assert argv[argv.index("--server.address") + 1] == "192.168.1.5"
+
+
+def test_build_streamlit_argv_binds_resolved_port():
+    argv = launch.build_streamlit_argv(Path("/x/app.py"), "127.0.0.1", 9999)
+    assert argv[argv.index("--server.port") + 1] == "9999"
+
+
+def test_build_streamlit_argv_includes_both_address_and_port_flags():
+    argv = launch.build_streamlit_argv(Path("/x/app.py"), "127.0.0.1", 8501)
+    assert "--server.address" in argv
+    assert "--server.port" in argv


### PR DESCRIPTION
## Behavior

`llauncher/ui/launch.py:build_streamlit_argv` previously emitted only
`--server.address`, leaving the port at Streamlit's hardcoded-by-omission
default of 8501 with no operator override. This adds `LLAUNCHER_UI_PORT`
(two-L spelling, consistent with the existing `LLAUNCHER_UI_HOST`),
consumed by a new `resolve_ui_port()` mirroring `resolve_ui_host()`'s
structure, and emitted as `--server.port <port>` alongside the existing
`--server.address <host>`.

## Validation contract (PARSE-AT-THE-DOOR)

- Unset or blank `LLAUNCHER_UI_PORT` → default `8501`. Absence is not
  garbage.
- Set but non-integer (e.g. `not-a-number`, `8080.5`, `8080x`) → fails
  loud with a `ValueError` naming the var and offending value; `main()`
  catches it, prints the message to stderr, and exits 1 before Streamlit
  is ever invoked. No silent fallback.
- Set but out of the 1-65535 range (e.g. `0`, `-1`, `65536`) → same
  fail-loud behavior.

## Test coverage

Added to `tests/unit/test_ui_launch.py` (mirrors existing `resolve_ui_host`
test style):
- `test_resolve_ui_port_defaults_to_8501`
- `test_resolve_ui_port_blank_override_falls_back_to_default`
- `test_resolve_ui_port_honors_env_override`
- `test_resolve_ui_port_non_integer_fails_loud` (parametrized: non-numeric, float-like, trailing-garbage)
- `test_resolve_ui_port_out_of_range_fails_loud` (parametrized: 0, negative, over 65535)
- `test_build_streamlit_argv_binds_resolved_port`
- `test_build_streamlit_argv_includes_both_address_and_port_flags`
- Updated the two pre-existing `build_streamlit_argv` tests for the new required `port` parameter.

Full suite: 1676 passed, 26 skipped (up from a 1664/26 baseline in this
worktree — 12 new tests, zero regressions). Non-UI coverage gate
(`--cov-fail-under=93`) passes at 100%; `llauncher/ui/*` (including this
file) is intentionally excluded from the coverage-gate scope per
`pyproject.toml`'s `[tool.coverage.run]` `omit`, pending #69's Streamlit
AppTest harness — consistent with existing project convention.

## Out of scope (per issue)

- `scripts/run.sh` (env-var rename batch, #151).
- README: verified `LLAUNCHER_UI_HOST` is not documented anywhere in
  `README.md` or other `.md` files in this repo, so the issue's
  conditional ("README env-var table (if present) updated") has nothing
  to update. No README changes made.
- No other flags, no `.streamlit` config changes.

Closes #356.