### PR TITLE
fix(installer): resolve nssm via PATH->choco fallback chain (#352)

### DIFF
--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -59,6 +59,7 @@ $EnvExample  = Join-Path $ScriptDir 'agent.env.example'
 
 function Say  ($msg) { Write-Host "[OK]  $msg" -ForegroundColor Green }
 function Info ($msg) { Write-Host "[..]  $msg" -ForegroundColor Yellow }
+function Warn ($msg) { Write-Host "[WARN]  $msg" -ForegroundColor Red }
 function Die  ($msg) { Write-Host "[!!]  $msg" -ForegroundColor Red; exit 1 }
 
 # --- Elevation check --------------------------------------------------
@@ -91,7 +92,15 @@ $nssmSource = $null
 
 if ($env:NSSM) {
     $nssmCandidates.Add($env:NSSM)
-    if (Test-Path $env:NSSM) { $nssm = $env:NSSM; $nssmSource = '$env:NSSM override' }
+    if (Test-Path $env:NSSM) {
+        $nssm = $env:NSSM; $nssmSource = '$env:NSSM override'
+    } else {
+        # Loud, not silent (#352 review): an operator who set $env:NSSM
+        # expected it to be used. Falling through to the next candidate
+        # without a word would leave them wondering why their override was
+        # ignored -- name the invalid path before continuing the chain.
+        Warn "`$env:NSSM is set to '$($env:NSSM)' but that path does not exist -- falling through to the next candidate."
+    }
 }
 
 if (-not $nssm) {
@@ -116,8 +125,18 @@ if (-not $nssm) {
     $nssmCandidates.Add($chocoLibNssmGlob)
     $chocoLibRoot = 'C:\ProgramData\chocolatey\lib\nssm\tools'
     if (Test-Path $chocoLibRoot) {
+        # The choco nssm package ships both win32 and win64 payloads with
+        # identical (or near-identical, within filesystem timestamp
+        # resolution) LastWriteTime -- Sort-Object -Descending alone leaves
+        # that tie's winner up to PowerShell 5.1's unstable sort, which can
+        # silently pick the 32-bit binary on one run and the 64-bit binary
+        # on the next. Prefer win64 deterministically as the primary sort
+        # key, falling back to LastWriteTime to break any remaining tie.
         $newestLibNssm = Get-ChildItem -Path $chocoLibRoot -Filter 'nssm.exe' -Recurse -ErrorAction SilentlyContinue |
-            Sort-Object LastWriteTime -Descending |
+            Sort-Object -Property @(
+                @{ Expression = { if ($_.FullName -match 'win64') { 0 } else { 1 } }; Descending = $false },
+                @{ Expression = 'LastWriteTime'; Descending = $true }
+            ) |
             Select-Object -First 1
         if ($newestLibNssm) { $nssm = $newestLibNssm.FullName; $nssmSource = 'chocolatey lib payload' }
     }

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -1,9 +1,13 @@
 # Install / refresh the llauncher-agent Windows service via NSSM.
 #
 # Prerequisites:
-#   - NSSM (Non-Sucking Service Manager) on PATH, or set $env:NSSM
-#     to the absolute path of nssm.exe. Download from https://nssm.cc/
-#     or `choco install nssm` / `scoop install nssm`.
+#   - NSSM (Non-Sucking Service Manager), resolved via a fallback chain
+#     (issue #352): $env:NSSM override -> PATH -> choco bin shim -> choco
+#     lib payload -> scoop shim. PATH is not required if nssm is findable
+#     via one of the other locations (e.g. a Windows Update dropped the
+#     choco bin dir from PATH but nssm.exe is still sitting right there).
+#     Download from https://nssm.cc/ or `choco install nssm` / `scoop
+#     install nssm`.
 #   - Project venv created via `scripts\run.bat install`.
 #   - This script must run elevated (right-click "Run as Administrator").
 #
@@ -64,17 +68,83 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
     Die "This script must be run from an elevated (Administrator) PowerShell."
 }
 
-# --- Locate nssm ------------------------------------------------------
-$nssm = if ($env:NSSM) { $env:NSSM } else { (Get-Command nssm.exe -ErrorAction SilentlyContinue).Source }
+# --- Locate nssm --------------------------------------------------------
+# PATH is not the only place nssm legitimately lives (issue #352): a
+# Windows Update can silently drop C:\ProgramData\chocolatey\bin from the
+# system PATH without touching choco's own install -- nssm.exe (and choco
+# itself) keep working fine from an elevated prompt that still has the
+# entry, but a fresh/other shell's `Get-Command nssm.exe` comes back empty
+# and the pre-#352 installer misdiagnosed that as "nssm not installed",
+# sending operators to reinstall tooling that was never missing (the bogus
+# precondition behind PR #345). Resolve through a fallback chain instead,
+# first match wins, and probe every candidate so a genuine absence can name
+# everywhere it looked:
+#   1. $env:NSSM override (explicit operator escape hatch, pre-#352)
+#   2. nssm.exe on PATH (Get-Command)
+#   3. the choco shim: C:\ProgramData\chocolatey\bin\nssm.exe
+#   4. the newest nssm.exe under choco's package payload:
+#      C:\ProgramData\chocolatey\lib\nssm\tools\**\nssm.exe
+#   5. scoop shim: %USERPROFILE%\scoop\shims\nssm.exe
+$nssmCandidates = [System.Collections.Generic.List[string]]::new()
+$nssm = $null
+$nssmSource = $null
+
+if ($env:NSSM) {
+    $nssmCandidates.Add($env:NSSM)
+    if (Test-Path $env:NSSM) { $nssm = $env:NSSM; $nssmSource = '$env:NSSM override' }
+}
+
+if (-not $nssm) {
+    $onPath = (Get-Command nssm.exe -ErrorAction SilentlyContinue).Source
+    if ($onPath) {
+        $nssmCandidates.Add($onPath)
+        $nssm = $onPath
+        $nssmSource = 'PATH'
+    } else {
+        $nssmCandidates.Add('nssm.exe (via PATH / Get-Command)')
+    }
+}
+
+$chocoBinNssm = 'C:\ProgramData\chocolatey\bin\nssm.exe'
+if (-not $nssm) {
+    $nssmCandidates.Add($chocoBinNssm)
+    if (Test-Path $chocoBinNssm) { $nssm = $chocoBinNssm; $nssmSource = 'chocolatey bin shim' }
+}
+
+$chocoLibNssmGlob = 'C:\ProgramData\chocolatey\lib\nssm\tools\**\nssm.exe'
+if (-not $nssm) {
+    $nssmCandidates.Add($chocoLibNssmGlob)
+    $chocoLibRoot = 'C:\ProgramData\chocolatey\lib\nssm\tools'
+    if (Test-Path $chocoLibRoot) {
+        $newestLibNssm = Get-ChildItem -Path $chocoLibRoot -Filter 'nssm.exe' -Recurse -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+        if ($newestLibNssm) { $nssm = $newestLibNssm.FullName; $nssmSource = 'chocolatey lib payload' }
+    }
+}
+
+$scoopShimNssm = Join-Path $env:USERPROFILE 'scoop\shims\nssm.exe'
+if (-not $nssm) {
+    $nssmCandidates.Add($scoopShimNssm)
+    if (Test-Path $scoopShimNssm) { $nssm = $scoopShimNssm; $nssmSource = 'scoop shim' }
+}
+
 if (-not $nssm -or -not (Test-Path $nssm)) {
+    $tried = ($nssmCandidates | ForEach-Object { "  - $_" }) -join "`n"
     Die @"
-nssm.exe not found. Install via one of:
+nssm.exe not found. Probed, in order (first match wins):
+$tried
+
+If nssm IS installed but off PATH (e.g. a Windows Update dropped
+C:\ProgramData\chocolatey\bin from PATH -- issue #352), either restore that
+PATH entry or set `$env:NSSM = '<path>\nssm.exe'` and re-run. Only install
+fresh tooling if none of the above actually resolves:
   choco install nssm
   scoop install nssm
-  https://nssm.cc/download (then add to PATH, or set `$env:NSSM = '<path>\nssm.exe'`)
+  https://nssm.cc/download (then add to PATH, or set `$env:NSSM`)
 "@
 }
-Say "Using NSSM at $nssm"
+Say "Using NSSM at $nssm (resolved via $nssmSource)"
 
 # --- Uninstall path ---------------------------------------------------
 if ($Uninstall) {

--- a/tests/unit/test_install_ps1_nssm_fallback.py
+++ b/tests/unit/test_install_ps1_nssm_fallback.py
@@ -56,6 +56,24 @@ def test_env_nssm_override_checked():
     )
 
 
+def test_env_nssm_override_invalid_path_warns_loudly():
+    """A set-but-invalid $env:NSSM must be announced, not silently dropped
+    (#352 review): an operator who set the override expected it to be used,
+    and falling through without a word leaves them wondering why it was
+    ignored."""
+    text = _source()
+    override_block = re.search(
+        r"if \(\$env:NSSM\) \{(.*?)\n\}", text, re.DOTALL
+    )
+    assert override_block is not None, "Could not find the $env:NSSM override block."
+    body = override_block.group(1)
+    assert "else" in body and "Warn" in body, (
+        "The $env:NSSM override block must emit a warning (Warn) in its "
+        "else branch when Test-Path fails on the override, before falling "
+        "through to the next candidate."
+    )
+
+
 def test_path_lookup_via_get_command():
     text = _source()
     assert re.search(r"Get-Command\s+nssm\.exe", text), (

--- a/tests/unit/test_install_ps1_nssm_fallback.py
+++ b/tests/unit/test_install_ps1_nssm_fallback.py
@@ -1,0 +1,156 @@
+"""Static-source guard for issue #352 (nssm PATH fallback chain).
+
+A Windows Update can silently drop ``C:\\ProgramData\\chocolatey\\bin`` from
+the system PATH without touching the underlying choco/nssm install --
+``nssm.exe`` keeps working fine from a shell that still has the entry, but
+``Get-Command nssm.exe`` in a fresh/other shell comes back empty. The
+pre-#352 installer treated that as "nssm not installed" and sent operators
+to reinstall tooling that was never missing (the bogus precondition behind
+PR #345, which risked clobbering the live service).
+
+``scripts/windows/install.ps1`` must resolve nssm through a fallback chain,
+first match wins, before ``Die``-ing:
+
+  1. ``$env:NSSM`` override
+  2. ``nssm.exe`` on PATH (``Get-Command``)
+  3. the choco bin shim: ``C:\\ProgramData\\chocolatey\\bin\\nssm.exe``
+  4. the choco lib payload: ``C:\\ProgramData\\chocolatey\\lib\\nssm\\tools\\**\\nssm.exe``
+  5. the scoop shim: ``%USERPROFILE%\\scoop\\shims\\nssm.exe``
+
+and the single resolved ``$nssm`` variable must be the only thing every
+NSSM invocation in the script uses -- no bare ``nssm`` calls scattered
+through the file that would bypass the resolution chain.
+
+These are static-source (text) assertions, not a ``pwsh``-execution test,
+so they run on any host without needing PowerShell installed -- same
+posture as ``test_install_ps1_unbuffered_env.py`` and
+``tests/architecture/test_ps1_ascii.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+INSTALL_PS1 = _repo_root() / "scripts" / "windows" / "install.ps1"
+
+
+def _source() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_env_nssm_override_checked():
+    text = _source()
+    assert "$env:NSSM" in text, (
+        "install.ps1 must still honor an $env:NSSM override as the first "
+        "link in the resolution chain."
+    )
+
+
+def test_path_lookup_via_get_command():
+    text = _source()
+    assert re.search(r"Get-Command\s+nssm\.exe", text), (
+        "install.ps1 must probe PATH via Get-Command nssm.exe."
+    )
+
+
+def test_choco_bin_shim_path_present():
+    text = _source()
+    assert r"C:\ProgramData\chocolatey\bin\nssm.exe" in text, (
+        "install.ps1 must fall back to the chocolatey bin shim "
+        r"C:\ProgramData\chocolatey\bin\nssm.exe (issue #352)."
+    )
+
+
+def test_choco_lib_payload_path_present():
+    text = _source()
+    assert r"C:\ProgramData\chocolatey\lib\nssm\tools" in text, (
+        "install.ps1 must fall back to nssm.exe under the chocolatey lib "
+        r"payload C:\ProgramData\chocolatey\lib\nssm\tools\**\nssm.exe "
+        "(issue #352)."
+    )
+
+
+def test_scoop_shim_path_present():
+    text = _source()
+    assert "scoop\\shims\\nssm.exe" in text, (
+        "install.ps1 must fall back to the scoop shim "
+        r"%USERPROFILE%\scoop\shims\nssm.exe (issue #352)."
+    )
+
+
+def test_failure_message_names_every_probed_path():
+    """On total failure, Die must enumerate every candidate tried, not just
+    say 'not found' (operators need to know what was actually checked)."""
+    text = _source()
+    die_match = re.search(r"if \(-not \$nssm.*?Die @\"(.*?)\"@", text, re.DOTALL)
+    assert die_match is not None, "Could not find the nssm-not-found Die block."
+    die_body = die_match.group(1)
+    assert "$tried" in die_body or "nssmCandidates" in text, (
+        "The Die message must be built from the list of probed candidates."
+    )
+
+
+def test_no_bare_nssm_invocations_outside_resolution_block():
+    """Every NSSM invocation after resolution must go through the resolved
+    ``$nssm`` variable (``& $nssm ...``) -- a bare ``nssm`` call would
+    silently bypass the fallback chain and reintroduce PATH-only failures."""
+    text = _source()
+    lines = text.splitlines()
+    bare_invocations = []
+    for i, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        # Match a command invocation of nssm that is NOT `& $nssm` and NOT
+        # inside the resolution/documentation block itself (which legitimately
+        # mentions nssm.exe / "nssm install" etc. in prose or as the PATH probe).
+        if re.search(r"(?<!\$)\bnssm(?:\.exe)?\s+(install|remove|stop|start|set|get)\b", stripped, re.IGNORECASE):
+            # Exclude prose/comment-style mentions like "choco install nssm"
+            # or "nssm install is never called" (documentation, not a call).
+            if re.match(r"^(choco|scoop)\s+install\s+nssm", stripped, re.IGNORECASE):
+                continue
+            if "`" in stripped or stripped.startswith("Registering") or "is never called" in stripped:
+                continue
+            bare_invocations.append((i, stripped))
+    assert not bare_invocations, (
+        "Found nssm invocation(s) not going through the resolved $nssm "
+        f"variable: {bare_invocations}"
+    )
+
+
+def test_all_ampersand_nssm_calls_use_resolved_variable():
+    """Every `&`-invoked nssm call in the script must use `$nssm`, the
+    single variable populated by the fallback chain."""
+    text = _source()
+    amp_calls = re.findall(r"&\s*\$?\w[\w.:\\]*\s+(?:install|remove|stop|start|set)\s+\$ServiceName", text)
+    # Every such call found via `& <something>` must specifically be `& $nssm`
+    stray = re.findall(r"&\s+(?!\$nssm\b)(\S*nssm\S*)\s", text, re.IGNORECASE)
+    assert not stray, f"Found & invocations of nssm not using $nssm: {stray}"
+
+
+def test_nssm_resolved_once_into_single_variable():
+    """The resolution chain must populate exactly one variable ($nssm) that
+    is then reused everywhere -- not re-resolved per call site."""
+    text = _source()
+    assignments = re.findall(r"^\$nssm\s*=", text, re.MULTILINE)
+    # $nssm is assigned in the resolution chain (may be assigned multiple
+    # times across the chain's if/elseif branches, but never inside the
+    # install/config section below the resolution block).
+    resolution_end = text.index("Say \"Using NSSM at $nssm")
+    post_resolution = text[resolution_end:]
+    post_resolution_assignments = re.findall(r"^\$nssm\s*=", post_resolution, re.MULTILINE)
+    assert not post_resolution_assignments, (
+        "$nssm must be resolved once in the fallback chain and never "
+        "reassigned afterward."
+    )
+    assert assignments, "$nssm must be assigned somewhere in the resolution chain."


### PR DESCRIPTION
## Summary

Fixes #352. `install.ps1`'s nssm discovery used only `Get-Command nssm.exe`
(PATH lookup) before `Die`-ing. A Windows Update dropped
`C:\ProgramData\chocolatey\bin` from the system PATH on the operator's box
without touching the underlying choco/nssm install -- nssm.exe kept working
fine from a shell that still had the entry, but the installer's PATH-only
probe came back empty and misdiagnosed a fully functional install as
"not found." That misdiagnosis produced PR #345's bogus tooling-reinstall
precondition, which risked clobbering the live service on top of a nssm
install that was never actually missing.

## Resolution chain (first match wins)

1. `$env:NSSM` override (unchanged, pre-#352 escape hatch)
2. `nssm.exe` on PATH (`Get-Command`)
3. chocolatey bin shim: `C:\ProgramData\chocolatey\bin\nssm.exe`
4. newest chocolatey lib payload: `C:\ProgramData\chocolatey\lib\nssm\tools\**\nssm.exe`
5. scoop shim: `%USERPROFILE%\scoop\shims\nssm.exe`

Resolved once into `$nssm`, which was already the only variable every NSSM
invocation in the script uses (`& $nssm ...` throughout) -- confirmed via
grep, no scattered bare `nssm` calls existed or were introduced. On total
failure, `Die` now enumerates every path actually probed instead of a
generic "not found," and points at restoring the PATH entry / setting
`$env:NSSM` as the real fix rather than reinstalling tooling that may
already be present.

## Live resolution evidence (this box, read-only probe -- did not run the installer)

```
Get-Command nssm.exe        -> C:\ProgramData\chocolatey\bin\nssm.exe   (still on PATH here)
choco bin shim               -> EXISTS: C:\ProgramData\chocolatey\bin\nssm.exe
choco lib payload             -> C:\ProgramData\chocolatey\lib\nssm\tools\nssm.exe (LastWriteTime 2017-04-26)
scoop shim                    -> absent
$env:NSSM                     -> not set
PATH contains chocolatey\bin? -> yes
```

This box's PATH is currently intact, so it doesn't reproduce #352's exact
failure mode, but it confirms candidates 2-4 all resolve correctly and the
chain would fall through to the choco bin shim (or lib payload) the moment
PATH drops the entry again.

## Test plan

- [x] `tests/unit/test_install_ps1_nssm_fallback.py` (new, 9 tests): asserts
  the `$env:NSSM`/PATH/choco-bin/choco-lib/scoop candidates are all present
  in source, the failure message is built from the probed-candidate list,
  and no nssm invocation in the script bypasses the resolved `$nssm`
  variable -- all pass.
- [x] `tests/unit/test_install_ps1_unbuffered_env.py`,
  `tests/unit/test_install_ps1_application_repoint.py`,
  `tests/unit/test_install_ps1_dedupe.py` (pwsh-gated, skip here without
  pwsh on PATH) -- all pass/skip cleanly, no regressions.
- [x] `tests/architecture/test_ps1_ascii.py` -- install.ps1 stays pure
  ASCII, passes.
- Not run: the actual installer end-to-end (operator's live-box test per
  the task's own instruction; this PR is static-source + read-only probe
  only).