### PR TITLE
fix(installer): collapse the [ui] extra into base dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Typer command-line surface, co-equal with MCP and UI. Subcommand groups: `model`
 git clone https://github.com/shanevcantwell/llauncher
 cd llauncher
 
-# Install in development mode (with UI)
-pip install -e ".[ui]"
+# Install in development mode (includes UI)
+pip install -e .
 
 # Optional: Install test dependencies
 pip install -e ".[test]"
@@ -53,7 +53,7 @@ cd github\llauncher
 rmdir /s /q .venv
 python -m venv .venv
 \.venv\Scripts\activate
-pip install -e ".[ui]"
+pip install -e .
 ```
 
 ## Quick Start

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -18,7 +18,7 @@ llauncher exposes 13 MCP tools across three categories:
 
 ```bash
 # Install llauncher with MCP support
-pip install -e ".[ui]"  # Includes all dependencies
+pip install -e .  # Includes all dependencies
 ```
 
 The MCP server is installed as a console script:

--- a/docs/generated/TEST_SUITE_SUMMARY.md
+++ b/docs/generated/TEST_SUITE_SUMMARY.md
@@ -16,10 +16,10 @@
 
 | Category | Files | Tests |
 |----------|-------|-------|
-| Unit | 82 | 1328 |
+| Unit | 89 | 1381 |
 | Integration | 14 | 94 |
-| Other | 17 | 177 |
-| **Total** | **113** | **1599** |
+| Other | 18 | 181 |
+| **Total** | **121** | **1656** |
 
 ## Tests carrying special markers
 
@@ -286,7 +286,7 @@ ad-hoc markers used in the suite without declaration.
 - **`test_returns_slots_disabled_envelope_verbatim`**
   - *No HTTP-status mapping at the MCP layer — the tool call returns*
 
-#### `tests/unit/test_agent.py` (84 tests)
+#### `tests/unit/test_agent.py` (85 tests)
 
 - **`test_health_returns_200`**
   - *Test that health endpoint returns 200.*
@@ -320,6 +320,8 @@ ad-hoc markers used in the suite without declaration.
   - *Posting without a body fails FastAPI validation.*
 - **`test_start_nonexistent_model_returns_500`**
   - *Unknown model surfaces ops.start's ``error`` action as 500.*
+- **`test_start_server_unhandled_exception_returns_structured_500`**
+  - *Issue #308: an unhandled exception from ``ops.start`` (not a*
 - **`test_stop_empty_port_is_idempotent_200`**
   - *Idempotent stop: 200 with ``already_empty`` action.*
 - **`test_stop_live_port_responds_while_termination_pending`**
@@ -567,7 +569,30 @@ ad-hoc markers used in the suite without declaration.
 - **`test_run_agent_passes_lifespan_on`**
   - *``run_agent()`` must pass ``lifespan="on"`` so the handler actually fires.*
 
-#### `tests/unit/test_agent_middleware.py` (9 tests)
+#### `tests/unit/test_agent_logging_setup.py` (10 tests)
+
+- **`test_configure_logging_adds_file_handler_targeting_log_dir`**
+  - *A FileHandler pointed at LAUNCHER_LOG_DIR/agent.log is configured.*
+- **`test_configure_logging_creates_log_dir`**
+  - *The log directory is created if it does not already exist.*
+- **`test_configure_logging_reconfigures_streams_when_supported`**
+  - *stdout/stderr are reconfigured to line-buffering when the stream*
+- **`test_configure_logging_skips_reconfigure_when_unsupported`**
+  - *A stream without ``reconfigure`` (e.g. a plain buffer / StringIO*
+- **`test_configure_logging_preserves_format_string`**
+  - *The existing timestamp/name/level/message format is preserved.*
+- **`test_returned_config_is_not_the_module_level_template`**
+  - *Must be a fresh dict per call, not the shared module constant —*
+- **`test_uvicorn_logger_handlers_include_a_file_handler_for_agent_log`**
+  - *The 'uvicorn' logger (which 'uvicorn.error' propagates into)*
+- **`test_uvicorn_access_logger_handlers_include_a_file_handler`**
+  - *Same guarantee for 'uvicorn.access' (request logging).*
+- **`test_access_and_error_records_actually_land_in_agent_log`**
+  - *Integration-style: dictConfig the built config, log through both*
+- **`test_configure_logging_root_file_handler_and_uvicorn_file_handlers_target_same_file`**
+  - *Belt-and-suspenders: the root logger's FileHandler (from*
+
+#### `tests/unit/test_agent_middleware.py` (10 tests)
 
 - **`test_no_token_allows_all_requests`**
   - *When no auth token is configured, all requests pass through.*
@@ -583,6 +608,8 @@ ad-hoc markers used in the suite without declaration.
   - *Empty string X-Api-Key is present but wrong — should return 403 (not 401).*
 - **`test_health_exempt_with_empty_key`**
   - */health remains accessible even when a wrong/empty key is sent (exempt path).*
+- **`test_exempt_paths_match_documented_set`**
+  - *Pin the exempt set to ADR-003's narrowed contract (#126 drift guard).*
 - **`test_limited_receive_forwards_non_request_message`**
   - *``limited_receive`` forwards non-``http.request`` messages verbatim.*
 - **`test_guarded_send_suppresses_late_response_after_rejection`**
@@ -661,6 +688,31 @@ ad-hoc markers used in the suite without declaration.
 - **`test_defaults_to_os_environ`**
   - *No explicit environ argument reads the real process environment.*
 
+#### `tests/unit/test_agent_venv_backstop.py` (11 tests)
+
+- **`test_exec_start_resolves_through_usr_local_bin_symlink`**
+  - *ExecStart never points at @VENV_BIN@/the dev checkout's .venv.*
+- **`test_backstop_execstartpre_present`**
+  - *The agent --user unit carries exactly one ExecStartPre backstop.*
+- **`test_backstop_checks_shared_venv_and_entrypoint`**
+  - *It verifies BOTH the shared venv dir AND the llauncher-agent entry point.*
+- **`test_backstop_is_fail_loud_not_best_effort`**
+  - *No leading '-' on the directive: a nonzero check MUST fail the unit.*
+- **`test_backstop_names_real_remediation_command`**
+  - *The journal message points at the REAL, existing root recompose step.*
+- **`test_backstop_message_goes_to_stderr`**
+  - *Fail-loud line must reach the journal via stderr.*
+- **`test_agent_unit_takes_no_cross_scope_dependency`**
+  - *A --user unit must NOT Requires=/After= a system ensure unit (forbidden).*
+- **`test_backstop_noop_when_entrypoint_present`**
+  - *Present, executable entry point => clean exit, no message.*
+- **`test_backstop_fails_loud_when_venv_missing`**
+  - *No /opt venv at all => nonzero + remediation on stderr.*
+- **`test_backstop_fails_loud_when_entrypoint_missing`**
+  - *Venv dir exists but the entry point does not => fail loud.*
+- **`test_backstop_fails_loud_when_entrypoint_not_executable`**
+  - *Entry point present but not executable => 'usable' check fails loud.*
+
 #### `tests/unit/test_audit_log.py` (14 tests)
 
 - **`test_record_creates_file`**
@@ -677,6 +729,12 @@ ad-hoc markers used in the suite without declaration.
 - **`test_read_entries_limit_returns_tail`**
 - **`test_observed_actions_distinct_from_commanded`**
 - **`test_swap_entry_carries_from_and_to_models`**
+
+#### `tests/unit/test_audit_log_write_failure.py` (2 tests)
+
+- **`test_record_does_not_raise_on_write_failure`**
+- **`test_record_still_writes_on_the_happy_path`**
+  - *Sanity check: the try/except does not change success-path behavior.*
 
 #### `tests/unit/test_audit_tab.py` (10 tests)
 
@@ -1051,6 +1109,22 @@ ad-hoc markers used in the suite without declaration.
 - **`test_query_rocm_parse_timeout_swallowed`**
 - **`test_csv_rows_skips_blank_lines`**
 
+#### `tests/unit/test_install_cli_manifest.py` (9 tests)
+
+- **`test_manifest_contains_ref_and_pip_freeze`**
+- **`test_manifest_has_a_composed_timestamp`**
+- **`test_manifest_warns_against_hand_editing`**
+- **`test_recompose_overwrites_stale_manifest`**
+  - *Re-running the ritual must describe the CURRENT venv, not append to*
+- **`test_llauncher_agent_is_symlinked_by_install_cli`**
+  - *The gap #360 closes: llauncher-agent was previously absent from*
+- **`test_install_cli_sources_the_manifest_helper`**
+- **`test_install_cli_writes_manifest_before_symlinking`**
+  - *The manifest must describe the composition BEFORE the console*
+- **`test_manifest_path_is_under_prefix`**
+- **`test_uninstall_removes_the_manifest_with_the_prefix`**
+  - *--uninstall's rm -rf "$PREFIX" already covers the manifest (it lives*
+
 #### `tests/unit/test_install_ps1_application_repoint.py` (5 tests)
 
 - **`test_application_is_repointed_in_common_config_block`**
@@ -1073,6 +1147,33 @@ ad-hoc markers used in the suite without declaration.
   - *Issue #298: two legacy same-key lines with NO pre-existing canonical*
 - **`test_legacy_only_migrates_without_dropping`**
 - **`test_no_legacy_keys_is_noop`**
+
+#### `tests/unit/test_install_ps1_nssm_fallback.py` (10 tests)
+
+- **`test_env_nssm_override_checked`**
+- **`test_env_nssm_override_invalid_path_warns_loudly`**
+  - *A set-but-invalid $env:NSSM must be announced, not silently dropped*
+- **`test_path_lookup_via_get_command`**
+- **`test_choco_bin_shim_path_present`**
+- **`test_choco_lib_payload_path_present`**
+- **`test_scoop_shim_path_present`**
+- **`test_failure_message_names_every_probed_path`**
+  - *On total failure, Die must enumerate every candidate tried, not just*
+- **`test_no_bare_nssm_invocations_outside_resolution_block`**
+  - *Every NSSM invocation after resolution must go through the resolved*
+- **`test_all_ampersand_nssm_calls_use_resolved_variable`**
+  - *Every `&`-invoked nssm call in the script must use `$nssm`, the*
+- **`test_nssm_resolved_once_into_single_variable`**
+  - *The resolution chain must populate exactly one variable ($nssm) that*
+
+#### `tests/unit/test_install_ps1_unbuffered_env.py` (3 tests)
+
+- **`test_pythonunbuffered_appended_to_env_pairs`**
+  - *``$envPairs += "PYTHONUNBUFFERED=1"`` appears, mirroring the*
+- **`test_pythonunbuffered_append_precedes_nssm_set`**
+  - *The append must happen before the ``AppEnvironmentExtra`` NSSM call*
+- **`test_pythonunbuffered_append_is_unconditional`**
+  - *The append must not be gated behind an ``if`` -- there is no*
 
 #### `tests/unit/test_install_sh_dedupe.py` (7 tests)
 
@@ -1437,7 +1538,7 @@ ad-hoc markers used in the suite without declaration.
 - **`test_api_key_help_names_both_platform_commands`**
   - *First-contact help tells you what the field wants, per platform.*
 
-#### `tests/unit/test_operations.py` (63 tests)
+#### `tests/unit/test_operations.py` (64 tests)
 
 - **`test_start_on_empty_port`**
 - **`test_start_idempotent_when_same_model_running`**
@@ -1445,6 +1546,8 @@ ad-hoc markers used in the suite without declaration.
 - **`test_start_reconciles_stale_lockfile`**
 - **`test_start_errors_when_model_not_in_config`**
 - **`test_start_errors_when_process_launch_fails`**
+- **`test_start_errors_when_marker_write_fails`**
+  - *Issue #308: a marker-write failure (disk full, permissions, ...)*
 - **`test_start_rejects_when_preflight_health_check_fails`**
   - *The new model-health seam (issue #57) blocks launch on unhealthy file.*
 - **`test_start_skips_preflight_when_check_is_none`**
@@ -1613,6 +1716,19 @@ ad-hoc markers used in the suite without declaration.
   - *All-nodes filter with empty registry → 'No nodes registered' branch.*
 - **`test_directory_with_llama_server_binary`**
 - **`test_directory_without_binary_fallback_to_directory`**
+
+#### `tests/unit/test_pinned_venv_install_preflight.py` (5 tests)
+
+- **`test_user_mode_fails_loud_when_pinned_venv_absent`**
+  - *--user install.sh must exit nonzero, naming the ritual, when the*
+- **`test_user_mode_preflight_passes_when_pinned_venv_present`**
+  - *With the pinned entry point present, preflight itself must not be the*
+- **`test_system_mode_preflight_unchanged_checks_dev_tree_venv`**
+  - *--system mode must NOT be redirected to /opt — it still checks this*
+- **`test_install_ui_fails_loud_when_pinned_venv_absent`**
+  - *install-ui.sh must exit nonzero, naming the ritual, when the pinned*
+- **`test_install_ui_preflight_passes_when_pinned_venv_present`**
+  - *With the pinned llauncher-ui entry point present, the hard preflight*
 
 #### `tests/unit/test_port_picker.py` (8 tests)
 
@@ -2769,6 +2885,15 @@ ad-hoc markers used in the suite without declaration.
 - **`test_ps1_is_pure_ascii`**
   - *Every ``.ps1`` must decode as pure ASCII.*
 
+#### `tests/architecture/test_pyproject_extras_shape.py` (3 tests)
+
+- **`test_streamlit_is_a_base_dependency`**
+  - *Streamlit (formerly the ``[ui]`` extra) must be a base dependency.*
+- **`test_no_ui_or_cli_extras`**
+  - *``ui`` and ``cli`` must not exist as optional-dependencies keys.*
+- **`test_test_extra_is_the_only_optional_dependency`**
+  - *``test`` is the operator-ruled sole survivor of the extras collapse.*
+
 #### `tests/architecture/test_pytest_ini_strict_markers.py` (4 tests)
 
 - **`test_pytest_ini_has_strict_markers_addopt`**
@@ -2972,7 +3097,7 @@ ad-hoc markers used in the suite without declaration.
 - **`test_size_column_scales_with_byte_count`**
 - **`test_local_target_calls_state_refresh_before_reading_models`**
 
-#### `tests/ui/test_models_tab.py` (13 tests)
+#### `tests/ui/test_models_tab.py` (14 tests)
 
 - **`test_registry_table_is_delegated_scoped_to_the_selected_target`**
 - **`test_registry_table_still_renders_while_an_edit_is_in_progress`**
@@ -2985,6 +3110,7 @@ ad-hoc markers used in the suite without declaration.
 - **`test_empty_remote_target_gets_no_onboarding_banner`**
 - **`test_each_local_model_gets_one_card_in_case_insensitive_name_order`**
 - **`test_running_local_server_reaches_its_own_card_and_no_other`**
+- **`test_same_model_running_on_two_ports_gets_two_controllable_cards`**
 - **`test_remote_target_cards_come_from_the_aggregator_not_local_state`**
 - **`test_remote_running_servers_are_filtered_to_the_target_node`**
 

--- a/docs/operations/run-as-a-service.md
+++ b/docs/operations/run-as-a-service.md
@@ -269,7 +269,7 @@ systemctl --user restart llauncher-ui
 
 What step 2 does, in order (so a failure is legible against a known
 sequence, not a black box): creates `/opt/llauncher/venv` if absent;
-`pip install`s `llauncher[ui]` **non-editable** from
+`pip install`s `llauncher` **non-editable** from
 `git+https://github.com/shanevcantwell/llauncher.git@$REF` (never `-e`,
 never a local checkout path — the whole point is independence from any
 clone's working-tree state); records `pip freeze` plus the ref and a UTC

--- a/llauncher/ui/launch.py
+++ b/llauncher/ui/launch.py
@@ -98,8 +98,8 @@ def main() -> int:
         import streamlit  # noqa: F401
     except ImportError:
         sys.stderr.write(
-            "Streamlit is not installed. Install the UI extra:\n"
-            '    pip install "llauncher[ui]"\n'
+            "Streamlit is not installed. Reinstall llauncher:\n"
+            '    pip install "llauncher"\n'
         )
         return 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,10 @@ dependencies = [
     "httpx>=0.26.0",
     "typer>=0.9.0",
     "rich>=13.0.0",
+    "streamlit>=1.30.0",
 ]
 
 [project.optional-dependencies]
-cli = ["typer>=0.9.0", "rich>=13.0.0"]
-ui = ["streamlit>=1.30.0"]
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -50,9 +50,9 @@ goto :help
     echo [INFO] Upgrading pip...
     "%PROJECT_DIR%\.venv\Scripts\python.exe" -m pip install --upgrade pip >nul 2>&1
 
-    echo [INFO] Installing llauncher with UI dependencies...
+    echo [INFO] Installing llauncher...
     cd /d "%PROJECT_DIR%"
-    "%PROJECT_DIR%\.venv\Scripts\python.exe" -m pip install -e ".[ui]"
+    "%PROJECT_DIR%\.venv\Scripts\python.exe" -m pip install -e .
     if errorlevel 1 (
         echo [ERROR] Installation failed
         exit /b 1

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -84,7 +84,7 @@ case "${1:-}" in
         print_error "run.sh install is disabled: it installed into a repo-local .venv,"
         print_error "disconnected from your global commands. For a global install"
         print_error "(puts llauncher / llauncher-ui on your PATH):"
-        echo "    pip install --user -e \".[ui]\"   # from this repo, with no venv active"
+        echo "    pip install --user -e .   # from this repo, with no venv active"
         exit 1
         ;;
     mcp)
@@ -112,7 +112,7 @@ case "${1:-}" in
     stop)
         # Do NOT call ensure_venv here: `stop` must not bootstrap a ~500MB
         # venv as a side effect on a machine that installed globally
-        # (`pip install --user -e ".[ui]"`) with no local .venv (issue #229).
+        # (`pip install --user -e .`) with no local .venv (issue #229).
         # If a repo-local venv exists, activate it so the agent already
         # running from it is reachable; otherwise rely on PATH.
         if [ -d "$PROJECT_DIR/.venv" ]; then
@@ -146,6 +146,6 @@ case "${1:-}" in
         echo "  LLAUNCHER_AGENT_NODE_NAME Friendly name for this node"
         echo ""
         echo "First time setup (puts llauncher / llauncher-ui on your PATH):"
-        echo "  pip install --user -e \".[ui]\"   # from this repo, with no venv active"
+        echo "  pip install --user -e .   # from this repo, with no venv active"
         ;;
 esac

--- a/scripts/systemd/install-cli.sh
+++ b/scripts/systemd/install-cli.sh
@@ -58,8 +58,8 @@ mkdir -p "$PREFIX"
 [ -x "$VENV/bin/python" ] || python3 -m venv "$VENV"
 "$VENV/bin/pip" install --quiet --upgrade pip
 
-echo "==> installing llauncher[ui] from public $REPO_URL @ $REF (non-editable)"
-"$VENV/bin/pip" install --quiet --upgrade "llauncher[ui] @ git+$REPO_URL@$REF"
+echo "==> installing llauncher from public $REPO_URL @ $REF (non-editable)"
+"$VENV/bin/pip" install --quiet --upgrade "llauncher @ git+$REPO_URL@$REF"
 
 echo "==> recording the pin: $MANIFEST"
 # The answerable-at-any-time pin (#360): exactly what this composition

--- a/tests/architecture/test_pyproject_extras_shape.py
+++ b/tests/architecture/test_pyproject_extras_shape.py
@@ -1,0 +1,71 @@
+"""Static guard: the extras shape ruled 2026-07-17 does not regrow.
+
+Why this test exists
+---------------------
+A bare ``pip install -e .`` used to produce an incomplete install: streamlit
+lived behind an opt-in ``[ui]`` extra, so only the sanctioned
+``run.bat install`` (``pip install -e ".[ui]"``) actually worked. The
+operator ratified collapsing the UI and CLI extras (2026-07-17): UI is not
+optional in this ecosystem, so its dependencies moved into base ``[project]
+dependencies``, and the ``cli`` extra was deleted outright as vestigial
+(typer/rich were already base deps). The operator separately ruled that the
+``test`` extra is **kept** — dev-only test tooling stays opt-in via
+``pip install -e ".[test]"``.
+
+This test pins that specific shape: streamlit lives in base ``dependencies``;
+there is no ``ui`` or ``cli`` key anywhere in ``[project.optional-dependencies]``;
+and ``test`` is the *only* key present, so neither half of the collapse can
+silently regrow nor silently disappear.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+# Repo root = two parents up from this file: tests/architecture/<file>.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _load_pyproject() -> dict:
+    with _PYPROJECT.open("rb") as f:
+        return tomllib.load(f)
+
+
+def test_streamlit_is_a_base_dependency() -> None:
+    """Streamlit (formerly the ``[ui]`` extra) must be a base dependency."""
+    data = _load_pyproject()
+    deps = data["project"]["dependencies"]
+    assert any(dep.split(">=")[0].split("==")[0].strip() == "streamlit" for dep in deps), (
+        "streamlit is missing from base [project] dependencies; a bare "
+        "`pip install -e .` must pull it directly (no extras)"
+    )
+
+
+def test_no_ui_or_cli_extras() -> None:
+    """``ui`` and ``cli`` must not exist as optional-dependencies keys."""
+    data = _load_pyproject()
+    extras = data["project"].get("optional-dependencies", {})
+    assert "ui" not in extras, (
+        "pyproject.toml [project.optional-dependencies] has a `ui` key "
+        "again; UI deps were deliberately collapsed into base dependencies "
+        "(2026-07-17 ratification) so `pip install -e .` is correct by "
+        "construction"
+    )
+    assert "cli" not in extras, (
+        "pyproject.toml [project.optional-dependencies] has a `cli` key "
+        "again; typer/rich are base dependencies and the extra was vestigial"
+    )
+
+
+def test_test_extra_is_the_only_optional_dependency() -> None:
+    """``test`` is the operator-ruled sole survivor of the extras collapse."""
+    data = _load_pyproject()
+    extras = data["project"].get("optional-dependencies", {})
+    assert set(extras.keys()) == {"test"}, (
+        f"expected [project.optional-dependencies] to contain exactly "
+        f"{{'test'}}, found {sorted(extras.keys())!r}; the operator ruled "
+        "2026-07-17 that `test` is kept as the sole extra while `ui`/`cli` "
+        "are collapsed into base dependencies"
+    )

--- a/tests/unit/test_run_sh_install_honesty.py
+++ b/tests/unit/test_run_sh_install_honesty.py
@@ -17,7 +17,7 @@ Issue #154's acceptance criteria (both pinned here):
   1. ``run.sh install`` no longer implies a global readiness it didn't
      deliver — it is disabled and points at the real global path.
   2. The documented global launch path
-     (``pip install --user -e ".[ui]"``) is discoverable from the
+     (``pip install --user -e .``) is discoverable from the
      script's own output / help.
 
 This module drives the real ``scripts/run.sh`` in a hermetic temp
@@ -35,7 +35,7 @@ from pathlib import Path
 import pytest
 
 
-GLOBAL_INSTALL_CMD = 'pip install --user -e ".[ui]"'
+GLOBAL_INSTALL_CMD = "pip install --user -e ."
 
 
 def _repo_root() -> Path:

--- a/tests/unit/test_run_sh_stop_no_venv_bootstrap.py
+++ b/tests/unit/test_run_sh_stop_no_venv_bootstrap.py
@@ -3,7 +3,7 @@
 Background
 ----------
 The ``stop`` case called ``ensure_venv`` before ``llauncher-agent --stop``.
-On a machine that installed globally via ``pip install --user -e ".[ui]"``
+On a machine that installed globally via ``pip install --user -e .``
 (no local ``.venv``), running ``./run.sh stop`` silently bootstrapped a full
 ~500MB venv as a side effect of *stopping* the agent — contradicting the
 no-side-effect / install-honesty goal issue #219 delivered (see also #154,


### PR DESCRIPTION
## Summary

A bare `pip install -e .` produced an incomplete install (no streamlit) because
UI deps lived behind an opt-in `[ui]` extra — diverging from the sanctioned
`run.bat install` (`pip install -e ".[ui]"`). Operator ratified (2026-07-17):
UI is not optional in this ecosystem, so `pip install -e .` should be correct
by construction.

- `pyproject.toml`: streamlit moved into base `[project] dependencies`
  **verbatim** (no floor bump — banked separately as #335). The `cli` extra
  is deleted outright: typer/rich were already base deps, so it duplicated
  rather than gated anything.
- **Bounced decision, ruled by operator mid-fix**: the task's "remove
  `[project.optional-dependencies]` entirely" phrasing would also have
  dropped the `test` extra with no replacement install path anywhere in the
  repo (no requirements-dev.txt / CI workflow / Makefile). Operator ruled:
  **keep** `test` as the sole surviving extra (`pip install -e ".[test]"`
  still installs pytest/pytest-asyncio/pytest-cov/pytest-mock).
- Every operative `.[ui]` reference updated to bare `pip install -e .`:
  `scripts/run.bat`, `scripts/run.sh` (3 spots), `scripts/systemd/install-cli.sh`,
  `README.md`, `docs/MCP.md`, `docs/operations/run-as-a-service.md`,
  `llauncher/ui/launch.py`, and the two `run.sh` regression tests
  (`tests/unit/test_run_sh_install_honesty.py`, `test_run_sh_stop_no_venv_bootstrap.py`).
- Historical narration deliberately left untouched: ADR-023's context section
  quotes what commands *used to be*; `docs/plans/sleeptime-remediation/**` are
  dated analysis snapshots of an already-resolved typer/rich gap.
- New guard: `tests/architecture/test_pyproject_extras_shape.py` — tomllib-based,
  pins the ruled shape (streamlit in base deps; no `ui`/`cli` extras; `test` is
  the only `optional-dependencies` key) so the split can't silently regrow
  either direction.
- `docs/generated/TEST_SUITE_SUMMARY.md` regenerated for the added test file.

Refs #334 (adjacent installer-door issue). Deliberately not absorbed: #335
(streamlit floor bump), ADR-023 Phase C (dependency lockfile).

## Gate evidence

| Gate | Result |
|---|---|
| Python version | 3.13.7 (≥3.11 required) |
| Scratch venv install | `pip install -e ".[test]"` in a fresh worktree venv pulled **streamlit-1.59.2** from base deps with no `[ui]` qualifier — the fix's proof — plus pytest/pytest-asyncio/pytest-cov/pytest-mock from the kept `test` extra |
| Full pytest vs #364 baseline | 58 failed / 1670 passed / 33 skipped (was 45/1482/32 in #364). Of the 13-failure delta: **12 map to #364's bucket 1** (WSL-bash-shadows-Git-Bash `execvpe(/bin/bash) failed`, confirmed via traceback for every one: `test_agent_venv_backstop` x4, `test_install_cli_manifest` x4, `test_pinned_venv_install_preflight` x3, `test_agent_logging_setup` x1 — the last one re-run in isolation on a quiet box and it **passed**, confirming a host-contention flake, not a real failure). **1 was a genuine new failure** (`test_test_summary_drift_regression.py`, caused by adding the new architecture test file) — fixed in this PR by regenerating `docs/generated/TEST_SUITE_SUMMARY.md`; re-run confirms it now passes. **Net: zero new failures relative to #364's environmental buckets.** |
| New test | `tests/architecture/test_pyproject_extras_shape.py` (3 tests) — all pass |
| Coverage | 99.19% measured (floor 99, `pytest.ini --cov-fail-under=99`) on the full run from the worktree's own venv, run from the worktree root — the #361 worktree-misattribution trap did not occur (per-module coverage numbers were legitimate, not 0%) |

## Test plan

- [ ] Reviewer confirms the `test`-extra retention ruling matches intent
- [ ] Reviewer spot-checks that no other `.[ui]`/`.[cli]` reference was missed
- [ ] CI / dispatched review gates the merge (not merged by this PR)