### PR TITLE
feat(systemd): pinned /opt/llauncher/venv units + compose ritual (#360)

### DIFF
--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -226,6 +226,71 @@ journalctl --user -u llauncher-ui -f      # live logs
 
 ---
 
+## Composing the pinned runtime venv
+
+**#357 ratified (2026-07-16): the systemd deployment runs from a unique,
+PINNED venv — `/opt/llauncher/venv` — independent of any operator's shell
+state and of any clone's working-tree state.** [ADR-023](../adrs/accepted/023-service-owned-venv-recomposition.md)'s
+service-owned-venv shape governs this; the repo `.venv` is dev-only and is
+**never** what a systemd `--user` unit's `ExecStart` resolves into (both the
+agent's and the UI's `--user` unit templates resolve through
+`/usr/local/bin` symlinks into `/opt/llauncher/venv` — see the sections
+above). Recomposing this venv **is** the deploy event: there is no
+auto-recompose (tracked separately, [#233](https://github.com/shanevcantwell/llauncher/issues/233))
+and no version-tag pin yet (tracked separately,
+[harness-tools#195](https://github.com/shanevcantwell/harness-tools/issues/195)) —
+today's ritual composes from a git ref (default `main`), records exactly
+what it installed, and is safe to re-run any time you want to redeploy.
+
+The ritual is a **root-owned, read-exec group `inference`** artifact,
+composed inside a deliberate sudo grant window and nothing else. It is one
+script, `scripts/systemd/install-cli.sh`, which performs every step below in
+sequence — the grant/revoke bracket is the operator's, the composition
+itself is not hand-typed:
+
+```bash
+# 1. Open your sudo grant window (however your host does that), then:
+
+# 2. Compose the pinned venv from the current default ref (main), or pin
+#    an explicit tag/branch/SHA with REF=:
+sudo bash scripts/systemd/install-cli.sh
+# sudo REF=v0.4.0-alpha bash scripts/systemd/install-cli.sh   # pin instead of `main`
+
+# 3. Confirm the pin — the manifest answers "what is this venv running"
+#    at any later time without re-deriving it:
+cat /opt/llauncher/venv-manifest.txt
+
+# 4. Restart the services so they pick up the recomposed venv:
+systemctl --user restart llauncher-agent
+systemctl --user restart llauncher-ui
+
+# 5. Revoke your sudo grant window.
+```
+
+What step 2 does, in order (so a failure is legible against a known
+sequence, not a black box): creates `/opt/llauncher/venv` if absent;
+`pip install`s `llauncher[ui]` **non-editable** from
+`git+https://github.com/shanevcantwell/llauncher.git@$REF` (never `-e`,
+never a local checkout path — the whole point is independence from any
+clone's working-tree state); records `pip freeze` plus the ref and a UTC
+timestamp to `/opt/llauncher/venv-manifest.txt`; symlinks
+`llauncher`, `llauncher-agent`, `llauncher-mcp`, and `llauncher-ui` into
+`/usr/local/bin`; and `chmod -R a+rX`s the whole tree (world read-exec,
+which is a superset of — and satisfies — group-`inference` read-exec; only
+root can write/recompose it).
+
+**Recompose = re-run the same script.** There is no separate "update" path:
+running `install-cli.sh` again refreshes the venv to the current `$REF` and
+overwrites the manifest to describe exactly what is now installed. If the
+pin was never composed on a host, both `install.sh` (the agent's `--user`
+installer) and `install-ui.sh` preflight for
+`/opt/llauncher/venv/bin/llauncher-agent` /
+`/opt/llauncher/venv/bin/llauncher-ui` respectively and **fail loud**,
+pointing back at this section — neither installer silently falls back to a
+repo venv.
+
+---
+
 ## Windows (NSSM)
 
 ### Prerequisites

--- a/scripts/systemd/install-cli.sh
+++ b/scripts/systemd/install-cli.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 # install-cli.sh — system install of the llauncher CLI from public origin/main.
 # ----------------------------------------------------------------------------
-# Installs `llauncher` (+ llauncher-mcp, llauncher-ui) onto the system PATH for
-# ALL accounts, pulled from the PUBLIC GitHub repo — decoupled from any dev
-# checkout and from any dev .venv. A dedicated venv lives at /opt/llauncher/venv
-# (its own Python, NOT added to PATH); only the console-script entry points are
-# symlinked into /usr/local/bin (already on every account's PATH). No venv bin
-# directory is ever placed on PATH.
+# Installs `llauncher` (+ llauncher-agent, llauncher-mcp, llauncher-ui) onto
+# the system PATH for ALL accounts, pulled from the PUBLIC GitHub repo —
+# decoupled from any dev checkout and from any dev .venv. A dedicated venv
+# lives at /opt/llauncher/venv (its own Python, NOT added to PATH); only the
+# console-script entry points are symlinked into /usr/local/bin (already on
+# every account's PATH). No venv bin directory is ever placed on PATH.
+#
+# This IS the compose ritual (#357 ratified Option A, issue #360): the
+# systemd deployment (agent user unit + UI user unit) resolves ExecStart
+# through these symlinks into this PINNED venv, independent of any operator's
+# state or any clone's working-tree state. Recompose = re-run this script;
+# that IS the deploy event. See docs/operations/run-as-a-service.md,
+# "Composing the pinned runtime venv", for the full grant-window ritual this
+# script is the composing step of.
 #
 # Usage (root):
 #   sudo bash scripts/systemd/install-cli.sh                 # install/refresh from main
@@ -21,12 +29,17 @@
 # ----------------------------------------------------------------------------
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/systemd/venv_manifest.sh
+. "$SCRIPT_DIR/venv_manifest.sh"
+
 REPO_URL="https://github.com/shanevcantwell/llauncher.git"
 REF="${REF:-main}"
 PREFIX="/opt/llauncher"
 VENV="$PREFIX/venv"
 BINDIR="/usr/local/bin"
-SCRIPTS=(llauncher llauncher-mcp llauncher-ui)
+MANIFEST="$PREFIX/venv-manifest.txt"
+SCRIPTS=(llauncher llauncher-agent llauncher-mcp llauncher-ui)
 
 [ "$(id -u)" -eq 0 ] || { echo "FATAL: run as root (sudo bash $0)"; exit 1; }
 
@@ -45,8 +58,17 @@ mkdir -p "$PREFIX"
 [ -x "$VENV/bin/python" ] || python3 -m venv "$VENV"
 "$VENV/bin/pip" install --quiet --upgrade pip
 
-echo "==> installing llauncher[ui] from public $REPO_URL @ $REF"
+echo "==> installing llauncher[ui] from public $REPO_URL @ $REF (non-editable)"
 "$VENV/bin/pip" install --quiet --upgrade "llauncher[ui] @ git+$REPO_URL@$REF"
+
+echo "==> recording the pin: $MANIFEST"
+# The answerable-at-any-time pin (#360): exactly what this composition
+# installed, so "what is /opt/llauncher/venv running" is never a guess.
+# Recomposing (re-running this script) overwrites the manifest along with
+# the venv — the manifest always describes the CURRENT /opt/llauncher/venv,
+# never a stale prior composition. Logic lives in venv_manifest.sh so it is
+# unit-testable without the network install above.
+write_venv_manifest "$VENV/bin/pip" "$MANIFEST" "$REF"
 
 echo "==> symlinking console scripts into $BINDIR (venv bin stays off PATH)"
 for s in "${SCRIPTS[@]}"; do
@@ -55,6 +77,8 @@ for s in "${SCRIPTS[@]}"; do
 done
 
 # world-readable/executable so every account can run the shared install
+# (venv-manifest.txt is a plain file under $PREFIX, so it inherits the
+# same read grant — the pin is answerable by any account, not just root).
 chmod -R a+rX "$PREFIX"
 
 echo "==> verify"

--- a/scripts/systemd/install-ui.sh
+++ b/scripts/systemd/install-ui.sh
@@ -9,7 +9,10 @@
 # Run as your OWN operator account — NOT root. The token-read path works in
 # place via your `inference`-group membership (host provisioning); the
 # /usr/local/bin/llauncher-ui symlink is placed by install-cli.sh (root).
-# Neither is this installer's job — it only warns if they are missing.
+# Neither is this installer's job. The pinned venv itself
+# (/opt/llauncher/venv, ADR-023, issue #360) is a hard preflight — this
+# installer FAILS LOUD if it is absent (no repo-venv fallback exists). The
+# symlink and group-membership preconditions remain soft warnings.
 #
 # LAUNCHER_STATE_DIR comes from the template (fixed at /var/lib/llauncher); it
 # is intentionally NOT overridable from this installer's caller environment.
@@ -71,14 +74,30 @@ uninstall() {
 
 [ "$DO_UNINSTALL" -eq 1 ] && uninstall
 
+# --- Preflight: the pinned venv is a hard requirement (issue #360) -----
+# #357 ratified Option A: the systemd deployment runs from a unique, PINNED
+# venv (/opt/llauncher/venv) independent of any operator's or clone's
+# working-tree state. There is no repo-venv fallback to degrade to — if the
+# pin was never composed, fail loud here and point at the ritual, rather
+# than rendering a unit doomed to fail at systemd's ExecStartPre backstop.
+PINNED_VENV="/opt/llauncher/venv"
+if [ ! -x "$PINNED_VENV/bin/llauncher-ui" ]; then
+    err "$PINNED_VENV/bin/llauncher-ui not found — the pinned runtime venv has"
+    err "not been composed on this host (ADR-023, issue #360). There is no"
+    err "fallback to a repo venv. Compose it (root, one-time or to recompose):"
+    err "  sudo bash $SCRIPT_DIR/install-cli.sh"
+    err "See docs/operations/run-as-a-service.md, \"Composing the pinned runtime venv\"."
+    exit 1
+fi
+
 # --- Preflight (warn, do NOT block) ------------------------------------
-# Both conditions are operator/host provisioning, out of this installer's
-# scope (ADR-022 §installer-vs-host-provisioning). Warn loudly so the cause
-# of a later failure is legible, but proceed — the unit can be rendered and
+# Host-provisioning conditions, out of this installer's scope (ADR-022
+# §installer-vs-host-provisioning). Warn loudly so the cause of a later
+# 403/token failure is legible, but proceed — the unit can be rendered and
 # enabled now; it will become functional once provisioning is in place.
 if [ ! -x "$UI_BIN" ]; then
-    info "[user:gate] $UI_BIN is absent. The unit's ExecStart points there."
-    info "  Run the CLI installer as root first:"
+    info "[user:gate] $UI_BIN is absent even though the pinned venv exists."
+    info "  Re-run the CLI installer as root to re-place the symlink:"
     info "    sudo bash $SCRIPT_DIR/install-cli.sh"
     info "  Until then the service will fail to start."
 fi

--- a/scripts/systemd/install.sh
+++ b/scripts/systemd/install.sh
@@ -3,11 +3,18 @@
 #
 # Two install scopes:
 #   --user   (default) — per-user unit under ~/.config/systemd/user, state
-#                        under $HOME. Unchanged from the original installer.
+#                        under $HOME. ExecStart resolves through
+#                        /usr/local/bin/llauncher-agent into the PINNED,
+#                        root-owned /opt/llauncher/venv (#357 ratified
+#                        Option A, issue #360) — never this checkout's
+#                        .venv. See docs/operations/run-as-a-service.md,
+#                        "Composing the pinned runtime venv".
 #   --system           — system unit at /etc/systemd/system run as the
 #                        dedicated `llauncher` account (group `inference`),
 #                        with state under /var/lib/llauncher. Requires root
-#                        and pre-existing host provisioning. See ADR-018.
+#                        and pre-existing host provisioning. Still recomposes
+#                        this checkout's dev-tree .venv (ADR-023 Phase A,
+#                        issue #227) — unchanged by #360. See ADR-018.
 #
 # Idempotent: safe to re-run after a `git pull` to pick up unit-file
 # changes. Will NOT overwrite an existing env file (so your token and
@@ -134,10 +141,33 @@ uninstall() {
 [ "$DO_UNINSTALL" -eq 1 ] && uninstall
 
 # --- Preflight ---------------------------------------------------------
-if [ ! -x "$VENV_BIN/llauncher-agent" ]; then
-    err "Did not find $VENV_BIN/llauncher-agent."
-    err "Run './scripts/run.sh setup' first to recompose the venv (ADR-023)."
-    exit 1
+# #357 ratified Option A (issue #360): the --user agent unit's ExecStart no
+# longer resolves into this dev checkout's .venv — it resolves through
+# /usr/local/bin/llauncher-agent into the PINNED, root-owned
+# /opt/llauncher/venv (same indirection ADR-023 already uses for the UI
+# unit). Fail loud here, at install time, rather than silently falling back
+# to a repo venv (which the unit template no longer even points at).
+#
+# --system mode is UNCHANGED by #360: it recomposes @PROJECT_DIR@/.venv via
+# the root ensure-venv oneshot (ADR-023 Phase A, issue #227) and still needs
+# that dev-tree venv populated first.
+if [ "$MODE" = "system" ]; then
+    if [ ! -x "$VENV_BIN/llauncher-agent" ]; then
+        err "Did not find $VENV_BIN/llauncher-agent."
+        err "Run './scripts/run.sh setup' first to recompose the venv (ADR-023)."
+        exit 1
+    fi
+else
+    PINNED_VENV="/opt/llauncher/venv"
+    if [ ! -x "$PINNED_VENV/bin/llauncher-agent" ]; then
+        err "Did not find $PINNED_VENV/bin/llauncher-agent."
+        err "The --user agent unit's ExecStart resolves through /usr/local/bin/llauncher-agent"
+        err "into the pinned $PINNED_VENV (ADR-023, issue #360) — there is no fallback to a"
+        err "repo venv. Compose it (root, one-time or to recompose):"
+        err "  sudo bash $SCRIPT_DIR/install-cli.sh"
+        err "See docs/operations/run-as-a-service.md, \"Composing the pinned runtime venv\"."
+        exit 1
+    fi
 fi
 
 if ! command -v systemctl >/dev/null; then
@@ -200,7 +230,11 @@ if [ ! -f "$ENV_FILE" ]; then
         say "Wrote $ENV_FILE, carrying forward the token from $TOKEN_FILE (not overwritten with a fresh one)."
     else
         info "Seeding $ENV_FILE from the template (one-time; see agent.env.example header)..."
-        TOKEN="$("$VENV_BIN/python" -c 'import secrets; print(secrets.token_urlsafe(32))')"
+        # Plain python3 (issue #360): token generation must not depend on
+        # either venv existing at install time — the dev .venv is no longer
+        # a --user-mode precondition, and the pinned /opt venv may not have
+        # been composed yet when this seeds the FIRST env file.
+        TOKEN="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
         # Seed from the example, then substitute the placeholder token.
         sed "s|replace-me-with-a-random-token|$TOKEN|" "$ENV_EXAMPLE" > "$ENV_FILE"
         say "Wrote $ENV_FILE (mode $FILE_MODE) with a generated 32-byte token."
@@ -294,6 +328,11 @@ if [ -z "$TOKEN_VALUE" ]; then
 fi
 
 # --- Unit file ---------------------------------------------------------
+# @VENV_BIN@ only appears in the --system template (llauncher-agent.service.system.in,
+# ADR-023 Phase A dev-tree recompose, unchanged by #360). The --user template
+# (llauncher-agent.service.in) dropped the placeholder — its ExecStart is a
+# fixed /usr/local/bin/llauncher-agent, so this substitution is a harmless
+# no-op there.
 mkdir -p "$UNIT_DIR"
 sed \
     -e "s|@VENV_BIN@|$VENV_BIN|g" \
@@ -306,8 +345,11 @@ say "Rendered unit to $UNIT_PATH"
 # The agent system unit Requires=/After= this root oneshot so the agent never
 # starts against a missing/broken venv. It is system-scoped because recompose
 # must run where the dev-tree .venv is writable (root), not as User=llauncher.
-# User mode owns its own venv via `run.sh setup` at launch, so it gets no
-# ensure unit here.
+# User mode's ExecStart now resolves through /usr/local/bin/llauncher-agent
+# into the PINNED /opt/llauncher/venv (issue #360) — it neither owns nor
+# recomposes a venv itself, and gets a fail-loud ExecStartPre backstop in
+# the unit template instead (mirrors the UI unit, ADR-023 Phase B). So it
+# gets no ensure unit here either.
 if [ "$MODE" = "system" ]; then
     ENSURE_TEMPLATE="$SCRIPT_DIR/llauncher-agent-ensure-venv.service.in"
     ENSURE_UNIT_PATH="$UNIT_DIR/$ENSURE_UNIT_NAME"

--- a/scripts/systemd/llauncher-agent.service.in
+++ b/scripts/systemd/llauncher-agent.service.in
@@ -14,6 +14,16 @@
 ;
 ; To autostart at boot without an active login session, run once:
 ;   sudo loginctl enable-linger "$USER"
+;
+; ADR-023 (#357 ratified Option A, issue #360): ExecStart resolves through
+; /usr/local/bin/llauncher-agent -> /opt/llauncher/venv/bin/llauncher-agent,
+; a PINNED venv independent of any dev checkout's working-tree state — never
+; @PROJECT_DIR@/.venv. The symlink is placed by scripts/systemd/install-cli.sh
+; (root; the single named owner of /opt/llauncher/venv per ADR-023). This unit
+; runs as the operator uid and CANNOT recompose that root-owned tree
+; (cross-scope recompose is forbidden), so it only DETECTS-and-FAILS-LOUD —
+; see the ExecStartPre backstop below, mirroring the UI unit's (ADR-023
+; Phase B / issue #228).
 
 [Unit]
 Description=llauncher remote management agent
@@ -32,7 +42,24 @@ Type=simple
 ; LLAUNCHER_AGENT_TOKEN, _HOST, _PORT, _NODE_NAME live there so
 ; `systemctl --user cat llauncher-agent` does not leak the token.
 EnvironmentFile=@ENV_FILE@
-ExecStart=@VENV_BIN@/llauncher-agent
+
+; Fail-loud backstop (ADR-023, issue #360): ExecStart resolves
+; /usr/local/bin/llauncher-agent -> /opt/llauncher/venv/bin/llauncher-agent,
+; the shared, ROOT-owned venv the operator's disk-hygiene policy treats as
+; non-durable (freely reaped by a sweep). A `systemd --user` unit CANNOT
+; write or recompose that root tree, and CANNOT Requires=/After= a system
+; ensure unit (cross-scope dependency forbidden) — so it only
+; DETECTS-and-FAILS-LOUD: if the shared venv or its llauncher-agent entry
+; point is missing/unusable, exit nonzero so the unit enters `failed` with
+; an actionable journal line, rather than starting a broken agent.
+; Recompose is a ROOT action: the operator re-runs the compose ritual
+; documented in docs/operations/run-as-a-service.md
+; ("Composing the pinned runtime venv"), which wraps
+; scripts/systemd/install-cli.sh. Invariant VENV-OWNED-OR-GUARANTEED /
+; PARSE-AT-THE-DOOR: guarantee or fail loud at the door; never start a
+; degraded service. (No leading `-`: a nonzero exit here MUST fail the unit.)
+ExecStartPre=/bin/sh -c 'test -d /opt/llauncher/venv && test -x /opt/llauncher/venv/bin/llauncher-agent || { echo "llauncher-agent backstop (ADR-023): shared venv /opt/llauncher/venv or its llauncher-agent entry point is missing or not executable. A --user unit cannot recompose this root-owned venv (cross-scope recompose is forbidden). Recompose it as root: sudo bash scripts/systemd/install-cli.sh (see docs/operations/run-as-a-service.md, \"Composing the pinned runtime venv\")" >&2; exit 1; }'
+ExecStart=/usr/local/bin/llauncher-agent
 WorkingDirectory=@PROJECT_DIR@
 
 ; Graceful: uvicorn (llauncher/agent/server.py:136) handles SIGTERM

--- a/scripts/systemd/venv_manifest.sh
+++ b/scripts/systemd/venv_manifest.sh
@@ -1,0 +1,28 @@
+# shellcheck shell=bash
+# Pinned-venv composition manifest, extracted so it is unit-testable in
+# isolation (tests/unit/test_install_cli_manifest.py) without driving the
+# full install-cli.sh network install (venv creation + `pip install` from
+# git+https). Sourced by scripts/systemd/install-cli.sh; defines one
+# function and runs nothing at source time.
+#
+# #357 ratified Option A (issue #360): the compose ritual records exactly
+# what it installed to /opt/llauncher/venv-manifest.txt — "the pin,
+# answerable at any time" (the issue's own words) rather than a guess.
+# Recompose = re-run the ritual, which overwrites the manifest so it always
+# describes the CURRENT pinned venv, never a stale prior composition.
+
+write_venv_manifest() {
+    # Args: $1 = path to the venv's pip binary, $2 = manifest destination
+    # path, $3 = the git ref that was installed.
+    local pip_bin="$1"
+    local manifest_path="$2"
+    local ref="$3"
+
+    {
+        echo "# llauncher /opt/llauncher/venv composition manifest"
+        echo "# Written by scripts/systemd/install-cli.sh — do not hand-edit."
+        echo "# ref: $ref"
+        echo "# composed: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        "$pip_bin" freeze
+    } > "$manifest_path"
+}

--- a/tests/unit/test_agent_venv_backstop.py
+++ b/tests/unit/test_agent_venv_backstop.py
@@ -1,0 +1,200 @@
+"""Guards for the agent's --user unit pinned-venv fail-loud backstop (#360).
+
+#357 ratified Option A: the systemd deployment (agent + UI --user units) runs
+from a unique, PINNED venv (``/opt/llauncher/venv``) independent of any dev
+checkout's working-tree state. ``llauncher-agent.service.in`` (the --user
+template) now resolves ``ExecStart`` through
+``/usr/local/bin/llauncher-agent -> /opt/llauncher/venv/bin/llauncher-agent``
+instead of ``@VENV_BIN@/llauncher-agent`` (this checkout's dev ``.venv``).
+
+Mirrors ``tests/unit/test_ui_venv_backstop.py`` (ADR-023 Phase B, issue #228)
+for the UI unit — same shape, same invariant (VENV-OWNED-OR-GUARANTEED /
+PARSE-AT-THE-DOOR), applied to the agent's --user template.
+
+Two surfaces are exercised:
+
+1. Static wiring — the ``ExecStartPre`` backstop is present, fail-loud (no
+   leading ``-``), keys on ``/opt/llauncher/venv`` + the entry point, names
+   the real remediation, ``ExecStart`` itself resolves through the
+   ``/usr/local/bin`` symlink (never ``@VENV_BIN@``/the dev checkout), and
+   the unit takes on no cross-scope dependency on a system ensure unit.
+
+2. Behavior — the actual ``ExecStartPre`` shell command, extracted from the
+   template and run against a hermetic fake ``/opt`` tree, no-ops when the
+   entry point is present and fails loud when the venv or entry point is
+   missing/unusable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until a ``.git`` entry is found."""
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+SYSTEMD_DIR = _repo_root() / "scripts" / "systemd"
+AGENT_UNIT = SYSTEMD_DIR / "llauncher-agent.service.in"
+
+
+def _directive_lines(text: str) -> list[str]:
+    """Non-comment unit lines (comments start with ';')."""
+    return [ln.strip() for ln in text.splitlines() if not ln.lstrip().startswith(";")]
+
+
+def _exec_start_pre_lines(text: str) -> list[str]:
+    return [ln for ln in _directive_lines(text) if ln.startswith("ExecStartPre=")]
+
+
+def _exec_start_line(text: str) -> str:
+    lines = [ln for ln in _directive_lines(text) if ln.startswith("ExecStart=")]
+    assert len(lines) == 1, lines
+    return lines[0]
+
+
+# ───────────────────────── static unit wiring ──────────────────────────
+
+
+def test_exec_start_resolves_through_usr_local_bin_symlink():
+    """ExecStart never points at @VENV_BIN@/the dev checkout's .venv."""
+    line = _exec_start_line(AGENT_UNIT.read_text())
+    assert line == "ExecStart=/usr/local/bin/llauncher-agent", line
+    assert "@VENV_BIN@" not in AGENT_UNIT.read_text()
+    assert ".venv" not in line
+
+
+def test_backstop_execstartpre_present():
+    """The agent --user unit carries exactly one ExecStartPre backstop."""
+    pre = _exec_start_pre_lines(AGENT_UNIT.read_text())
+    assert len(pre) == 1, pre
+
+
+def test_backstop_checks_shared_venv_and_entrypoint():
+    """It verifies BOTH the shared venv dir AND the llauncher-agent entry point."""
+    line = _exec_start_pre_lines(AGENT_UNIT.read_text())[0]
+    assert "test -d /opt/llauncher/venv" in line
+    assert "test -x /opt/llauncher/venv/bin/llauncher-agent" in line
+
+
+def test_backstop_is_fail_loud_not_best_effort():
+    """No leading '-' on the directive: a nonzero check MUST fail the unit."""
+    line = _exec_start_pre_lines(AGENT_UNIT.read_text())[0]
+    assert not line.startswith("ExecStartPre=-")
+    assert "exit 1" in line
+
+
+def test_backstop_names_real_remediation_command():
+    """The journal message points at the REAL, existing root recompose step."""
+    line = _exec_start_pre_lines(AGENT_UNIT.read_text())[0]
+    assert "sudo bash scripts/systemd/install-cli.sh" in line
+    assert (SYSTEMD_DIR / "install-cli.sh").exists()
+
+
+def test_backstop_message_goes_to_stderr():
+    """Fail-loud line must reach the journal via stderr."""
+    line = _exec_start_pre_lines(AGENT_UNIT.read_text())[0]
+    assert ">&2" in line
+
+
+def test_agent_unit_takes_no_cross_scope_dependency():
+    """A --user unit must NOT Requires=/After= a system ensure unit (forbidden)."""
+    directives = _directive_lines(AGENT_UNIT.read_text())
+    assert not any(ln.startswith("Requires=") for ln in directives)
+    assert not any(
+        ln.startswith("After=") and "ensure-venv" in ln for ln in directives
+    )
+    line = _exec_start_pre_lines(AGENT_UNIT.read_text())[0]
+    assert "install-cli.sh" in line  # present as guidance...
+    assert "bash scripts/systemd/install-cli.sh" not in line.split("echo", 1)[0]
+
+
+# ───────────────────────── behavior of the check ───────────────────────
+
+
+def _backstop_command(text: str) -> str:
+    """Extract the `/bin/sh -c '<cmd>'` payload from the ExecStartPre line."""
+    line = _exec_start_pre_lines(text)[0]
+    prefix = "ExecStartPre=/bin/sh -c "
+    assert line.startswith(prefix), line
+    payload = line[len(prefix):]
+    assert payload.startswith("'") and payload.endswith("'"), payload
+    return payload[1:-1]
+
+
+def _run_backstop(cmd: str, fake_root: Path) -> subprocess.CompletedProcess[str]:
+    """Run the backstop command with /opt rerooted under a tmp dir.
+
+    The command hardcodes absolute /opt paths; we rewrite them to the fake
+    root so the test is hermetic and touches no real system path — in
+    particular never the real /opt/llauncher/venv (out of this issue's
+    scope: composing it is a user:gate operator action, not this test's).
+    """
+    rerooted = cmd.replace("/opt/llauncher/venv", str(fake_root / "opt/llauncher/venv"))
+    return subprocess.run(
+        ["bash", "-c", rerooted],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _make_entrypoint(fake_root: Path) -> Path:
+    venv_bin = fake_root / "opt/llauncher/venv/bin"
+    venv_bin.mkdir(parents=True)
+    ep = venv_bin / "llauncher-agent"
+    ep.write_text("#!/bin/sh\n")
+    ep.chmod(0o755)
+    return ep
+
+
+def test_backstop_noop_when_entrypoint_present(tmp_path: Path):
+    """Present, executable entry point => clean exit, no message."""
+    cmd = _backstop_command(AGENT_UNIT.read_text())
+    _make_entrypoint(tmp_path)
+
+    result = _run_backstop(cmd, tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr.strip() == ""
+
+
+def test_backstop_fails_loud_when_venv_missing(tmp_path: Path):
+    """No /opt venv at all => nonzero + remediation on stderr."""
+    cmd = _backstop_command(AGENT_UNIT.read_text())
+
+    result = _run_backstop(cmd, tmp_path)
+
+    assert result.returncode != 0
+    assert "install-cli.sh" in result.stderr
+
+
+def test_backstop_fails_loud_when_entrypoint_missing(tmp_path: Path):
+    """Venv dir exists but the entry point does not => fail loud."""
+    cmd = _backstop_command(AGENT_UNIT.read_text())
+    (tmp_path / "opt/llauncher/venv").mkdir(parents=True)
+
+    result = _run_backstop(cmd, tmp_path)
+
+    assert result.returncode != 0
+    assert "install-cli.sh" in result.stderr
+
+
+def test_backstop_fails_loud_when_entrypoint_not_executable(tmp_path: Path):
+    """Entry point present but not executable => 'usable' check fails loud."""
+    cmd = _backstop_command(AGENT_UNIT.read_text())
+    ep = _make_entrypoint(tmp_path)
+    ep.chmod(0o644)
+
+    result = _run_backstop(cmd, tmp_path)
+
+    assert result.returncode != 0
+    assert "install-cli.sh" in result.stderr

--- a/tests/unit/test_install_cli_manifest.py
+++ b/tests/unit/test_install_cli_manifest.py
@@ -1,0 +1,171 @@
+"""Guards for the pinned-venv compose ritual's manifest (#357 ratified
+Option A, issue #360).
+
+The compose ritual (``scripts/systemd/install-cli.sh``) records exactly
+what it installed to ``/opt/llauncher/venv-manifest.txt`` — "the pin,
+answerable at any time" per the issue's acceptance criteria — via
+``write_venv_manifest`` (extracted to ``scripts/systemd/venv_manifest.sh``
+so it is testable without driving the real network install). These tests
+never touch the real ``/opt/llauncher/venv`` or the network: they call
+``write_venv_manifest`` directly against a fake ``pip`` and a ``tmp_path``
+manifest destination.
+
+A second group asserts install-cli.sh's static wiring: ``llauncher-agent``
+is now a symlinked script (the gap #360 closes — it was previously absent
+from ``SCRIPTS``, so the agent's --user unit had no ``/usr/local/bin``
+symlink to resolve through), and the manifest path/sourcing are wired
+in-script.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+SYSTEMD_DIR = _repo_root() / "scripts" / "systemd"
+INSTALL_CLI = SYSTEMD_DIR / "install-cli.sh"
+MANIFEST_HELPER = SYSTEMD_DIR / "venv_manifest.sh"
+
+
+# ───────────────────────── write_venv_manifest() ────────────────────────
+
+
+def _make_fake_pip(tmp_path: Path, freeze_output: str) -> Path:
+    """A fake `pip` whose `freeze` subcommand prints fixed output."""
+    fake_pip = tmp_path / "fake-pip"
+    fake_pip.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "freeze" ]; then\n'
+        f'  printf %s "{freeze_output}"\n'
+        "fi\n"
+    )
+    fake_pip.chmod(0o755)
+    return fake_pip
+
+
+def _write_manifest(
+    pip_bin: Path, manifest_path: Path, ref: str
+) -> subprocess.CompletedProcess[str]:
+    script = (
+        "set -euo pipefail\n"
+        f'source "{MANIFEST_HELPER}"\n'
+        f'write_venv_manifest "{pip_bin}" "{manifest_path}" "{ref}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_manifest_contains_ref_and_pip_freeze(tmp_path: Path):
+    manifest = tmp_path / "venv-manifest.txt"
+    fake_pip = _make_fake_pip(tmp_path, "llauncher==0.4.0\nfastapi==0.111.0\n")
+
+    _write_manifest(fake_pip, manifest, "v0.4.0-alpha")
+
+    text = manifest.read_text()
+    assert "# ref: v0.4.0-alpha" in text
+    assert "llauncher==0.4.0" in text
+    assert "fastapi==0.111.0" in text
+
+
+def test_manifest_has_a_composed_timestamp(tmp_path: Path):
+    manifest = tmp_path / "venv-manifest.txt"
+    fake_pip = _make_fake_pip(tmp_path, "llauncher==0.4.0\n")
+
+    _write_manifest(fake_pip, manifest, "main")
+
+    text = manifest.read_text()
+    composed_lines = [ln for ln in text.splitlines() if ln.startswith("# composed:")]
+    assert len(composed_lines) == 1, composed_lines
+    # UTC ISO-8601-ish stamp, e.g. "# composed: 2026-07-17T12:00:00Z"
+    assert composed_lines[0].endswith("Z")
+
+
+def test_manifest_warns_against_hand_editing(tmp_path: Path):
+    manifest = tmp_path / "venv-manifest.txt"
+    fake_pip = _make_fake_pip(tmp_path, "llauncher==0.4.0\n")
+
+    _write_manifest(fake_pip, manifest, "main")
+
+    assert "do not hand-edit" in manifest.read_text().lower()
+
+
+def test_recompose_overwrites_stale_manifest(tmp_path: Path):
+    """Re-running the ritual must describe the CURRENT venv, not append to
+    or preserve a stale prior composition."""
+    manifest = tmp_path / "venv-manifest.txt"
+    old_pip = _make_fake_pip(tmp_path, "llauncher==0.3.0\n")
+    _write_manifest(old_pip, manifest, "v0.3.0")
+    assert "llauncher==0.3.0" in manifest.read_text()
+
+    new_pip = _make_fake_pip(tmp_path, "llauncher==0.4.0\n")
+    _write_manifest(new_pip, manifest, "v0.4.0-alpha")
+
+    text = manifest.read_text()
+    assert "llauncher==0.4.0" in text
+    assert "llauncher==0.3.0" not in text
+    assert "# ref: v0.4.0-alpha" in text
+    assert "# ref: v0.3.0" not in text
+
+
+# ───────────────────────── install-cli.sh static wiring ────────────────
+
+
+def test_llauncher_agent_is_symlinked_by_install_cli():
+    """The gap #360 closes: llauncher-agent was previously absent from
+    SCRIPTS, so the agent --user unit had no /usr/local/bin symlink to
+    resolve ExecStart through. It must be a first-class symlinked script,
+    alongside the CLI/UI scripts install-cli.sh already placed."""
+    text = INSTALL_CLI.read_text()
+    assert "SCRIPTS=(llauncher llauncher-agent llauncher-mcp llauncher-ui)" in text
+
+
+def test_install_cli_sources_the_manifest_helper():
+    text = INSTALL_CLI.read_text()
+    assert '. "$SCRIPT_DIR/venv_manifest.sh"' in text
+
+
+def test_install_cli_writes_manifest_before_symlinking():
+    """The manifest must describe the composition BEFORE the console
+    scripts are (re)pointed at it, so a partial/failed manifest write never
+    leaves symlinks pointing at an undocumented pin."""
+    lines = INSTALL_CLI.read_text().splitlines()
+    manifest_idx = next(
+        i for i, ln in enumerate(lines) if "write_venv_manifest" in ln
+    )
+    symlink_idx = next(
+        i for i, ln in enumerate(lines) if 'ln -sfn "$VENV/bin/$s"' in ln
+    )
+    assert manifest_idx < symlink_idx
+
+
+def test_manifest_path_is_under_prefix():
+    text = INSTALL_CLI.read_text()
+    assert 'MANIFEST="$PREFIX/venv-manifest.txt"' in text
+
+
+def test_uninstall_removes_the_manifest_with_the_prefix():
+    """--uninstall's rm -rf "$PREFIX" already covers the manifest (it lives
+    under $PREFIX) — pin this so a future refactor that moves the manifest
+    out from under $PREFIX is caught."""
+    text = INSTALL_CLI.read_text()
+    assert 'rm -rf "$PREFIX"' in text

--- a/tests/unit/test_pinned_venv_install_preflight.py
+++ b/tests/unit/test_pinned_venv_install_preflight.py
@@ -1,0 +1,203 @@
+"""Guards for the installers' pinned-venv preflight (#357 ratified Option A,
+issue #360).
+
+Both ``scripts/systemd/install.sh`` (--user mode) and
+``scripts/systemd/install-ui.sh`` must fail loud, at install time, when
+``/opt/llauncher/venv`` has never been composed on the host — with **no
+silent fallback to a repo venv** (the acceptance criterion's own words).
+``install.sh --system`` mode is UNCHANGED by #360 (it still recomposes this
+checkout's dev-tree ``.venv`` via ADR-023 Phase A) and is asserted to stay
+that way.
+
+These tests never touch the real ``/opt/llauncher/venv`` (a fully composed
+one may already exist on the dev host — out of this issue's scope to
+compose or depend on it either way). Each copies the real installer script
+into a hermetic ``tmp_path`` and rewrites its hardcoded ``/opt/llauncher/venv``
+occurrences to a fake root under ``tmp_path`` before running it — the same
+rerooting technique ``test_ui_venv_backstop.py`` uses for the unit template's
+``ExecStartPre`` command, applied here to the whole installer script.
+
+Both installers exit during preflight (well before any ``systemctl`` call)
+when the pinned venv is absent, so these tests need no live systemd user
+session — the process under test never reaches that far.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash not available"
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+SYSTEMD_DIR = _repo_root() / "scripts" / "systemd"
+
+
+def _hermetic_systemd_copy(tmp_path: Path, fake_opt_venv: Path) -> Path:
+    """Copy scripts/systemd/ into tmp_path with /opt/llauncher/venv rerooted.
+
+    SCRIPT_DIR is derived from BASH_SOURCE at runtime, so sibling files
+    (templates, migrate_env_keys.sh) must be copied alongside for a faithful
+    hermetic run. The hardcoded ``/opt/llauncher/venv`` string is rewritten
+    to ``fake_opt_venv`` in every copied file so the preflight check never
+    touches the real system path.
+    """
+    dest_dir = tmp_path / "scripts" / "systemd"
+    shutil.copytree(SYSTEMD_DIR, dest_dir)
+    for f in dest_dir.iterdir():
+        if f.is_file():
+            text = f.read_text()
+            if "/opt/llauncher/venv" in text:
+                f.write_text(text.replace("/opt/llauncher/venv", str(fake_opt_venv)))
+    return dest_dir
+
+
+def _make_entrypoint(fake_opt_venv: Path, name: str) -> Path:
+    venv_bin = fake_opt_venv / "bin"
+    venv_bin.mkdir(parents=True, exist_ok=True)
+    ep = venv_bin / name
+    ep.write_text("#!/bin/sh\n")
+    ep.chmod(0o755)
+    return ep
+
+
+# ─────────────────────── install.sh (--user mode) ───────────────────────
+
+
+def test_user_mode_fails_loud_when_pinned_venv_absent(tmp_path: Path):
+    """--user install.sh must exit nonzero, naming the ritual, when the
+    pinned /opt/llauncher/venv has never been composed."""
+    fake_opt_venv = tmp_path / "opt" / "llauncher" / "venv"
+    systemd_dir = _hermetic_systemd_copy(tmp_path, fake_opt_venv)
+    env = {"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin"}
+
+    result = subprocess.run(
+        ["bash", str(systemd_dir / "install.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "opt/llauncher/venv" in combined or str(fake_opt_venv) in combined
+    assert "install-cli.sh" in combined
+    assert "run-as-a-service.md" in combined
+    assert "Composing the pinned runtime venv" in combined
+    # No silent fallback message implying success:
+    assert "Rendered unit" not in combined
+
+
+def test_user_mode_preflight_passes_when_pinned_venv_present(tmp_path: Path):
+    """With the pinned entry point present, preflight itself must not be the
+    reason a run stops — it must get past the venv check. (The script may
+    still stop later at a real systemctl call inside this hermetic sandbox;
+    we only assert the preflight boundary, per the acceptance criterion's
+    'installer preflight logic' scope.)"""
+    fake_opt_venv = tmp_path / "opt" / "llauncher" / "venv"
+    systemd_dir = _hermetic_systemd_copy(tmp_path, fake_opt_venv)
+    _make_entrypoint(fake_opt_venv, "llauncher-agent")
+    env = {"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin"}
+
+    result = subprocess.run(
+        ["bash", str(systemd_dir / "install.sh"), "--no-start"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    combined = result.stdout + result.stderr
+    # The pinned-venv preflight's own failure message must NOT appear —
+    # whatever happens next (real systemctl unavailable in this sandbox is
+    # an acceptable, different failure), it isn't this preflight rejecting us.
+    assert "There is no" not in combined or "fallback to a" not in combined
+    assert "not been composed" not in combined
+
+
+def test_system_mode_preflight_unchanged_checks_dev_tree_venv(tmp_path: Path):
+    """--system mode must NOT be redirected to /opt — it still checks this
+    checkout's own .venv (ADR-023 Phase A, untouched by #360). Run as a
+    non-root synthetic invocation to exercise only the venv preflight
+    ordering (it fails before the root check would even matter, since the
+    venv preflight runs first)."""
+    fake_opt_venv = tmp_path / "opt" / "llauncher" / "venv"
+    systemd_dir = _hermetic_systemd_copy(tmp_path, fake_opt_venv)
+    project_dir = systemd_dir.parent.parent
+    env = {"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin"}
+
+    result = subprocess.run(
+        ["bash", str(systemd_dir / "install.sh"), "--system"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    combined = result.stdout + result.stderr
+    # It must be complaining about the DEV TREE venv, never /opt.
+    assert str(project_dir / ".venv" / "bin" / "llauncher-agent") in combined
+    assert "run.sh setup" in combined
+    assert str(fake_opt_venv) not in combined
+
+
+# ─────────────────────── install-ui.sh ───────────────────────
+
+
+def test_install_ui_fails_loud_when_pinned_venv_absent(tmp_path: Path):
+    """install-ui.sh must exit nonzero, naming the ritual, when the pinned
+    /opt/llauncher/venv has never been composed — this is a HARD preflight
+    (issue #360), unlike the softer symlink/group warnings beside it."""
+    fake_opt_venv = tmp_path / "opt" / "llauncher" / "venv"
+    systemd_dir = _hermetic_systemd_copy(tmp_path, fake_opt_venv)
+    env = {"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin"}
+
+    result = subprocess.run(
+        ["bash", str(systemd_dir / "install-ui.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "not been composed" in combined
+    assert "install-cli.sh" in combined
+    assert "run-as-a-service.md" in combined
+    assert "Composing the pinned runtime venv" in combined
+    assert "Rendered unit" not in combined
+
+
+def test_install_ui_preflight_passes_when_pinned_venv_present(tmp_path: Path):
+    """With the pinned llauncher-ui entry point present, the hard preflight
+    must not be what stops the run."""
+    fake_opt_venv = tmp_path / "opt" / "llauncher" / "venv"
+    systemd_dir = _hermetic_systemd_copy(tmp_path, fake_opt_venv)
+    _make_entrypoint(fake_opt_venv, "llauncher-ui")
+    env = {"HOME": str(tmp_path / "home"), "PATH": "/usr/bin:/bin"}
+
+    result = subprocess.run(
+        ["bash", str(systemd_dir / "install-ui.sh")],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    combined = result.stdout + result.stderr
+    assert "not been composed" not in combined


### PR DESCRIPTION
## What / why

#357 ratified Option A: the systemd deployment gets a unique, **pinned** venv (`/opt/llauncher/venv`) independent of any operator's shell state and any clone's working-tree state. ADR-023's service-owned-venv shape (already built for the UI unit) is now applied symmetrically to the agent's `--user` unit, and the compose ritual is documented as a runnable sequence.

## Changes

- **`scripts/systemd/llauncher-agent.service.in`** (the `--user` agent template — issue #360 names it `llauncher-agent.service.user.in`, but the repo's actual filename is `.service.in`): `ExecStart` now resolves through `/usr/local/bin/llauncher-agent -> /opt/llauncher/venv/bin/llauncher-agent`, never `@VENV_BIN@`/this checkout's `.venv`. Adds a fail-loud `ExecStartPre` backstop mirroring the UI unit's (ADR-023 Phase B, #228) — a `--user` unit can't recompose the root-owned pin, so it detects-and-fails-loud instead.
- **`scripts/systemd/install.sh`**: `--user` mode's preflight now checks `/opt/llauncher/venv` instead of the dev-tree `.venv` (no silent fallback); token generation no longer depends on either venv existing. `--system` mode is **unchanged** — it still recomposes this checkout's dev-tree `.venv` via the existing root ensure-unit (ADR-023 Phase A, #227), which is a separate deployment mode from the one #360 targets.
- **`scripts/systemd/install-cli.sh`**: adds `llauncher-agent` to the symlinked `SCRIPTS` array (closing the gap — it was previously absent, so the agent unit had no `/usr/local/bin` symlink to resolve through) and records the composition to `/opt/llauncher/venv-manifest.txt` (ref, UTC timestamp, `pip freeze`) via a new sourceable helper.
- **`scripts/systemd/venv_manifest.sh`** (new): `write_venv_manifest`, extracted so the manifest-writing logic is unit-testable without a network `pip install` (same pattern as the existing `migrate_env_keys.sh`).
- **`scripts/systemd/install-ui.sh`**: the pinned-venv check is promoted from a soft warning to a **hard, fail-loud preflight** — no repo-venv fallback exists.
- **`docs/operations/run-as-a-service.md`**: new "Composing the pinned runtime venv" section — one contiguous runnable script block for the grant-window ritual (open sudo window → compose via `install-cli.sh` → confirm the manifest → restart services → revoke window). Inserted as a single clearly-delimited section; does not restructure the doc (PR #212 has an open, unrelated conflict in this same file — kept surgical so its eventual resolution stays tractable).

## Scope notes

- Follows ADR-023's existing `/usr/local/bin` symlink indirection; no second mechanism invented.
- Does **not** compose `/opt/llauncher/venv`, touch live services, or modify any installed units (templates + installers + docs only), per the issue's guardrails.
- Out of scope (per #360): auto-recompose (#233), version tagging (harness-tools#195) — the ritual installs from a git ref (default `main`) today.
- `chmod -R a+rX` (world read-exec) on `/opt/llauncher`, already the case pre-#360, is a superset of the issue's "read-exec group `inference`" phrasing — left as-is rather than narrowed, since narrowing would be a behavior change beyond this issue's scope.

## Tests

New, all passing:
- `tests/unit/test_agent_venv_backstop.py` — static + behavioral coverage of the new agent backstop (mirrors `test_ui_venv_backstop.py`).
- `tests/unit/test_pinned_venv_install_preflight.py` — `install.sh` (`--user` vs `--system`) and `install-ui.sh` fail-loud preflight behavior, run against copies of the real scripts with `/opt/llauncher/venv` rerooted under `tmp_path` (never touches the real path).
- `tests/unit/test_install_cli_manifest.py` — `write_venv_manifest` behavior + `install-cli.sh` static wiring.

Gate: full suite from the worktree, `PYTHONPATH=<worktree>` (coverage environment-masks 0% without it from a worktree venv):

```
1701 passed, 26 skipped, 100.00% coverage
```
vs. the stated baseline of 1676 passed / 26 skipped — zero new failures, +25 (exactly the new tests added).

Closes #360

---
**Correction (Opus review, pre-merge):** the claim above that the runbook insert is "clear of PR #212's conflict zone" is wrong — the insertion anchors on text #212's branch deletes (the Ubuntu UI --user section, main ~152-225), so #212 WILL conflict here and must resolve over this section after this PR lands. Also noted for the compose window: the ExecStartPre backstop tests the venv entry point while ExecStart invokes the /usr/local/bin symlink (same asymmetry as the shipped UI unit) — the symlink is created by this PR's install-cli.sh addition; verify it lands when the venv is first composed.
